### PR TITLE
Update link that went to 404

### DIFF
--- a/source/models/index.md
+++ b/source/models/index.md
@@ -5,7 +5,7 @@ implementing a route's `model` hook, by passing the model as an argument
 to `{{link-to}}`, or by calling a route's `transitionTo()` method.
 
 See [Specifying a Route's
-Model](../routing/specifying-a-routes-model) for more information
+Model](../v1.10.0/routing/specifying-a-routes-model) for more information
 on setting a route's model.
 
 For simple applications, you can get by using jQuery to load JSON data


### PR DESCRIPTION
The link to specifying a routes model was broken.