### PR TITLE
Stay on same page when switching versions

### DIFF
--- a/source/404.html.erb
+++ b/source/404.html.erb
@@ -5,7 +5,9 @@ title: 404 - Not Found
 <h1>404</h1>
 
 <p>
-  This page wasn't found. If you were looking for documentation, please try
-  the <a href="/guides">Guides</a> section of the site. If you expected
-  something else to be here, please <a href="https://github.com/emberjs/website/issues">file a ticket</a>.
+  This page doesn't exist in this version of the Guides.
+  Try hitting the back button to go back to where you were,
+  or go to the <a href="/">Guides homepage</a>.
+  If you expected something else to be here, please
+  <a href="https://github.com/emberjs/website/issues">file a ticket</a>.
 </p>

--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -5,7 +5,7 @@ $.ajax('/versions.json')
     var versionSelect = $(".version-select");
     versionSelect.select2({
         data: data
-    })
+    });
     versionSelect.select2('val', currentRevision);
 
     versionSelect.on('change', function() {

--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -2,13 +2,13 @@ var currentRevision = '<%= data.search.revision %>';
 
 $.ajax('/versions.json')
   .done(function(data) {
-    var versionSelect = $(".version-select");
-    versionSelect.select2({
+    var versionSelectBox = $(".version-select");
+    versionSelectBox.select2({
       data: data
     });
-    versionSelect.select2('val', currentRevision);
+    versionSelectBox.select2('val', currentRevision);
 
-    versionSelect.on('change', function() {
+    versionSelectBox.on('change', function() {
       var version = this.value;
 
       window.location = window.location.href.replace(currentRevision, version);

--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -11,6 +11,6 @@ $.ajax('/versions.json')
     versionSelect.on('change', function() {
       var version = this.value;
 
-      window.location = '/' + version + '/';
+      window.location = window.location.href.replace(currentRevision, version);
     });
   });

--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -4,7 +4,7 @@ $.ajax('/versions.json')
   .done(function(data) {
     var versionSelect = $(".version-select");
     versionSelect.select2({
-        data: data
+      data: data
     });
     versionSelect.select2('val', currentRevision);
 


### PR DESCRIPTION
Also updated 404 to be more helpful in case page doesn't exist in the version switched to.

To test the JS code, I went to http://guides.emberjs.com/v1.11.0/concepts/core-concepts/, ran the relevant code:

```js
var versionSelectBox = $(".version-select");
versionSelectBox.on('change', function() {
  var version = this.value;
  window.location = window.location.href.replace(currentRevision, version);
});
```

and then manually switched from v11 to v10.