### PR TITLE
Fix typo on naming-conventions

### DIFF
--- a/source/concepts/naming-conventions.md
+++ b/source/concepts/naming-conventions.md
@@ -125,7 +125,7 @@ The template can iterate over the elements of the controller:
 
 ```handlebars
 <ul>
-{{#each item in controller}}
+{{#each item in model}}
   <li>{{item.title}}</li>
 {{/each}}
 </ul>


### PR DESCRIPTION
The page [naming-conventions]( http://guides.emberjs.com/v1.11.0/concepts/naming-conventions/ ) says that we should modify the `favorites.hbs` template with this:

```<ul>
{{#each item in controller}}
  <li>{{item.title}}</li>
{{/each}}
</ul>
```

I guess it is incorrect and should change from `controller` to `model` like that: 
```<ul>
{{#each item in model}}
  <li>{{item.title}}</li>
{{/each}}
</ul>
```