### PR TITLE
Implements highlighting

### DIFF
--- a/lib/highlighter.rb
+++ b/lib/highlighter.rb
@@ -1,5 +1,6 @@
 require "redcarpet"
 require "coderay"
+require "nokogiri"
 
 module Highlighter
   class MissingLanguageError < StandardError; end
@@ -17,42 +18,68 @@ module Highlighter
 
       raise MissingLanguageError, error_message if language.nil?
 
-      language, file_name = _detect_language_and_filename(language)
+      language, file_name, changes = _detect_language_filename_and_changes(language)
 
       result = %Q{<div class="highlight #{language} #{class_name}">}
       result += '<div class="ribbon"></div>'
       result += '<div class="scroller">'
-      result += _code_table(string, language, file_name)
+      result += _code_table(string, language, file_name, changes)
       result += '</div>'
       result += %Q{</div>}
       result
     end
 
-    def _detect_language_and_filename(language)
-
+    def _detect_language_filename_and_changes(language)
       file_name = nil
+      changes = []
+      changes_regex = /\{(.+)\}$/
       bare_language_regex = /\A\w+\z/
+
+      if change_numbers = changes_regex.match(language)
+        language = language.sub(changes_regex, '')
+
+        changes = _parse_changes(change_numbers[1])
+      end
 
       unless language =~ bare_language_regex
         file_name = language
 
-        language = case /\.(\w+)$/.match(language)[1]
-                   when 'hbs'
-                     'handlebars'
-                   when 'js'
-                     'javascript'
-                   when 'html'
-                     'html'
-                   when 'css'
-                     'css'
-                   when 'json'
-                     'json'
-                   end
+        language = _determine_language(language)
       end
-      [language, file_name]
+      [language, file_name, changes]
     end
 
-    def _code_table(string, language, file_name)
+    def _determine_language(language)
+      case /\.(\w+)$/.match(language)[1]
+      when 'hbs'
+        'handlebars'
+      when 'js'
+        'javascript'
+      when 'html'
+        'html'
+      when 'css'
+        'css'
+      when 'json'
+        'json'
+      end
+    end
+
+    def _parse_changes(change_numbers)
+      changes = change_numbers.split(',').map do |change|
+        state = case change.slice(0)
+                when '+'
+                  'added'
+                when '-'
+                  'removed'
+                else
+                  nil
+                end
+
+        [change.to_i.abs, state]
+      end
+    end
+
+    def _code_table(string, language, file_name, changes)
       code = CodeRay.scan(string, language)
 
       table = code.div css: :class,
@@ -71,7 +98,30 @@ module Highlighter
 HEADER
       end
 
-      table
+      _highlight_lines(table, changes)
+    end
+
+    def _highlight_lines(table, highlights)
+      return table if highlights.empty?
+
+      table_xml = Nokogiri.XML(table)
+
+      numbers_node = table_xml.at_xpath('//td[@class="line-numbers"]/pre')
+      code_node = table_xml.at_xpath('//td[@class="code"]/pre')
+
+      numbers_contents = numbers_node.inner_html.split("\n")
+      code_contents = code_node.inner_html.split("\n")
+
+      highlights.each do |line_number, state|
+        index = line_number - 1
+        numbers_contents[index] = "<span class=\"highlight-line #{state}\">#{numbers_contents[index]}</span>"
+        code_contents[index] = "<span class=\"highlight-line #{state}\">#{code_contents[index]}</span>"
+      end
+
+      numbers_node.inner_html = numbers_contents.join("\n")
+      code_node.inner_html = code_contents.join("\n")
+
+      table_xml.to_xml
     end
 
     def highlight(language, class_name, &block)

--- a/source/stylesheets/highlight.css.scss
+++ b/source/stylesheets/highlight.css.scss
@@ -4,12 +4,19 @@
 $border-radius: 5px;
 
 $blue:   #1f58ce;
