### PR TITLE
Fixes 404's on routing pages

### DIFF
--- a/source/routing/generated-objects.md
+++ b/source/routing/generated-objects.md
@@ -3,7 +3,7 @@ Ember.js attempts to find corresponding Route, Controller, View, and Template
 classes named according to naming conventions. If an implementation of any of
 these objects is not found, appropriate objects will be generated in memory for you.
 
-[1]: /guides/routing/defining-your-routes
+[1]: ../defining-your-routes
 
 #### Generated routes
 
@@ -35,8 +35,8 @@ The type of controller Ember.js chooses to generate for you depends on your rout
 - If it does not return anything, an instance of `Ember.Controller` will be generated.
 
 
-[2]: /guides/controllers/representing-a-single-model-with-objectcontroller
-[3]: /guides/controllers/representing-multiple-models-with-arraycontroller
+[2]: ../../controllers/representing-a-single-model-with-objectcontroller
+[3]: ../../controllers/representing-multiple-models-with-arraycontroller
 
 
 #### Generated Views and Templates

--- a/source/routing/setting-up-a-controller.md
+++ b/source/routing/setting-up-a-controller.md
@@ -47,7 +47,7 @@ export default Ember.Route.extend({
 As a second argument, it receives the route handler's model. For more
 information, see [Specifying a Route's Model][1].
 
-[1]: /guides/routing/specifying-a-routes-model
+[1]: ../specifying-a-routes-model
 
 The default `setupController` hook sets the `model` property of the
 associated controller to the route handler's model.


### PR DESCRIPTION
The "routing guide", "ObjectController" & "ArrayController" links currently 404 on the [routing/generating-objects](http://guides.emberjs.com/v1.10.0/routing/generated-objects/) page.

"Specifying a Route's Model" link on [routing/setting-up-a-controller](http://guides.emberjs.com/v1.10.0/routing/setting-up-a-controller/) also 404's.