### PR TITLE
Updated reference to middleman-swiftype

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/LeonB/middleman-swiftype.git
-  revision: 13bd1dffa195553cc4bab0f01985dab31388ec82
+  revision: 98a7fdb365cedcaa472caa4dd2132f79f0d7d15b
   specs:
     middleman-swiftype (0.0.1)
       middleman-core (>= 3.0)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git push --tags
 Next, build a new artifact and move it to the guides site repo, committing it to GitHub:
 
 ```shell
-middleman swiftype --only-generate
+middleman build
 mv ./build <path to guides site repo>/artifacts/<revision number>
 cd <path to guides site repo>
 git add --all
@@ -51,7 +51,7 @@ Visit the site to ensure that everything looks good. Assuming there are no issue
 
 ```shell
 cd <path to guides site repo>
-npm publish # runs `divshot promote staging production` && `npm switftype`
+npm publish # runs `divshot promote staging production` && `npm swiftype`
 ```
 
 


### PR DESCRIPTION
Updated reference to middleman-swiftype; it now generates the search.json on build. The new version of middleman-swiftype has rspec tests around all of the functionality we use. I updated README.md to show new usage (simply using `middleman build`).