### PR TITLE
fixes broken link when previous_chapter.url is an empty string

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -149,7 +149,10 @@ module TOC
       elsif whats_before = previous_guide
         previous_chapter = whats_before.chapters.last
 
-        url = "/#{previous_guide.url}/#{previous_chapter.url}.html"
+        is_root = previous_chapter.url.empty?
+
+        url = is_root ? "/#{previous_guide.url}.html" : "/#{previous_guide.url}/#{previous_chapter.url}.html"
+
         title = " \u2190 #{previous_chapter.title}"
 
         link_to(title, url, options)


### PR DESCRIPTION
This broken link results in a 404:
![This broken link results in a 404](https://cloud.githubusercontent.com/assets/8061074/7738033/420d0a2a-ff1e-11e4-8f3a-79cade554974.png)