-$gray:   #777777;
-$green:  #007700;
+$gray:   #545454;
+$textColor: #222;
+$green:  #005f00;
+$orange: #8f4a2c;
+
+$highlight-yellow: #f8eec7;
+$highlight-green: #E8F4E5;
+$highlight-red: #ffecec;
 
 body.guides .highlight {
   @include border-radius($border-radius);
   border: 1px solid #d1d1d1;
+  color: $textColor;
 }
 
 #content .highlight {
@@ -46,6 +53,45 @@ body.guides .highlight {
   &.handlebars .ribbon {
     @include hidpi('handlebars-ribbon', png);
   }
+
+  .highlight-line {
+    display: inline-block;
+    margin: 0 -10px;
+    background-color: $highlight-yellow;
+    border-right: $highlight-yellow solid 5px;
+    border-left: $highlight-yellow solid 5px;
+    box-sizing: content-box;
+
+    &.added {
+      border-color: $highlight-green;
+      background-color: $highlight-green;
+    }
+
+    &.removed {
+      border-color: $highlight-red;
+      background-color: $highlight-red;
+    }
+  }
+
+  .code .highlight-line {
+    width: 613px;
+    margin: 0 -13px;
+    border-left-width: 13px;
+    border-right-width: 13px;
+  }
+
+  .line-numbers .highlight-line {
+    width: 28px;
+    border-right-color: darken($highlight-yellow, 20%);
+
+    &.added {
+      border-right-color: darken($highlight-green, 20%);
+    }
+
+    &.removed {
+      border-right-color: darken($highlight-red, 20%);
+    }
+  }
 }
 
 .CodeRay {
@@ -55,7 +101,7 @@ body.guides .highlight {
     text-align: center;
     border-right: 1px solid #d1d1d1;
     background-color: #f6f6f6;
-    color: #b4b4b4;
+    color: $gray;
     @include border-top-left-radius($border-radius);
     @include border-bottom-left-radius($border-radius);
   }
@@ -71,7 +117,7 @@ body.guides .highlight {
   }
 
   .comment {
-    color: $gray;
+    color: $green;
   }
 
   .attribute-name {
@@ -87,7 +133,7 @@ body.guides .highlight {
   }
 
   .keyword {
-    color: #ce791f;
+    color: $orange;
   }
 
   .key, .function {

--- a/spec/highlighter_spec.rb
+++ b/spec/highlighter_spec.rb
@@ -12,37 +12,65 @@ describe Highlighter::Helpers do
     Object.send :remove_const, :HelperTester
   end
 
-  describe '#_detect_language_and_filename' do
+  describe '#_detect_language_filename_and_changes' do
     it 'returns bare languages and does not return a filename' do
-      language, filename = HelperTester.new._detect_language_and_filename('javascript')
+      language, filename, changes = HelperTester.new._detect_language_filename_and_changes('javascript')
       expect(language).to eq 'javascript'
       expect(filename).to be_nil
+      expect(changes).to eq []
 
-      language, filename = HelperTester.new._detect_language_and_filename('handlebars')
+      language, filename, changes = HelperTester.new._detect_language_filename_and_changes('handlebars')
       expect(language).to eq 'handlebars'
       expect(filename).to be_nil
+      expect(changes).to eq []
     end
 
     it 'returns the detected language and the filename from a filename' do
-      language, filename = HelperTester.new._detect_language_and_filename('app/components/my-component.js')
+      language, filename, changes = HelperTester.new._detect_language_filename_and_changes('app/components/my-component.js')
       expect(language).to eq 'javascript'
       expect(filename).to eq 'app/components/my-component.js'
+      expect(changes).to eq []
 
-      language, filename = HelperTester.new._detect_language_and_filename('app/templates/application.hbs')
+      language, filename, changes = HelperTester.new._detect_language_filename_and_changes('app/templates/application.hbs')
       expect(language).to eq 'handlebars'
       expect(filename).to eq 'app/templates/application.hbs'
+      expect(changes).to eq []
 
-      language, filename = HelperTester.new._detect_language_and_filename('app/index.html')
+      language, filename, changes = HelperTester.new._detect_language_filename_and_changes('app/index.html')
       expect(language).to eq 'html'
       expect(filename).to eq 'app/index.html'
+      expect(changes).to eq []
 
-      language, filename = HelperTester.new._detect_language_and_filename('app/styles/app.css')
+      language, filename, changes = HelperTester.new._detect_language_filename_and_changes('app/styles/app.css')
       expect(language).to eq 'css'
       expect(filename).to eq 'app/styles/app.css'
+      expect(changes).to eq []
 
-      language, filename = HelperTester.new._detect_language_and_filename('bower.json')
+      language, filename, changes = HelperTester.new._detect_language_filename_and_changes('bower.json')
       expect(language).to eq 'json'
       expect(filename).to eq 'bower.json'
+      expect(changes).to eq []
+    end
+
+    it 'returns detected code changes' do
+      _, _, changes = HelperTester.new._detect_language_filename_and_changes('app/components/my-component.js{1,+3,4,-5,+6,-7}')
+
+      expect(changes).to eq [
+        [1, nil],
+        [3, 'added'],
+        [4, nil],
+        [5, 'removed'],
+        [6, 'added'],
+        [7, 'removed'],
+      ]
+
+      _, _, changes = HelperTester.new._detect_language_filename_and_changes('javascript{+2,3,-5}')
+
+      expect(changes).to eq [
+        [2, 'added'],
+        [3, nil],
+        [5, 'removed']
+      ]
     end
   end
 
@@ -81,6 +109,48 @@ OUTPUT
 </pre></td>
   <td class="code"><pre><span class="reserved">export</span> <span class="keyword">default</span> Ember.Component.extend()</pre></td>
 </tr></table>
+</div></div>
+OUTPUT
+    end
+
+    it 'returns a code block with a filename in the table when using a filename fence with highlighting' do
+      code_block = HelperTester.new._highlight("export default Ember.Component.extend()\nvar added;\nvar removed;",
+                                               'app/components/my-foo.js{1,+2,-3}')
+      expect(code_block).to eq <<-OUTPUT.sub(/\n$/, '')
+<div class="highlight javascript "><div class="ribbon"></div><div class="scroller"><?xml version="1.0"?>
+<table class="CodeRay">
+  <thead>
+    <tr>
+      <td colspan="2">app/components/my-foo.js</td>
+    </tr>
+  </thead>
+<tr>
+  <td class="line-numbers"><pre><span class="highlight-line ">1</span>
+<span class="highlight-line added">2</span>
+<span class="highlight-line removed">3</span></pre></td>
+  <td class="code"><pre><span class="highlight-line "><span class="reserved">export</span> <span class="keyword">default</span> Ember.Component.extend()</span>
+<span class="highlight-line added"><span class="keyword">var</span> added;</span>
+<span class="highlight-line removed"><span class="keyword">var</span> removed;</span></pre></td>
+</tr></table>
+</div></div>
+OUTPUT
+    end
+
+    it 'returns a code block with a filename in the table when using a filename fence with highlighting' do
+      code_block = HelperTester.new._highlight("export default Ember.Component.extend()\nvar added;\nvar removed;",
+                                               'javascript{1,+2,-3}')
+      expect(code_block).to eq <<-OUTPUT.sub(/\n$/, '')
+<div class="highlight javascript "><div class="ribbon"></div><div class="scroller"><?xml version="1.0"?>
+<table class="CodeRay">
+  <tr>
+  <td class="line-numbers"><pre><span class="highlight-line ">1</span>
+<span class="highlight-line added">2</span>
+<span class="highlight-line removed">3</span></pre></td>
+  <td class="code"><pre><span class="highlight-line "><span class="reserved">export</span> <span class="keyword">default</span> Ember.Component.extend()</span>
+<span class="highlight-line added"><span class="keyword">var</span> added;</span>
+<span class="highlight-line removed"><span class="keyword">var</span> removed;</span></pre></td>
+</tr>
+</table>
 </div></div>
 OUTPUT
     end


### PR DESCRIPTION
At the end of the filename or language add `{1,2,-4,+5}`,
`+` signifies that the line should be marked as added
`-` signifies that the line should be marked as removed
line numbers are otherwise highlighted

Does not currently handle ranges

Also updates colors in code blocks, fixing contrast

**Bringing it back**

@trek 