### PR TITLE
Update Google Analytics guide embed code

### DIFF
--- a/source/cookbook/helpers_and_components/adding_google_analytics_tracking.md
+++ b/source/cookbook/helpers_and_components/adding_google_analytics_tracking.md
@@ -14,14 +14,12 @@ Add google analytic's base code to the html file that renders your ember app.
   <title>My Ember Site</title>
   <script type="text/javascript">
 
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-XXXXX-Y']);
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
+    ga('create', 'UA-XXXXX-Y', 'auto');
 
   </script>
 </head>


### PR DESCRIPTION
The embed code in the current version of this guide does not work with the corresponding Router code. `ga()` is not available to the Router. Updating to the latest embed code provided by Google makes this example work again without editing the Router code.