### PR TITLE
Update the fork repo to be used for suggesting recipes

### DIFF
--- a/source/cookbook/contributing/participating_if_you_know_ember.md
+++ b/source/cookbook/contributing/participating_if_you_know_ember.md
@@ -19,5 +19,5 @@ Based on your experience and knowledge of Ember, we recommend submitting pull re
 
 You will be able to suggest possible recipes by forking this project and submitting a pull request with a new recipe (see [Suggesting a Recipe](../suggesting_a_recipe)).
 
-[fork_repo]: https://github.com/emberjs/website
+[fork_repo]: https://github.com/emberjs/guides
 [suggesting_a_recipe]: ./suggesting_a_recipe

--- a/source/cookbook/contributing/suggesting_a_recipe.md
+++ b/source/cookbook/contributing/suggesting_a_recipe.md
@@ -22,7 +22,7 @@ When you are ready to submit your recipe, push your local branch to the remote b
 submit a pull request. Before submitting a pull request, make sure someone hasn't already submitted a similar
 recipe and that your recipe is a good fit for the Cookbook (see _Deciding If A Recipe Is A Good Fit_).
 
-[fork_repo]: https://github.com/emberjs/website
+[fork_repo]: https://github.com/emberjs/guides
 [feature_branch]: http://nvie.com/posts/a-successful-git-branching-model/
 [understanding]: ./understanding_the_cookbook_format
 [deciding]: ./deciding_if_a_recipe_is_a_good_fit


### PR DESCRIPTION
Previously it was the emberjs/website repo, now its the emberjs/guides
repo that you'll fork as part of the process to suggest new recipes.