### PR TITLE
Made "Routes" header plural, for consistency

### DIFF
--- a/source/concepts/core-concepts.md
+++ b/source/concepts/core-concepts.md
@@ -67,7 +67,7 @@ HTML. In many applications, models are loaded via an HTTP JSON API,
 although Ember is agnostic to the backend that you choose.
 
 
-#### Route
+#### Routes
 
 A **route** is an object that tells the template which model it should
 display.


### PR DESCRIPTION
Consistent with "Templates," "Components," and "Models."

I left "Router" alone, because there's only one.