### PR TITLE
Remove select2 input outline on focus

### DIFF
--- a/source/stylesheets/select2.scss
+++ b/source/stylesheets/select2.scss
@@ -2,6 +2,7 @@
   box-sizing: border-box;
   display: inline-block;
   margin: 0;
+  outline: none;
   position: relative;
   vertical-align: middle; }
   .select2-container .select2-selection--single {
@@ -40,7 +41,8 @@
       box-sizing: border-box;
       border: none;
       font-size: 100%;
-      margin-top: 5px; }
+      margin-top: 5px;
+      outline: none; }
       .select2-container .select2-search--inline .select2-search__field::-webkit-search-cancel-button {
         -webkit-appearance: none; }
 

--- a/source/stylesheets/select2.scss
+++ b/source/stylesheets/select2.scss
@@ -2,7 +2,6 @@
   box-sizing: border-box;
   display: inline-block;
   margin: 0;
-  outline: none;
   position: relative;
   vertical-align: middle; }
   .select2-container .select2-selection--single {
@@ -117,7 +116,8 @@
 .select2-container--default .select2-selection--single {
   background-color: #fff;
   border: 1px solid #aaa;
-  border-radius: 4px; }
+  border-radius: 4px;
+  outline: none; }
   .select2-container--default .select2-selection--single .select2-selection__rendered {
     color: #444;
     line-height: 28px; }


### PR DESCRIPTION
This will make the select2 input more consistent with the site's inputs and their lack of `outline` when focused.