### PR TITLE
[DOC] Clarify component dashes

### DIFF
--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -2,7 +2,7 @@ To define a component, create a template whose name starts with
 `components/`. To define a new component, `{{blog-post}}` for example,
 create a `components/blog-post` template.
 
-**Note:** Components must have a dash in their name. So `blog-post` is an acceptable name,
+**Note:** Components must have at least one dash in their name. So `blog-post` is an acceptable name,
 but `post` is not. This prevents clashes with current or future HTML element names, and
 ensures Ember picks up the components automatically.
 

--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -2,9 +2,8 @@ To define a component, create a template whose name starts with
 `components/`. To define a new component, `{{blog-post}}` for example,
 create a `components/blog-post` template.
 
-**Note:** Components must have at least one dash in their name. So `blog-post` is an acceptable name,
-but `post` is not. This prevents clashes with current or future HTML element names, and
-ensures Ember picks up the components automatically.
+**Note:** Components must have at least one dash in their name. So `blog-post` is an acceptable name, so is `audio-player-controls`, but `post` is not. This prevents clashes with current or future HTML element names, and
+ensures Ember detects the components automatically.
 
 A sample component template would look like this:
 


### PR DESCRIPTION
Makes it clear that a components name needs to have one dash, but can have more.