### PR TITLE
Moved rails-assets-* to their own block.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
 
 gem "redcarpet"
 gem "activesupport"
@@ -13,9 +12,12 @@ gem "listen"
 gem "builder"
 gem "middleman-alias"
 gem "middleman-swiftype", :git => "git://github.com/LeonB/middleman-swiftype.git"
-gem "rails-assets-js-md5"
-gem "rails-assets-moment"
 gem "underscore-rails"
+
+source 'https://rails-assets.org' do
+  gem "rails-assets-js-md5"
+  gem "rails-assets-moment"
+end
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/bsclifton/middleman-swiftype.git
-  revision: 0fbf932f53eaa04f062909e7ff98814c6d6e5c83
+  remote: git://github.com/LeonB/middleman-swiftype.git
+  revision: 13bd1dffa195553cc4bab0f01985dab31388ec82
   specs:
     middleman-swiftype (0.0.1)
       middleman-core (>= 3.0)
@@ -127,6 +127,11 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry (0.9.12.6-x86-mingw32)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+      win32console (~> 1.3)
     rack (1.6.0)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -185,6 +190,7 @@ GEM
     websocket-driver (0.5.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.1)
+    win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -205,8 +211,8 @@ DEPENDENCIES
   poltergeist
   pry
   rack
-  rails-assets-js-md5
-  rails-assets-moment
+  rails-assets-js-md5!
+  rails-assets-moment!
   rake
   redcarpet
   rspec


### PR DESCRIPTION
Hi There,

I was running the guides and I received the following warning.

```
Warning: this Gemfile contains multiple primary sources.
Using `source` more than once without a block is a security risk, and may result in installing unexpected gems.
To resolve this warning, use a block to indicate which gems should come from the secondary source.
To upgrade this warning to an error, run `bundle config disable_multisource true`.
```

According to the [rails-assets website](https://rails-assets.org/) the proper form seems to be to put the rails-assets specific gems into their own block.

There were also some updates to other dependencies, but I can revert them if you want.

Thanks for all the hard work, these guides are awesome! I'm really excited to seem them with the ember-cli changes.