### PR TITLE
Update example so nothing is hidden behind flag

### DIFF
--- a/source/templates/binding-element-attributes.md
+++ b/source/templates/binding-element-attributes.md
@@ -53,7 +53,8 @@ renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos">Photos</a>
 
-<input id="ember257" class="ember-view ember-text-field" type="text" title="Name">
+<input id="ember257" class="ember-view ember-text-field" type="text" 
+       title="Name">
 ```
 
 There are two ways to enable support for data attributes. One way would be to add an


### PR DESCRIPTION
Part of the this code snippet was hidden behind the "HTML" flag of the code box. Adding a new line makes it so all code is viewable.