### PR TITLE
Update for findAll, findRecord, peekAll, and peekRecord

### DIFF
--- a/source/controllers/index.md
+++ b/source/controllers/index.md
@@ -92,10 +92,10 @@ the entire application, but the controller's model may change
 throughout the lifetime of the application without requiring that
 the template know anything about those mechanics.
 
-For example, if the user navigates from `/posts/1` to `/posts/2`,
-the `PostController` will change its model from `Post.find(1)` to
-`Post.find(2)`. The template will update its representations of any
-properties on the model, as well as any computed properties on the
+For example, if the user navigates from `/posts/1` to `/posts/2`, the
+`PostController`'s model will change from `store.findRecord('post', 1)` to
+`store.findRecord('post', 2)`. The template will update its representations of
+any properties on the model, as well as any computed properties on the
 controller that depend on the model.
 
 This makes it easy to test a template in isolation by rendering it

--- a/source/models/connecting-to-an-http-server.md
+++ b/source/models/connecting-to-an-http-server.md
@@ -25,7 +25,7 @@ For example, if you ask for a `photo` record by ID:
 ```app/routes/photo.js
 export default Ember.Route.extend({
   model: function(params) {
-    return this.store.find('photo', params.photo_id);
+    return this.store.findRecord('photo', params.photo_id);
   }
 });
 ```

--- a/source/models/creating-and-deleting-records.md
+++ b/source/models/creating-and-deleting-records.md
@@ -21,7 +21,7 @@ var store = this.store;
 store.createRecord('post', {
   title: 'Rails is Omakase',
   body: 'Lorem ipsum',
-  author: store.find('user', 1)
+  author: store.findRecord('user', 1)
 });
 ```
 
@@ -35,7 +35,7 @@ var post = store.createRecord('post', {
   body: 'Lorem ipsum'
 });
 
-store.find('user', 1).then(function(user) {
+store.findRecord('user', 1).then(function(user) {
   post.set('author', user);
 });
 ```
@@ -48,14 +48,14 @@ it from `all()` queries on the `store`. The deletion can then be persisted using
 Alternatively, you can use the `destroyRecord` method to delete and persist at the same time.
 
 ```js
-store.find('post', 1).then(function (post) {
+store.findRecord('post', 1).then(function(post) {
   post.deleteRecord();
   post.get('isDeleted'); // => true
   post.save(); // => DELETE to /posts/1
 });
 
 // OR
-store.find('post', 2).then(function (post) {
+store.findRecord('post', 2).then(function(post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```

--- a/source/models/defining-models.md
+++ b/source/models/defining-models.md
@@ -23,7 +23,7 @@ specify a record's type using the model name. For example, the store's
 type of record to find:
 
 ```js
-store.find('person', 1);
+store.findRecord('person', 1);
 ```
 
 The table below shows how model names map to model file paths.

--- a/source/models/finding-records.md
+++ b/source/models/finding-records.md
@@ -1,44 +1,49 @@
-The Ember Data store provides a simple interface for finding records of a single
-type through the `store` object's `find` method. Internally, the `store`
-uses either `findAll` or `findRecord` based on the supplied arguments.
+The Ember Data store provides an interface for retrieving records of a single
+type.
 
-The first argument to `store.find()` is always the record type. The optional second
-argument determines if a request is made for all records or just a single record.
+### Retrieving a Single Record
 
-### Finding All Records of a Type
-
-```javascript
-var posts = this.store.find('post'); // => GET /posts
-```
-
-To get a list of records already loaded into the store, without making
-another network request, use `all` instead.
-
-```javascript
-var posts = this.store.all('post'); // => no network request
-```
-
-`find` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `all`
-directly returns a `DS.RecordArray`.
-
-It's important to note that `DS.RecordArray` is not a JavaScript array.
-It is an object that implements [`Ember.Enumerable`][1]. This is important
-because, for example, if you want to retrieve records by index, the `[]` notation
-will not work--you'll have to use `objectAt(index)` instead.
-
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html
-
-### Finding a Single Record
-
-If you provide a number or string as the second argument to `store.find()`,
-Ember Data will assume that you are passing in an ID and attempt to retrieve a record of the type passed in as the first argument with that ID. This will
+Use `store.findRecord()` to retrieve a record by its type and ID. This will
 return a promise that fulfills with the requested record:
 
 ```javascript
-var aSinglePost = this.store.find('post', 1); // => GET /posts/1
+var post = this.store.findRecord('post', 1); // => GET /posts/1
 ```
 
