### PR TITLE
Fix mis-named PostsRoute file (line 47)

### DIFF
--- a/source/routing/redirection.md
+++ b/source/routing/redirection.md
@@ -44,7 +44,7 @@ Router.map(function() {
 });
 ```
 
-```app/routes/post.js
+```app/routes/posts.js
 export default Ember.Route.extend({
   afterModel: function(posts, transition) {
     if (posts.get('length') === 1) {


### PR DESCRIPTION
Another small change, but confusing especially because ES6 module syntax means filenames have important semantic information.