### PR TITLE
Trigger search on enter. Fixes #125

### DIFF
--- a/source/javascripts/swiftype.js.erb
+++ b/source/javascripts/swiftype.js.erb
@@ -1,5 +1,25 @@
-$(function() {
+var Swiftype = window.Swiftype || {};
+(function() {
+  Swiftype.key = '<%= data.search.engine_key %>';
+  Swiftype.inputElement = '#st-search-input';
+  Swiftype.resultContainingElement = '#st-results-container';
+  Swiftype.attachElement = '#st-search-input';
+  Swiftype.renderStyle = 'overlay';
+  Swiftype.disableAutocomplete = true;
 
+  Swiftype.searchSearchFields = {'<%= data.search.document_type %>': ['body', 'title', 'url']};
+  Swiftype.searchFetchFields = {'<%= data.search.document_type %>': ['title','body',  'url']};
+  Swiftype.searchDocumentTypes = ['<%= data.search.document_type %>'];
+
+  var script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.async = true;
+  script.src = '//swiftype.com/embed.js';
+  var entry = document.getElementsByTagName('script')[0];
+  entry.parentNode.insertBefore(script, entry);
+}());
+
+$(function() {
   var onComplete = function(item, prefix) {
     window.location = '/<%= data.search.revision %>' + item['url'];
   };


### PR DESCRIPTION
Uses search behavior directly from swiftype like done in [emberjs/website](https://github.com/emberjs/website/blob/master/source/javascripts/app/swiftype.js) while keeping autocomplete feature from the jQuery plugin.

Only caveat with this approach is that I don't see how we can customize overlay rendering URLs to include the `revision`.

Also, mentioned to @trek the idea of migrating to the [new configurable search widget](https://swiftype.com/documentation/tutorials/upgrade_to_configurable_search_widget). Unfortunately couldn't give this a try without an install key(not the engine key) and I didn't manage to get any crawling done on a sample app. I'd be down on getting that done if anyone cares on setting up the configuration and sending over an install key.