-### Querying For Records
+Use `store.peekRecord()` to retrieve a record by its type and ID, without making
+a network request. This will return the record only if it is already present in
+the store:
+
+```javascript
+var post = this.store.peekRecord('post', 1); // => no network request
+```
+
+### Retrieving Multiple Records
+
+Use `store.findAll()` to retrieve all of the records for a given type:
+
+```javascript
+var posts = this.store.findAll('post'); // => GET /posts
+```
+
+Use `store.peekAll()` to retrieve all of the records for a given type that are
+already loaded into the store, without making a network request:
+
+```javascript
+var posts = this.store.peekAll('post'); // => no network request
+```
+
+`store.findAll()` returns a `DS.PromiseArray` that fulfills to a
+`DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
+
+It's important to note that `DS.RecordArray` is not a JavaScript array.  It is
+an object that implements [`Ember.Enumerable`][1]. This is important because,
+for example, if you want to retrieve records by index, the `[]` notation will
+not work--you'll have to use `objectAt(index)` instead.
+
+[1]: http://emberjs.com/api/classes/Ember.Enumerable.html
+
+### Querying for Multiple Records
 
 Ember Data provides the ability to query for records that meet certain criteria. Calling `store.query()`
 will make a `GET` request with the passed object serialized as query params. This method returns
@@ -48,7 +53,7 @@ For example, we could search for all `person` models who have the name of
 `Peter`:
 
 ```javascript
-var peters = this.store.query('person', { name: "Peter" }); // => GET to /persons?name=Peter
+var peters = this.store.query('person', { name: 'Peter' }); // => GET to /persons?name=Peter
 ```
 
 ### Integrating with the Route's Model Hook
@@ -89,7 +94,7 @@ export default Ember.Route.extend({
 ```app/routes/post.js
 export default Ember.Route.extend({
   model: function(params) {
-    return this.store.find('post', params.post_id);
+    return this.store.findRecord('post', params.post_id);
   }
 })
 ```

--- a/source/models/frequently-asked-questions.md
+++ b/source/models/frequently-asked-questions.md
@@ -84,18 +84,18 @@ export default Ember.Route.extend({
 
 #### How do I inform Ember Data about new records created on the backend?
 
-When you request a record using Ember Data's `store.find` method, Ember
+When you request a record using Ember Data's `store.findRecord` method, Ember
 will automatically load the data into the store. This allows Ember to
 avoid the latency of making a round trip to the backend next time
 that record is requested. Additionally, loading a record into the
 store will update any `RecordArray`s (e.g. the result of
-`store.filter` or `store.all`) that should include that record. This
+`store.filter` or `store.findAll`) that should include that record. This
 means any data bindings or computed properties that depend on the
 `RecordArray` will automatically be synced to include the new or
 updated record values.
 
 Some applications may want to add or update records in the store
-without requesting the record via `store.find`. To accomplish this you
+without requesting the record via `store.findRecord`. To accomplish this you
 can use the `DS.Store`'s `push` or `pushPayload`
 methods. This is useful for web applications that have a channel
 (such as [SSE](http://dev.w3.org/html5/eventsource/) or

--- a/source/models/index.md
+++ b/source/models/index.md
@@ -146,7 +146,7 @@ the ID of `1` from our route's `model` hook:
 ```app/routes/index.js
 export default Ember.Route.extend({
   model: function() {
-    return this.store.find('person', 1);
+    return this.store.findRecord('person', 1);
   }
 });
 ```
@@ -240,7 +240,7 @@ have a `Person` model. An individual record in your app might
 have a type of `person` and an ID of `1` or `steve-buscemi`.
 
 ```js
