### PR TITLE
Update displaying-the-number-of-incomplete-todos

### DIFF
--- a/source/getting-started/displaying-the-number-of-incomplete-todos.md
+++ b/source/getting-started/displaying-the-number-of-incomplete-todos.md
@@ -17,8 +17,8 @@ actions: {
 },
 
 remaining: function() {
-  return this.filterBy('isCompleted', false).get('length');
-}.property('@each.isCompleted'),
+  return this.get('model').filterBy('isCompleted', false).get('length');
+}.property('model.@each.isCompleted'),
 
 inflection: function() {
   var remaining = this.get('remaining');


### PR DESCRIPTION
`this.filterBy` caused a run-time error: "this.filterBy is not a function"
and without `model.@each.isCompleted` the `remaining` property wouldn't get updated.