### PR TITLE
Simplify format for skipping toc entries

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -1,9 +1,9 @@
 - title: "Guides and Tutorials"
   url: 'index'
+  skip_toc: true
   chapters:
     - title: "Ember.js Guides"
       url: ""
-      skip_sidebar: true
 
 - title: "Getting Started"
   url: 'getting-started'
@@ -235,73 +235,73 @@
       url: "contributing/index"
     - title: "Understanding the Cookbook Format"
       url: "contributing/understanding_the_cookbook_format"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Participating If You Know Ember"
       url: "contributing/participating_if_you_know_ember"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Participating If You Don't Know Ember"
       url: "contributing/participating_if_you_dont_know_ember"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Deciding If A Recipe is a Good Fit"
       url: "contributing/deciding_if_a_recipe_is_a_good_fit"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Suggesting A Recipe"
       url: "contributing/suggesting_a_recipe"
-      skip_sidebar_item: true
+      skip_toc: true
     # ui and ux
     - title: "User Interface and Interaction"
       url: "user_interface_and_interaction/index"
     - title: "Adding CSS Classes to Your Components"
       url: "user_interface_and_interaction/adding_css_classes_to_your_components"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Adding CSS Classes to Your Components Based on Properties"
       url: "user_interface_and_interaction/adding_css_classes_to_your_components_based_on_properties"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Focusing a Textfield after It's Been Inserted"
       url: "user_interface_and_interaction/focusing_a_textfield_after_its_been_inserted"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Displaying Formatted Dates With Moment.js"
       url: "user_interface_and_interaction/displaying_formatted_dates_with_moment_js"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Specifying Data-Driven Areas of Templates That Do Not Need To Update"
       url: "user_interface_and_interaction/specifying_data_driven_areas_of_templates_that_do_not_need_to_update"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Using Modal Dialogs"
       url: "user_interface_and_interaction/using_modal_dialogs"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Resetting scroll on route changes"
       url: "user_interface_and_interaction/resetting_scroll_on_route_changes"
-      skip_sidebar_item: true
+      skip_toc: true
     # events and bindings
     - title: "Event Handling & Data Binding"
       url: "event_handling_and_data_binding/index"
     - title: "Binding Properties of an Object to Its Own Properties"
       url: "event_handling_and_data_binding/binding_properties_of_an_object_to_its_own_properties"
-      skip_sidebar_item: true
+      skip_toc: true
     # helpers & components
     - title: "Helpers & Components"
       url: "helpers_and_components/index"
     - title: "Creating Reusable Social Share Buttons"
       url: "helpers_and_components/creating_reusable_social_share_buttons"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "A Spinning Button for Asynchronous Actions"
       url: "helpers_and_components/spin_button_for_asynchronous_actions"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Adding Google Analytics Tracking"
       url: "helpers_and_components/adding_google_analytics_tracking"
-      skip_sidebar_item: true
+      skip_toc: true
     # objects
     - title: "Working with Objects"
       url: "working_with_objects/index"
     - title: "Incrementing Or Decrementing A Property"
       url: "working_with_objects/incrementing_or_decrementing_a_property"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Setting Multiple Properties At Once"
       url: "working_with_objects/setting_multiple_properties_at_once"
-      skip_sidebar_item: true
+      skip_toc: true
     - title: "Continuous Redrawing of Views"
       url: "working_with_objects/continuous_redrawing_of_views"
-      skip_sidebar_item: true
+      skip_toc: true
 
 - title: "Understanding Ember.js"
   url: 'understanding-ember'

--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -22,9 +22,7 @@ module TOC
       buffer = "<ol class='toc-level-0'>"
       # indentation below is to aid in understanding the HTML structure
         guides.each do |guide|
-          next if guide.chapters.any? do |entry|
-            entry[:skip_sidebar]
-          end
+          next if guide.skip_toc
 
           slugs = request.path.split('/')
 
@@ -41,7 +39,7 @@ module TOC
             buffer << link_to(guide.title, middleman_url)
             buffer << "<ol class='toc-level-1 #{(current ? 'selected' : '')}'>"
               guide.chapters.each do |chapter|
-                next if chapter[:skip_sidebar_item]
+                next if chapter.skip_toc
                 url = "#{guide.url}/#{chapter.url}.html"
 
                 sub_current = (url == current_page.path)

--- a/spec/fixtures/guides.yml
+++ b/spec/fixtures/guides.yml
@@ -6,16 +6,16 @@ guides:
         url: "index"
       - title: "Nobody really cares about this"
         url: "meh"
-        skip_sidebar_item: true
+        skip_toc: true
   - title: "Secret stuff"
     url: "secret"
+    skip_toc: true
     chapters:
       - title: "Don't tell anybody"
         url: ""
-        skip_sidebar: true
   - title: "Extending Middleman"
     url: "extending-middleman"
     chapters:
       - title: "What are extensions?"
         url: "index"
-        skip_sidebar_item: true
+        skip_toc: true

--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -45,11 +45,11 @@ describe TOC::Helpers do
       expect(toc).to include("What even is middleman?")
     end
 
-    it "does not includes guide titles that are marked to skip sidebar" do
+    it "does not includes guide titles that are marked to skip" do
       expect(toc).not_to include("Secret stuff")
     end
 
-    it "does not includes chapter titles that are marked to skip sidebar" do
+    it "does not includes chapter titles that are marked to skip" do
       expect(toc).not_to include("Nobody really cares about this")
     end
 
@@ -57,15 +57,15 @@ describe TOC::Helpers do
       expect(toc).to include("middleman-basics")
     end
 
-    it "does not include guide urls for guides that are marked to skip sidebar" do
+    it "does not include guide urls for guides that are marked to skip" do
       expect(toc).not_to include("secret")
     end
 
-    it "does not include chapter urls that are marked to skip sidebar" do
+    it "does not include chapter urls that are marked to skip" do
       expect(toc).not_to include("meh")
     end
 
-    it "contains a link to first chapter as a guide link even if it is marked with :skip_sidebar_item" do
+    it "contains a link to first chapter as a guide link even if a chapter is marked skip" do
       expect(toc).to include("extending-middleman")
     end
 


### PR DESCRIPTION
This PR makes it easier to understand how to skip TOC entries. It also makes skipping guides and chapters consistent, which will pave the way towards arbitrary levels of nesting and significantly cleaning up the code.

See the last section of https://github.com/emberjs/guides/issues/10#issuecomment-108136584 for more details.