### PR TITLE
Fixed version picker for IE

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ gem install bundler wdm tzinfo-data
 gem update listen middleman
 ```
 
-If you get an error like this:
+If you get an error like this when doing a gem update (or bundle install):
 
 ```Unable to download data from https://rubygems.org/ - SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (https://rubygems.org/latest_specs.4.8.gz)```
 
-1. Follow the [instructions on this post](https://gist.github.com/luislavena/f064211759ee0f806c88) to install the trust cert
-2. If the error still happens, try running ```gem update --system```
-3. Lastly, you can try [downloading this cacert file](http://curl.haxx.se/ca/cacert.pem) locally and setting your ```SSL_CERT_FILE``` environment variable to point to its path (System > Advanced system settings > Environment variables > then "New" under system variables).
+1. Follow the [instructions on this post](https://gist.github.com/luislavena/f064211759ee0f806c88) to install the trust cert.
+2. Create an environment variable with a name of ```SSL_CERT_FILE``` (System > Advanced system settings > Environment variables > then "New" under system variables) and set the value to the full path of the cert you [installed in step 1](https://gist.github.com/luislavena/f064211759ee0f806c88). The value should look something like ```C:\Ruby21\lib\ruby\2.1.0\rubygems\ssl_certs\AddTrustExternalCARoot-2048.pem```.
+3. Close your shell and re-open, so it loads the new environment variable.
+4. Try again
+5. If the error still happens, try running ```gem update --system```
 
 After these workarounds, you should finally be able to run ```bundle exec middleman```. You may be prompted by Windows Firewall; Click "Allow access" and you'll be in business!

--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -9,7 +9,7 @@ $.ajax('/versions.json')
     versionSelect.select2('val', currentRevision);
 
     versionSelect.on('change', function() {
-      var version = this.selectedOptions[0].value;
+      var version = this.value;
 
       window.location = '/' + version + '/';
     });


### PR DESCRIPTION
Fixed a bug w/ the version selection (was causing error in IE; the select object doesn't have a selectedOptions property in IE).  Also includes updates to the README for Windows devs.