### PR TITLE
Document display settings for version select

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -299,6 +299,8 @@ p {
 }
 
 .version-select {
+  // Hide from users without javascript enabled
+  // select2 will override this for users with javascript
   display: none;
 }
 


### PR DESCRIPTION
Adds a comment explaining why `display: none` is set for version select

CC @trek 

https://github.com/emberjs/guides/pull/192