### PR TITLE
Fixes the link to Legal in the Ember Guides documentation footer.

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -86,7 +86,7 @@
       <div id="footer-wrapper">
         <div class="info">
           Copyright <%= Time.now.strftime('%Y') %> <a href="http://tilde.io">Tilde Inc.</a><br>
-          <a href="http://emberjs.com/team">Core Team</a> | <a href="http://emberjs.com/sponsors">Sponsors</a> | <a href="http:emberjs.com/legal">Legal</a></br>
+          <a href="http://emberjs.com/team">Core Team</a> | <a href="http://emberjs.com/sponsors">Sponsors</a> | <a href="http://emberjs.com/legal">Legal</a></br>
           <a href="http://emberjs.com/guidelines">Community Guidelines</a>
         </div>
         <div class="statement">Ember.js is free, open source and always will be.</div>


### PR DESCRIPTION
The link to Legal in the footer has a malformed protocol, "http:" without the //

All of the footer links are broken in the 1.11 branch in the same way and I'll open another pull request for those shortly.