### PR TITLE
Update Fixture documentation for Adapter initialisation.

### DIFF
--- a/source/models/the-fixture-adapter.md
+++ b/source/models/the-fixture-adapter.md
@@ -13,12 +13,11 @@ Using the fixture adapter entails three very simple setup steps:
 
 #### Creating a Fixture Adapter
 
-Simply attach it as the `ApplicationAdapter` property on your instance
-of `Ember.Application`:
+Simply set the default adapter of your `Ember.Application` to be a `FixtureAdapter` by creating `app/adapters/application.js` and inserting the following:
 
-```JavaScript
-var App = Ember.Application.create();
-App.ApplicationAdapter = DS.FixtureAdapter;
+```app/adapters/application.js
+import DS from 'ember-data';
+export default DS.FixtureAdapter.extend();
 ```
 
 #### Define Your Model


### PR DESCRIPTION
Changing the `ApplicationAdapter` property to a FixtureAdapter on my `Ember.Application` instance did not work. Fixed by defining FixtureAdapter as a default in `/app/adapters/application.js`.

Any further clarifications/comments to these instructions would be appreciated.