### PR TITLE
Fixed Typo

### DIFF
--- a/source/views/built-in-views.md
+++ b/source/views/built-in-views.md
@@ -1,4 +1,4 @@
-Ember comes pre-packaged with a set of views for building a basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
+Ember comes pre-packaged with a set of views for building basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
 
 * [Ember.Checkbox](http://emberjs.com/api/classes/Ember.Checkbox.html)
 * [Ember.TextField](http://emberjs.com/api/classes/Ember.TextField.html)


### PR DESCRIPTION
Just fixing a small typo:

"for build a basic controls live text inputs, ..."

to

"for build basic controls live text inputs, ..."