### PR TITLE
[MISC] `action` helper should not be used on `div`

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -174,9 +174,9 @@ pressed modifier keys. You can supply an `allowedKeys` option
 to specify which keys should not be ignored.
 
 ```handlebars
-<div {{action 'anActionName' allowedKeys="alt"}}>
+<button {{action 'anActionName' allowedKeys="alt"}}>
   click me
-</div>
+</button>
 ```
 
 This way the `{{action}}` will fire when clicking with the alt key


### PR DESCRIPTION
As a best practice, `{{action}}` helper for the `click` event should be used only on `button` or `input[type="button"]`, maybe on `a` tho for `a` is more likely for transitions so `link-to` would be used then, but definitely not on `div`. Also non interactive elements won't receive click on safari mobile https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile