### PR TITLE
Use block params version of {{#with}}

### DIFF
--- a/source/understanding-ember/the-view-layer.md
+++ b/source/understanding-ember/the-view-layer.md
@@ -622,7 +622,7 @@ most recent view with one.
 #### Other Variables
 
 Handlebars helpers in Ember may also specify variables. For example, the
-`{{#with controller.person as tom}}` form specifies a `tom` variable
+`{{#with controller.person as |tom|}}` form specifies a `tom` variable
 that descendent scopes can access. Even if a child context has a `tom`
 property, the `tom` variable will supersede it.
 


### PR DESCRIPTION
related to https://github.com/emberjs/guides/issues/196

This replaces references to `{{#with ... as ...}}` with `{{#with ... as |...|}}`.