### PR TITLE
Fix two links being on one line in the glossary

### DIFF
--- a/source/getting-started/glossary.md
+++ b/source/getting-started/glossary.md
@@ -54,8 +54,8 @@ Asynchronous calls typically return a promise (or deferred). This is an object w
 
 Ember.js makes use of these in places like the model hook for a route. Until the promise resolves, Ember is able to put the route into a "loading" state.
 
-[An open standard for sound, interoperable JavaScript promises](https://promisesaplus.com/)
-[emberjs.com - A word on promises](http://emberjs.com/guides/routing/asynchronous-routing/#toc_a-word-on-promises)
+* [An open standard for sound, interoperable JavaScript promises](https://promisesaplus.com/)
+* [emberjs.com - A word on promises](http://emberjs.com/guides/routing/asynchronous-routing/#toc_a-word-on-promises)
 
 
 ## SSR


### PR DESCRIPTION
Change the two plain lines, which are interpreted as a hard-wrapped single paragraph, into an unordered list

You can currently see the problem at [Glossary – Promise section](http://guides.emberjs.com/v1.11.0/ember-cli/glossary/#toc_promise)