### PR TITLE
Make CSS classes more consistent for TOC

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -19,7 +19,7 @@ module TOC
 
   module Helpers
     def toc_for(guides)
-      buffer = "<ol id='toc-list'>"
+      buffer = "<ol class='toc-level-0'>"
       # indentation below is to aid in understanding the HTML structure
         guides.each do |guide|
           next if guide.chapters.any? do |entry|
@@ -37,9 +37,9 @@ module TOC
           file = "source" + middleman_base_url + ".md"
           raise "#{file} does not exist but is referenced in data/guides.yml. " unless File.exist?(file)
 
-          buffer << "<li class='level-1 #{current ? 'selected' : ''}'>"
+          buffer << "<li class='toc-level-0 #{current ? 'selected' : ''}'>"
             buffer << link_to(guide.title, middleman_url)
-            buffer << "<ol class='#{(current ? 'selected' : '')}'>"
+            buffer << "<ol class='toc-level-1 #{(current ? 'selected' : '')}'>"
               guide.chapters.each do |chapter|
                 next if chapter[:skip_sidebar_item]
                 url = "#{guide.url}/#{chapter.url}.html"
@@ -48,7 +48,7 @@ module TOC
 
                 middleman_url = "/" + url
 
-                buffer << "<li class='level-3 #{sub_current ? ' sub-selected' : ''}'>"
+                buffer << "<li class='toc-level-1 #{sub_current ? ' sub-selected' : ''}'>"
                   buffer << link_to(chapter.title, middleman_url)
                 buffer << "</li>"
               end

--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -48,7 +48,7 @@ module TOC
 
                 middleman_url = "/" + url
 
-                buffer << "<li class='toc-level-1 #{sub_current ? ' sub-selected' : ''}'>"
+                buffer << "<li class='toc-level-1 #{sub_current ? 'selected' : ''}'>"
                   buffer << link_to(chapter.title, middleman_url)
                 buffer << "</li>"
               end

--- a/source/javascripts/app/guides/toc.js
+++ b/source/javascripts/app/guides/toc.js
@@ -1,5 +1,5 @@
 $(function(){
-  $("#toc-list .level-1 > a").click(function() {
+  $(".toc-level-0 .toc-level-0 > a").click(function() {
     $(this).parent().find('> ol').slideToggle(function() {
       positionBackToTop(true);
     });

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -219,7 +219,7 @@ p {
           display: block;
         }
 
-        li.sub-selected {
+        li.selected {
           background-color: #f2d1cb;
           > a {
             font-family: 'Maven Pro';
@@ -280,7 +280,7 @@ p {
             color: rgb(94, 94, 94);
           }
         }
-        &.sub-selected {
+        &.selected {
           // fancy me up.
         }
       }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -194,7 +194,7 @@ p {
     }
   }
 
-  ol#toc-list {
+  ol.toc-level-0 {
     background: #f9e7e4;
     li {
       font-size: 12px;
@@ -230,7 +230,7 @@ p {
 
       }
 
-      &.level-1 {
+      &.toc-level-0 {
         text-transform: uppercase;
 
         > a {
@@ -246,7 +246,7 @@ p {
           }
         }
 
-        & + .level-1 > a {
+        & + .toc-level-0 > a {
           margin-top: -1px;
         }
 
@@ -265,7 +265,7 @@ p {
         }
       }
 
-      &.level-2, &.level-3 {
+      &.toc-level-1, &.toc-level-2 {
 
         a {
           padding: 6px 1em 6px 1em;
@@ -1152,7 +1152,7 @@ a.edit-page {
     }
   }
 
-  ol#toc-list {
+  ol.toc-level-0 {
     li a {
       display: block;
       overflow: hidden;
@@ -1183,7 +1183,7 @@ a.edit-page {
     @include border-radius(3px);
   }
 
-  #sidebar ol#toc-list li > ol {
+  #sidebar ol.toc-level-0 li > ol {
     display: block;
   }
 }

--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -69,6 +69,22 @@ describe TOC::Helpers do
     it "contains a link to first chapter as a guide link even if it is marked with :skip_sidebar_item" do
       expect(toc).to include("extending-middleman")
     end
+
+    it "adds the toc-level-0 class to the outermost <ol>" do
+      expect(toc).to include("<ol class='toc-level-0'><li class='toc-level-0 '>")
+    end
+
+    it "adds the toc-level-0 class to the outermost <li>s" do
+      expect(toc).to include("<li class='toc-level-0 '><a href=\"/middleman-basics/index.html\">")
+    end
+
+    it "adds the toc-level-1 class to the inner <ol>s" do
+      expect(toc).to include("<ol class='toc-level-1 '><li class='toc-level-1")
+    end
+
+    it "adds the toc-level-1 class to the inner <li>s" do
+      expect(toc).to include("<li class='toc-level-1  sub-selected'><a href=\"/middleman-basics/index.html\">")
+    end
   end
 
   describe "#page_title" do

--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -31,8 +31,7 @@ describe TOC::Helpers do
     let(:toc) { helper.toc_for(helper.data.guides) }
 
     before(:each) do
-      building_page = double(path: "custom-extensions/building-custom-extensions.html")
-      allow(helper).to receive(:request).and_return(building_page)
+      allow(helper).to receive(:request).and_return(basics_page)
       allow(File).to receive(:exist?).and_return(true)
     end
 
@@ -71,19 +70,31 @@ describe TOC::Helpers do
     end
 
     it "adds the toc-level-0 class to the outermost <ol>" do
-      expect(toc).to include("<ol class='toc-level-0'><li class='toc-level-0 '>")
+      expect(toc).to include("<ol class='toc-level-0'><li class='toc-level-0 selected'>")
     end
 
     it "adds the toc-level-0 class to the outermost <li>s" do
-      expect(toc).to include("<li class='toc-level-0 '><a href=\"/middleman-basics/index.html\">")
+      expect(toc).to include("<li class='toc-level-0 selected'><a href=\"/middleman-basics/index.html\">")
     end
 
     it "adds the toc-level-1 class to the inner <ol>s" do
-      expect(toc).to include("<ol class='toc-level-1 '><li class='toc-level-1")
+      expect(toc).to include("<ol class='toc-level-1 selected'><li class='toc-level-1")
     end
 
     it "adds the toc-level-1 class to the inner <li>s" do
-      expect(toc).to include("<li class='toc-level-1  sub-selected'><a href=\"/middleman-basics/index.html\">")
+      expect(toc).to include("<li class='toc-level-1 selected'><a href=\"/middleman-basics/index.html\">")
+    end
+
+    it "adds the selected class to the outermost <li> tag" do
+      expect(toc).to include("<li class='toc-level-0 selected'>")
+    end
+
+    it "adds the selected class to the <ol> tag of the current page" do
+      expect(toc).to include("<ol class='toc-level-1 selected'>")
+    end
+
+    it "adds the selected class to the <li> tag of the current page" do
+      expect(toc).to include("<li class='toc-level-1 selected'>")
     end
   end
 


### PR DESCRIPTION
This PR simplifies the CSS classes in the TOC, paving the way towards arbitrary levels of nesting and significantly cleaning up the code. 

See the middle section of https://github.com/emberjs/guides/issues/10#issuecomment-108136584 for more details.