### PR TITLE
Document how to find the end of the loading event.

### DIFF
--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -134,6 +134,9 @@ export default Ember.Route.extend({
   actions: {
     loading: function(transition, originRoute) {
       //displayLoadingSpinner();
+      this.router.one('didTransition', function () {
+        // hideLoadingSpinner();
+      });
 
       // Return true to bubble this event to `FooRoute`
       // or `ApplicationRoute`.


### PR DESCRIPTION
I found it difficult to discover how to actually be notified of when the end of a transition occurred after receiving the loading event. I believe this is the correct way, and if so, I think it'd be helpful for others to see this example.

This was discussed briefly on emberjs/website#1566.