### PR TITLE
several dead-link fix and ES6 -> ES5 syntax

### DIFF
--- a/source/models/the-fixture-adapter.md
+++ b/source/models/the-fixture-adapter.md
@@ -79,6 +79,6 @@ a uniquely identifiable field. By default, Ember Data assumes this key
 is called `id`. Should you not provide an `id` field in your fixtures, or
 not override the primary key, the Fixture Adapter will throw an error.
 
-[1]: /v1.11.0/models/defining-models
-[2]: /v1.11.0/models/finding-records
-[3]: /v1.11.0/models/the-rest-adapter
+[1]: ../defining-models
+[2]: ../finding-records
+[3]: ../the-rest-adapter

--- a/source/models/the-fixture-adapter.md
+++ b/source/models/the-fixture-adapter.md
@@ -40,7 +40,7 @@ In order to attach fixtures to your model, you have to use `reopenClass` method 
 fixtures:
 
 ```app/models/documenter.js
-let Documenter = DS.Model.extend({
+var Documenter = DS.Model.extend({
   firstName: DS.attr( 'string' ),
   lastName: DS.attr( 'string' )
 });
@@ -52,7 +52,7 @@ Documenter.reopenClass({
   ]
 });
 
-export default Documenter
+export default Documenter;
 ```
 
 That's it! You can now use all of methods for [Finding Records][2] in your
@@ -79,6 +79,6 @@ a uniquely identifiable field. By default, Ember Data assumes this key
 is called `id`. Should you not provide an `id` field in your fixtures, or
 not override the primary key, the Fixture Adapter will throw an error.
 
-[1]: /guides/models/defining-models
-[2]: /guides/models/finding-records
-[3]: /guides/models/the-rest-adapter
+[1]: /v1.11.0/models/defining-models
+[2]: /v1.11.0/models/finding-records
+[3]: /v1.11.0/models/the-rest-adapter

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -115,7 +115,7 @@ When an action is triggered, but no matching action handler is
 implemented on the controller, the current route, or any of the
 current route's ancestors, an error will be thrown.
 
-![Action Bubbling](/../images/template-guide/action-bubbling.png)
+![Action Bubbling](../../images/template-guide/action-bubbling.png)
 
 This allows you to create a button that has different behavior based on
 where you are in the application. For example, you might want to have a
@@ -165,7 +165,7 @@ You can specify an alternative event by using the `on` option.
 You should use the normalized event names [listed in the View guide][1].
 In general, two-word event names (like `keypress`) become `keyPress`.
 
-[1]: /../understanding-ember/the-view-layer/#toc_adding-new-events
+[1]: ../../understanding-ember/the-view-layer/#toc_adding-new-events
 
 ### Specifying Whitelisted Modifier Keys
 

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -115,7 +115,7 @@ When an action is triggered, but no matching action handler is
 implemented on the controller, the current route, or any of the
 current route's ancestors, an error will be thrown.
 
-![Action Bubbling](/v1.11.0/images/template-guide/action-bubbling.png)
+![Action Bubbling](/../images/template-guide/action-bubbling.png)
 
 This allows you to create a button that has different behavior based on
 where you are in the application. For example, you might want to have a
@@ -165,7 +165,7 @@ You can specify an alternative event by using the `on` option.
 You should use the normalized event names [listed in the View guide][1].
 In general, two-word event names (like `keypress`) become `keyPress`.
 
-[1]: /v1.11.0/understanding-ember/the-view-layer/#toc_adding-new-events
+[1]: /understanding-ember/the-view-layer/#toc_adding-new-events
 
 ### Specifying Whitelisted Modifier Keys
 

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -165,7 +165,7 @@ You can specify an alternative event by using the `on` option.
 You should use the normalized event names [listed in the View guide][1].
 In general, two-word event names (like `keypress`) become `keyPress`.
 
-[1]: /understanding-ember/the-view-layer/#toc_adding-new-events
+[1]: /../understanding-ember/the-view-layer/#toc_adding-new-events
 
 ### Specifying Whitelisted Modifier Keys
 

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -115,7 +115,7 @@ When an action is triggered, but no matching action handler is
 implemented on the controller, the current route, or any of the
 current route's ancestors, an error will be thrown.
 
-![Action Bubbling](/images/template-guide/action-bubbling.png)
+![Action Bubbling](/v1.11.0/images/template-guide/action-bubbling.png)
 
 This allows you to create a button that has different behavior based on
 where you are in the application. For example, you might want to have a
@@ -165,7 +165,7 @@ You can specify an alternative event by using the `on` option.
 You should use the normalized event names [listed in the View guide][1].
 In general, two-word event names (like `keypress`) become `keyPress`.
 
-[1]: /guides/understanding-ember/the-view-layer/#toc_adding-new-events
+[1]: /v1.11.0/understanding-ember/the-view-layer/#toc_adding-new-events
 
 ### Specifying Whitelisted Modifier Keys
 


### PR DESCRIPTION
I found a few dead links in the v1.11.0 guide and a syntax inconsistency regarding the two leading ECMA versions (5 & 6).