### PR TITLE
Pad single-line objects with white-space

### DIFF
--- a/source/cookbook/ember_data/linking_to_slugs.md
+++ b/source/cookbook/ember_data/linking_to_slugs.md
@@ -57,7 +57,7 @@ the Route's model hook.
 ```js
 App.PostRoute = Ember.Route.extend({
   model: function(params) {
-    return this.store.findOne('post', {slug: params.post_slug});
+    return this.store.findOne('post', { slug: params.post_slug });
   }
 });
 ```

--- a/source/models/defining-models.md
+++ b/source/models/defining-models.md
@@ -213,8 +213,8 @@ other side, set the inverse to null.
 
 ```app/models/folder.js
 export default DS.Model.extend({
-  children: DS.hasMany('folder', {inverse: 'parent'}),
-  parent: DS.belongsTo('folder', {inverse: 'children'})
+  children: DS.hasMany('folder', { inverse: 'parent' }),
+  parent: DS.belongsTo('folder', { inverse: 'children' })
 });
 ```
 
@@ -222,6 +222,6 @@ or
 
 ```app/models/folder.js
 export default DS.Model.extend({
-  parent: belongsTo('folder', {inverse: null})
+  parent: belongsTo('folder', { inverse: null })
 });
 ```

--- a/source/models/the-rest-adapter.md
+++ b/source/models/the-rest-adapter.md
@@ -163,7 +163,7 @@ have a model with a `hasMany` relationship:
 
 ```app/models/post.js
 export default DS.Model.extend({
-  comments: DS.hasMany('comment', {async: true})
+  comments: DS.hasMany('comment', { async: true })
 });
 ```
 

--- a/source/object-model/reopening-classes-and-instances.md
+++ b/source/object-model/reopening-classes-and-instances.md
@@ -30,7 +30,7 @@ But when you need to create class methods or add properties to the class itself 
 ```javascript
 Person.reopenClass({
   createMan: function() {
-    return Person.create({isMan: true})
+    return Person.create({ isMan: true })
   }
 });
 

--- a/source/routing/defining-your-routes.md
+++ b/source/routing/defining-your-routes.md
@@ -253,7 +253,7 @@ define a serialize method on your route:
 
 ```app/router.js
 Router.map(function() {
-  this.route('post', {path: '/posts/:post_slug'});
+  this.route('post', { path: '/posts/:post_slug' });
 });
 ```
 
@@ -296,7 +296,7 @@ by your app.
 
 ```app/router.js
 Router.map(function() {
-  this.route('catchall', {path: '/*wildcard'});
+  this.route('catchall', { path: '/*wildcard' });
 });
 ```
 

--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -200,7 +200,7 @@ separate levels." Take for example:
 
 ```app/router.js
 Router.map(function() {
-  this.route('foo', {path: '/foo/:id'}, function() {
+  this.route('foo', { path: '/foo/:id' }, function() {
     this.route('baz');
   });
 });

--- a/source/understanding-ember/run-loop.md
+++ b/source/understanding-ember/run-loop.md
@@ -70,7 +70,7 @@ and a template to display its attributes:
 If we execute the following code without the run loop:
 
 ```javascript
-var user = User.create({firstName:'Tom', lastName:'Huda'});
+var user = User.create({ firstName: 'Tom', lastName: 'Huda' });
 user.set('firstName', 'Yehuda');
 // {{firstName}} and {{fullName}} are updated
 
@@ -91,7 +91,7 @@ user.set('lastName', 'Katz');
 However, if we have the run loop in the above code, the browser will only rerender the template once the attributes have all been set.
 
 ```javascript
-var user = User.create({firstName:'Tom', lastName:'Huda'});
+var user = User.create({ firstName: 'Tom', lastName: 'Huda' });
 user.set('firstName', 'Yehuda');
 user.set('lastName', 'Katz');
 user.set('firstName', 'Tom');


### PR DESCRIPTION
Reduces formatting inconsistencies by following

> Pad single-line objects with white-space.
> 
> https://github.com/emberjs/ember.js/blob/master/STYLEGUIDE.md#objects

throughout the guides.