### PR TITLE
Add a note about Ember CLI's Bower dependency to Getting Started section

### DIFF
--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -20,7 +20,7 @@ npm install -g ember-cli
 Note that Ember's build tool has a few dependencies of its own. In particular, you will need to install [Bower](http://bower.io/) to use Ember's build tool as described in these guides.
 
 ```bash
-npm install bower
+npm install -g bower
 ```
 
 Read the [Getting Started section](http://www.ember-cli.com/#getting-started) of the `ember-cli` project for more information about Ember CLI's dependencies.

--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -17,13 +17,14 @@ build tools with `npm`.
 npm install -g ember-cli
 ```
 
-Note that Ember's build tool has a few dependencies of its own. In particular, you will need to install [Bower](http://bower.io/) to use Ember's build tool as described in these guides.
+Note that the Ember CLI build tool has a few dependencies of its own. In particular, you will need to install [Bower](http://bower.io/) (if you don't have it already) in order to use Ember's build tool as described in these guides. You'll also want to install [PhantomJS](http://phantomjs.org/), which Ember CLI uses to run tests from the command line (without the need for a browser to be open).
 
 ```bash
 npm install -g bower
+npm install -g phantomjs
 ```
 
-Read the [Getting Started section](http://www.ember-cli.com/#getting-started) of the `ember-cli` project for more information about Ember CLI's dependencies.
+Read the [Getting Started section](http://www.ember-cli.com/#getting-started) of the `ember-cli` project for more information about Ember CLI's dependencies .
 
 ## Testing your installation
 

--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -17,6 +17,14 @@ build tools with `npm`.
 npm install -g ember-cli
 ```
 
+Note that Ember's build tool has a few dependencies and of its own. In particular, you will need to install [Bower](http://bower.io/) to use Ember's build tool as described in these guides.
+
+```bash
+npm install bower
+```
+
+Read the [Getting Started section](http://www.ember-cli.com/#getting-started) of the `ember-cli` project for more information about Ember CLI's dependencies.
+
 ## Testing your installation
 
 When installation completes, test your install to ensure it worked by generating a

--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -17,7 +17,7 @@ build tools with `npm`.
 npm install -g ember-cli
 ```
 
-Note that Ember's build tool has a few dependencies and of its own. In particular, you will need to install [Bower](http://bower.io/) to use Ember's build tool as described in these guides.
+Note that Ember's build tool has a few dependencies of its own. In particular, you will need to install [Bower](http://bower.io/) to use Ember's build tool as described in these guides.
 
 ```bash
 npm install bower


### PR DESCRIPTION
Following the instructions in Ember's getting started guide resulted in a `Error: ENOENT, open '/Users/[user]/ember_projects/package.json' at Error (native)` error the first time I ran `$ ember new` as described in the instructions, and then a `Cannot find module 'ember-cli/lib/broccoli/ember-app'` error when I ran `$ ember server`. :sob:

After some Googling, I realized that this was because I didn't have Bower installed.

As someone new to the JavaScript ecosystem brought in to try out Ember, this was an unfriendly start that could easily have been avoided if I had known about Ember CLI's dependency on Bower. I also included the PhantomJS suggestion since I saw from 5ee1ef6a3a2fd74d733dd6ccfce0c100b2fd5391 that it was previously there and figured that might also be helpful.

Hope this helps someone else get started faster! :snowboarder: