### PR TITLE
1) Fixed CSS (was missing guides class on body)

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -1,8 +1,8 @@
 - title: "Guides and Tutorials"
-  url: '/'
+  url: 'index'
   chapters:
     - title: "Ember.js Guides"
-      url: "index"
+      url: ""
       skip_sidebar: true
 
 - title: "Getting Started"
@@ -233,23 +233,23 @@
   url: 'views'
   chapters:
     - title: "Introduction"
-      url: "/index"
+      url: "index"
     - title: "Defining a View"
-      url: "/defining-a-view"
+      url: "defining-a-view"
     - title: "Handling Events"
-      url: "/handling-events"
+      url: "handling-events"
     - title: "Inserting Views in Templates"
-      url: "/inserting-views-in-templates"
+      url: "inserting-views-in-templates"
     - title: "Adding Layouts to Views"
-      url: "/adding-layouts-to-views"
+      url: "adding-layouts-to-views"
     - title: "Customizing a View's Element"
-      url: "/customizing-a-views-element"
+      url: "customizing-a-views-element"
     - title: "Built-in Views"
-      url: "/built-in-views"
+      url: "built-in-views"
     - title: "Manually Managing View Hierarchy"
-      url: "/manually-managing-view-hierarchy"
+      url: "manually-managing-view-hierarchy"
     #- title: "Building Reusable Views"
-      #url: "/building-reusable-views"
+      #url: "building-reusable-views"
 
 - title: "Enumerables"
   url: 'enumerables'

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -12,7 +12,7 @@
     <%= yield_content :head %>
   </head>
 
-  <body class="<%= page_classes %>">
+  <body class="guides <%= page_classes %>">
 
     <!--[if lt IE 9]>
       <script type="text/javascript" src="/javascripts/common-old-ie.js"></script>


### PR DESCRIPTION
2) Fixed links in "views" section
3) Fixed the default/index page; it was showing empty string instead of "Ember.js Guides" (same w/ page title; also fixed).