### PR TITLE
Put info on classes together

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -34,6 +34,8 @@
   chapters:
     - title: "Classes and Instances"
       url: "classes-and-instances"
+    - title: "Reopening Classes and Instances"
+      url: "reopening-classes-and-instances"
     - title: "Computed Properties"
       url: "computed-properties"
     - title: "Computed Properties and Aggregate Data with @each"
@@ -42,8 +44,6 @@
       url: "observers"
     - title: "Bindings"
       url: "bindings"
-    - title: "Reopening Classes and Instances"
-      url: "reopening-classes-and-instances"
     - title: "Bindings, Observers, Computed Properties: What Do I Use When?"
       url: "what-do-i-use-when"
 


### PR DESCRIPTION
Info on reopening classes was stuck between "Bindings" and "What Do I Use When?", far away from the initial discussion of classes, and breaking up the flow of computed properties, observers, and bindings. This moves the info on reopening classes to a more logical place.