### PR TITLE
Raise exception when data/guides.yml references guides that don't exist

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -31,7 +31,11 @@ module TOC
           requested_guide_url = slugs[0]
           current = (guide.url == requested_guide_url)
 
-          middleman_url = "/#{guide.url}/#{guide.chapters[0].url}.html"
+          middleman_base_url = "/#{guide.url}/#{guide.chapters[0].url}"
+          middleman_url = middleman_base_url + ".html"
+
+          file = "source" + middleman_base_url + ".md"
+          raise file + " does not exist. Please fix guides.yml." unless File.exist?(file)
 
           buffer << "<li class='level-1 #{current ? 'selected' : ''}'>"
             buffer << link_to(guide.title, middleman_url)

--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -40,6 +40,14 @@ guides:
     before(:each) do
       building_page = double(path: "custom-extensions/building-custom-extensions.html")
       allow(helper).to receive(:request).and_return(building_page)
+      allow(File).to receive(:exist?).and_return(true)
+    end
+
+    it "raises an exception if a file doesn't exist" do
+      allow(File).to receive(:exist?).and_return(false)
+      expect {
+        helper.toc_for(helper.data.guides)
+      }.to raise_error(RuntimeError, "source/middleman-basics/index.md does not exist. Please fix guides.yml.")
     end
 
     it "includes guide titles except guides that are marked to skip sidbar" do


### PR DESCRIPTION
Addresses #249.

Feedback welcome!

Notes:

* Not sure if this is the approach @trek had in mind but seemed the simplest way to go about it. If you'd prefer a different approach, just let me know what you're thinking.
* Not sure I covered all cases. Somebody who knows this code better than me should take a look :)
* `allow(File).to receive(:exist?).and_return(true)` feels a bit blunt.
* In `toc.rb`, `middleman_url` variable has a couple variations, is declared and then overwritten, and seems redundant with `url` on line 45. This seems ripe for refactoring... if I'm not missing something, I'll open an issue and take a stab at cleaning it up. I'm hesitating because it appends `.html` to the end but I don't actually see the `.html` anywhere in the app, so I'm worried I'm missing something.