### PR TITLE
Fixing missing Ember. variable

### DIFF
--- a/source/templates/writing-helpers.md
+++ b/source/templates/writing-helpers.md
@@ -4,7 +4,7 @@ For example, imagine you are frequently wrapping certain values in a `<span>` ta
 
 ```app/helpers/highlight.js
 export default Ember.Handlebars.makeBoundHelper( function(value, options) {
-  var escaped = Handlebars.Utils.escapeExpression(value);
+  var escaped = Ember.Handlebars.Utils.escapeExpression(value);
   return new Ember.Handlebars.SafeString('<span class="highlight">' + escaped + '</span>');
 });
 ```


### PR DESCRIPTION
Was following the example locally and noticed you need Ember.Handlebars.Utils