### PR TITLE
Fix models/index.md

### DIFF
--- a/source/models/index.md
+++ b/source/models/index.md
@@ -16,7 +16,7 @@ changes, and saving them back to the server can dramatically simplify
 your code while improving the robustness and performance of your
 application.
 
-Many Ember apps use [Ember Data][emberdata] to handle this.
+Many Ember apps use [Ember Data](https://github.com/emberjs/data) to handle this.
 Ember Data is a library that integrates tightly with Ember.js to make it
 easy to retrieve records from a server, cache them for performance,
 save updates back to the server, and create new records on the client.


### PR DESCRIPTION
The guides currently read ' [Ember Data][emberdata] ' in the introduction to models page. I have replaced it with link to the supposed url.