### PR TITLE
Adding note about preventDefault flag

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -185,6 +185,9 @@ to specify which keys should not be ignored.
 This way the `{{action}}` will fire when clicking with the alt key
 pressed down.
 
+### Default Event
+By default, `event.preventDefault()` is called on all events handled by `{{action}}` helpers. To avoid this you can add `preventDefault=false` as a parameter. 
+
 ### Stopping Event Propagation
 
 By default, the `{{action}}` helper allows events it handles to bubble


### PR DESCRIPTION
It took me a long time to figure out that it was possible to use the `{{action}}` helper and still keep the default action of an event. I figured I'd put it in the docs so others wouldn't have that issue. 

I found this info here: http://stackoverflow.com/questions/28451449/parent-action-prevents-from-submit-action-from-ever-being-called-in-ember-js