### PR TITLE
Fix links in guides about testing and Ember Inspector

### DIFF
--- a/source/ember-inspector/troubleshooting.md
+++ b/source/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this happens:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](/guides/ember-inspector/installation#toc_file-protocol).
+follow [these steps](../installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using Jsbin, follow [these steps](#toc_using-the-inspector-with-jsbin).
 
@@ -48,7 +48,7 @@ It means that you are either not using a data persistence library
 (such as Ember Data), or the library you're using does not support the
 Ember Inspector.
 
-If you are the library's author, [see this section](/guides/ember-inspector/data#toc_building-a-data-custom-adapter) on how to add Ember Inspector support.
+If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Ember Inspector support.
 
 ### Promises Not Detected
 

--- a/source/ember-inspector/view-tree.md
+++ b/source/ember-inspector/view-tree.md
@@ -11,7 +11,7 @@ Click on the `View Tree` menu on the left to see your views.
 You can click on any model, controller, view, or component
 to send them to the [object inspector][object-inspector-guide].
 
-[object-inspector-guide]: /guides/ember-inspector/object-inspector
+[object-inspector-guide]: ../object-inspector
 
 
 <img src="../../images/guides/ember-inspector/view-tree-object-inspector.png" width="680">

--- a/source/testing/testing-controllers.md
+++ b/source/testing/testing-controllers.md
@@ -124,4 +124,4 @@ test('modify the post', function(assert) {
 ```
 
 [Unit Testing Basics]: ../unit-testing-basics
-[needs]: /guides/controllers/dependencies-between-controllers
+[needs]: ../../controllers/dependencies-between-controllers


### PR DESCRIPTION
Previously, the links point to pages that do not exist. Using relative path in
the URL fixes the issue.