### PR TITLE
update how to disable location API

### DIFF
--- a/source/routing/specifying-the-location-api.md
+++ b/source/routing/specifying-the-location-api.md
@@ -34,6 +34,6 @@ application in a larger page).
 
 ```app/router.js
 Ember.Router.extend({
-  location: 'history'
+  location: 'none'
 });
 ```


### PR DESCRIPTION
In the v1.11.0 of the guides the option for disabling the location API wasn't updated fromt the previous version, it say:
```
Ember.Router.extend({
  location: 'history'
});
```
it should say:

```
Ember.Router.extend({
  location: 'none'
});
```