-this.store.find('person', 1); // => { id: 1, name: 'steve-buscemi' }
+this.store.findRecord('person', 1); // => { id: 1, name: 'steve-buscemi' }
 ```
 
 An ID is usually assigned to a record by the server when you save it for

--- a/source/models/persisting-records.md
+++ b/source/models/persisting-records.md
@@ -13,7 +13,7 @@ post.save(); // => POST to '/posts'
 ```
 
 ```javascript
-store.find('post', 1).then(function (post) {
+store.findRecord('post', 1).then(function(post) {
   post.get('title'); // => "Rails is Omakase"
 
   post.set('title', 'A new post');
@@ -86,12 +86,12 @@ function retry(callback, nTimes) {
       // and the new retry limit
       return retry(callback, nTimes - 1);
     }
- 
+
     // otherwise, if we hit the retry limit, rethrow the error
     throw reason;
   });
 }
- 
+
 // try to save the post up to 5 times
 retry(function() {
   return post.save();

--- a/source/models/the-rest-adapter.md
+++ b/source/models/the-rest-adapter.md
@@ -12,7 +12,7 @@ with based on the name of the model. For example, if you ask for a
 `Post` by ID:
 
 ```js
-store.find('post', 1).then(function(post) {
+store.findRecord('post', 1).then(function(post) {
 });
 ```
 
@@ -28,7 +28,7 @@ REST adapter:
     <tr><th>Action</th><th>HTTP Verb</th><th>URL</th></tr>
   </thead>
   <tbody>
-    <tr><th>Find</th><td>GET</td><td>/posts/123</td></tr>
+    <tr><th>Find Record</th><td>GET</td><td>/posts/123</td></tr>
     <tr><th>Find All</th><td>GET</td><td>/posts</td></tr>
     <tr><th>Update</th><td>PUT</td><td>/posts/123</td></tr>
     <tr><th>Create</th><td>POST</td><td>/posts</td></tr>
@@ -98,7 +98,7 @@ be nested inside a property called `person`:
 
 After `destroyRecord` or after `deleteRecord` and `save`, the adapter expects the server to return an empty object (`{}`).
 
-If you don't have the option to change the data that the server responds with, you can override the 
+If you don't have the option to change the data that the server responds with, you can override the
 [DS.JSONSerializer#extractDeleteRecord](http://emberjs.com/api/data/classes/DS.JSONSerializer.html#method_extractDeleteRecord), like so:
 
 ```js
@@ -301,7 +301,7 @@ expected to be an array:
 But once loaded on a model instance, it will behave as an object:
 
 ```js
-var cursor = this.store.find('cursor', 1);
+var cursor = this.store.findRecord('cursor', 1);
 cursor.get('position.x'); //=> 4
 cursor.get('position.y'); //=> 9
 ```

--- a/source/models/working-with-records.md
+++ b/source/models/working-with-records.md
@@ -6,7 +6,7 @@ objects. Making changes is as simple as setting the attribute you
 want to change:
 
 ```js
-var tyrion = this.store.find('person', 1);
+var tyrion = this.store.findRecord('person', 1);
 // ...after the record has loaded
 tyrion.set('firstName', "Yollo");
 ```

--- a/source/routing/asynchronous-routing.md
+++ b/source/routing/asynchronous-routing.md
@@ -219,9 +219,9 @@ depends on the fully resolved value of a model.
 ```app/routes/articles.js
 export default Ember.Route.extend({
   model: function() {
-    // `this.store.find('article')` returns a promise-like object
+    // `this.store.findAll('article')` returns a promise-like object
     // (it has a `then` method that can be used like a promise)
-    return this.store.find('article');
+    return this.store.findAll('article');
   },
   afterModel: function(articles) {
     if (articles.get('length') === 1) {

--- a/source/understanding-ember/dependency-injection-and-service-lookup.md
+++ b/source/understanding-ember/dependency-injection-and-service-lookup.md
@@ -18,7 +18,7 @@ export default Ember.Controller.extend({
   actions: {
     findItems() {
       // Dependency injection provides the store object to the controller instance.
-      this.store.find('item').then((items) => {
+      this.store.findAll('item').then((items) => {
         this.set('items', items);
       });
     }


### PR DESCRIPTION
Updated docs to match https://github.com/emberjs/rfcs/pull/27

Pending:

- [x] [Rename and deprecate finders (store.all -> store.peekAll and store.getById -> store.peekRecord)](https://github.com/emberjs/data/pull/3209)
- [x] [Make store.findAll(type) public](https://github.com/emberjs/data/pull/3234)
- [x] [Rename store.findByRecord to store.findRecord](https://github.com/emberjs/data/pull/3241)