### PR TITLE
Remove references to shorthand Em

### DIFF
--- a/source/cookbook/helpers_and_components/writing_a_custom_handlebars_helper.md
+++ b/source/cookbook/helpers_and_components/writing_a_custom_handlebars_helper.md
@@ -15,7 +15,7 @@ Write a custom Handlebars helper that can be called from any template and gets u
 ```js
 App = Ember.Application.create();
 
-App.ApplicationRoute = Em.Route.extend({
+App.ApplicationRoute = Ember.Route.extend({
   model: function() {
     return 980; // cents
   }

--- a/source/cookbook/working_with_objects/continuous_redrawing_of_views.md
+++ b/source/cookbook/working_with_objects/continuous_redrawing_of_views.md
@@ -104,7 +104,7 @@ export default Ember.ArrayController.extend({
     comment: null,
     actions: {
       add: function () {
-        this.addObject(Em.Object.create({
+        this.addObject(Ember.Object.create({
           comment: this.get('comment'),
           clock: ClockService.create()
         }));

--- a/source/templates/binding-element-attributes.md
+++ b/source/templates/binding-element-attributes.md
@@ -88,7 +88,7 @@ export default Ember.View.reopen({
     var self = this;
 
     // bind attributes beginning with 'data-'
-    Em.keys(this).forEach(function(key) {
+    Ember.keys(this).forEach(function(key) {
       if (key.substr(0, 5) === 'data-') {
         self.get('attributeBindings').pushObject(key);
       }


### PR DESCRIPTION
Replaces references to `Em.*` with `Ember.*`.

I think seeing these would be confusing to new people coming in.