### PR TITLE
Moves version selector out of sidebar nav borders

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -61,11 +61,13 @@
     <%= yield_content :outside_wrapper %>
 
     <div id="content-wrapper">
-      <div id="sidebar">
+      <div id="sidebar-wrapper">
         <select class="version-select" style="width: 100%"></select>
+        <div id="sidebar">
 
-        <%= toc_for(data.guides) %>
-        <div id="back-to-top"><a id="back-top-top" href="#">&#11014; Back to Top</a></div>
+          <%= toc_for(data.guides) %>
+          <div id="back-to-top"><a id="back-top-top" href="#">&#11014; Back to Top</a></div>
+        </div>
       </div>
       <div id="content" class="has-sidebar">
         <div class="chapter">

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -135,19 +135,26 @@ p {
   Sidebar
 **/
 
-#sidebar {
-  font-family: 'Maven Pro';
-  font-weight: normal;
-  margin-top: 38px;
+#sidebar-wrapper {
   float: left;
   width: $sidebar-width;
+  margin-top: 38px;
+}
+
+#sidebar {
+  margin-top: 10px;
+  float: left;
+  width: $sidebar-width;
+  position: relative;
+  font-family: 'Maven Pro';
+  font-weight: normal;
+  background: #f4ece9;
+
+  border-left: 1px solid #d4ccc8;
+  border-right: 1px solid #d4ccc8;
   min-height: 475px;
   margin-bottom: 28px;
   padding-bottom: 120px;
-  background: #f4ece9;
-  border-left: 1px solid #d4ccc8;
-  border-right: 1px solid #d4ccc8;
-  position: relative;
 
   #back-to-top {
     padding-left: 13px;


### PR DESCRIPTION
Updates the styling to get rid of the double bordering on the select2, the result is below

![ember js - models working with records 2015-03-03 15-24-03](https://cloud.githubusercontent.com/assets/144138/6471482/58b50de2-c1b9-11e4-8c60-e30f42c425f7.png)
