### PR TITLE
Add guides link to Repositories page

### DIFF
--- a/source/contributing/repositories.md
+++ b/source/contributing/repositories.md
@@ -9,9 +9,13 @@ Ember is made up of several libraries. If you wish to add a feature or fix a bug
 
 * [https://github.com/emberjs/data](https://github.com/emberjs/data)
 
-**Ember Website** - Source for [http://emberjs.com](http://emberjs.com) including these guides.
+**Ember Website** - Source for [http://emberjs.com](http://emberjs.com)
 
 * [https://github.com/emberjs/website](https://github.com/emberjs/website)
+
+**Ember Guides** - Source for [http://guides.emberjs.com](http://guides.emberjs.com) which you are currently reading.
+
+* [https://github.com/emberjs/guides](https://github.com/emberjs/guides)
 
 # Libraries Used By Ember
 


### PR DESCRIPTION
This adds a link to the Repositories page to the new separate Guides repo and removes outdated comment that the guides are included in the website repo.