### PR TITLE
Fix unclosed code block

### DIFF
--- a/source/models/defining-models.md
+++ b/source/models/defining-models.md
@@ -100,6 +100,7 @@ attribute types, and new types can be registered as transforms. See the
 [ISO 8601]: http://en.wikipedia.org/wiki/ISO_8601
 
 #### Options
+
 `DS.attr` takes an optional hash as a second parameter:
 
 - `defaultValue`: Pass a string or a function to be called to set the
@@ -167,6 +168,7 @@ To declare a many-to-many relationship between two models, use
 export default DS.Model.extend({
   tags: DS.hasMany('tag')
 });
+```
 
 ```app/models/tag.js
 export default DS.Model.extend({


### PR DESCRIPTION
Fixes the unclosed code block that causes this to be displayed with the filename in the middle

![unclosed code block](https://dl.dropboxusercontent.com/spa/ibxdnt7kjmsxult/wpj-arw2.png)