### PR TITLE
link and image fix

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -118,7 +118,7 @@ When an action is triggered, but no matching action handler is
 implemented on the controller, the current route, or any of the
 current route's ancestors, an error will be thrown.
 
-![Action Bubbling](../images/template-guide/action-bubbling.png)
+![Action Bubbling](../../images/template-guide/action-bubbling.png)
 
 This allows you to create a button that has different behavior based on
 where you are in the application. For example, you might want to have a
@@ -168,7 +168,7 @@ You can specify an alternative event by using the `on` option.
 You should use the normalized event names [listed in the View guide][1].
 In general, two-word event names (like `keypress`) become `keyPress`.
 
-[1]: ../../understanding-ember/the-view-layer/#toc_adding-new-events
+[1]: http://emberjs.com/api/classes/Ember.View.html#toc_event-names
 
 ### Specifying Whitelisted Modifier Keys
 


### PR DESCRIPTION
Not sure why the image is broken on the actions page, it works when I build it and the link is the same as the live site.

I notice sometimes people use <img> tags instead of Markdown image text so I tried that.