### PR TITLE
Fix "specifying-a-routes-model" link (line 47)

### DIFF
--- a/source/routing/setting-up-a-controller.md
+++ b/source/routing/setting-up-a-controller.md
@@ -44,7 +44,7 @@ export default Ember.Route.extend({
 ```
 
 As a second argument, it receives the route handler's model. For more
-information, see [Specifying a Route's Model][../specifying-a-routes-model/].
+information, see [Specifying a Route's Model](../specifying-a-routes-model/).
 
 The default `setupController` hook sets the `model` property of the
 associated controller to the route handler's model.

--- a/source/routing/setting-up-a-controller.md
+++ b/source/routing/setting-up-a-controller.md
@@ -17,6 +17,7 @@ To tell one of these controllers which model to present, set its
 Router.map(function() {
   this.route('post', { path: '/posts/:post_id' });
 });
+```
 
 ``` app/routes/post.js
 export default Ember.Route.extend({


### PR DESCRIPTION
As with my other PR today, I know this is changed on master, but it isn't cherry-picked back into the v1.11.0 so the version that is actually deployed to emberjs.com/guides/v1.11.0 is rendering incorrectly.  Broken windows theory and all that...