### PR TITLE
Metadata now lives in 'meta', not 'content.meta'

### DIFF
--- a/source/models/handling-metadata.md
+++ b/source/models/handling-metadata.md
@@ -40,7 +40,7 @@ var meta = this.store.metadataFor("post");
 Or you can access the metadata just for this query:
 
 ```js
-var meta = result.get("content.meta");
+var meta = result.get("meta");
 ```
 
 Now, `meta.total` can be used to calculate how many pages of posts you'll have.


### PR DESCRIPTION
Hello, Ember newbie here. I might be terribly wrong but, after some trial&error, debugging, and looking at ember-data's code, I believe this is that the guides should actually say.

Please enlighten me if this is not the case :-) Thank you!