### PR TITLE
Close fenced code block.

### DIFF
--- a/source/testing/test-helpers.md
+++ b/source/testing/test-helpers.md
@@ -86,7 +86,7 @@ test('simple test', function(assert) {
 });
 ```
 
-First we tell QUnit that this test should have one assertion made by the end 
+First we tell QUnit that this test should have one assertion made by the end
 of the test by calling `assert.expect` with an argument of `1`. We then visit the new
 posts URL "/posts/new", enter the text "My new post" into an input control
 with the CSS class "title", and click on a button whose class is "submit".
@@ -167,8 +167,9 @@ export default Ember.Test.registerAsyncHelper('addContact',
     click('button.create');
   }
 );
+```
 
-Finally, don't forget to add your helpers in `tests/.jshintrc` and in 
+Finally, don't forget to add your helpers in `tests/.jshintrc` and in
 `tests/helpers/start-app.js`. In `tests/.jshintrc` you need to add it in the
 `predef` section, otherwise you will get failing jshint tests:
 


### PR DESCRIPTION
Noticed this in the live version of the [Testing: Test Helpers](http://guides.emberjs.com/v1.11.0/testing/test-helpers/) page:

![ember-test-helper-guide](https://cloud.githubusercontent.com/assets/1858316/6994527/1d1e3006-dad2-11e4-8971-d54fc850f694.jpg)

Closing the code block should fix it.