### PR TITLE
Fix calling a custom async helper

### DIFF
--- a/source/testing/test-helpers.md
+++ b/source/testing/test-helpers.md
@@ -154,7 +154,7 @@ export default Ember.Test.registerAsyncHelper('dblclick',
   }
 );
 
-// dblclick("#person-1")
+// dblclick(assert, "#person-1")
 ```
 
 Async helpers also come in handy when you want to group interaction


### PR DESCRIPTION
The `assert` object has to be passed through.