### PR TITLE
Remove global `App` variable.

### DIFF
--- a/source/models/finding-records.md
+++ b/source/models/finding-records.md
@@ -70,7 +70,7 @@ Ember deal with figuring out whether a network request is needed or not.
 ```app/router.js
 var Router = Ember.Router.extend({});
 
-App.Router.map(function() {
+Router.map(function() {
   this.route('posts');
   this.route('post', { path: ':post_id' });
 });


### PR DESCRIPTION
The `App` variable, previously used as the Ember application's global namespace, is no longer used in the guides in favor of ES6 modules. The `App` would be undefined in this case.