### PR TITLE
Fixes the links to Core Team, Sponsors, Legal and Community Guidelines

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -86,8 +86,8 @@
       <div id="footer-wrapper">
         <div class="info">
           Copyright <%= Time.now.strftime('%Y') %> <a href="http://tilde.io">Tilde Inc.</a><br>
-          <a href="http:emberjs.com/team">Core Team</a> | <a href="http:emberjs.com/sponsors">Sponsors</a> | <a href="http:emberjs.com/legal">Legal</a></br>
-          <a href="http:emberjs.com/guidelines">Community Guidelines</a>
+          <a href="http://emberjs.com/team">Core Team</a> | <a href="http://emberjs.com/sponsors">Sponsors</a> | <a href="http://emberjs.com/legal">Legal</a></br>
+          <a href="http://emberjs.com/guidelines">Community Guidelines</a>
         </div>
         <div class="statement">Ember.js is free, open source and always will be.</div>
         <div class="links">


### PR DESCRIPTION
Fixes the links to Core Team, Sponsors, Legal and Community Guidelines in the guides footer by making the protocol complete.