### PR TITLE
Typos and missing links

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -148,6 +148,8 @@
       url: "working-with-records"
     - title: "The Rest Adapter"
       url: "the-rest-adapter"
+    - title: "The Basic Adapter"
+      url: "the-basic-adapter"
     - title: "Connecting to an HTTP Server"
       url: "connecting-to-an-http-server"
     - title: "Handling Metadata"

--- a/data/guides.yml
+++ b/data/guides.yml
@@ -100,6 +100,8 @@
       url: "loading-and-error-substates"
     - title: "Preventing and Retrying Transitions"
       url: "preventing-and-retrying-transitions"
+    - title: "Link to Router Flow"
+      url: "link-to-router-flow"
 
 - title: "Components"
   url: 'components'
@@ -322,6 +324,12 @@
       url: "run-loop"
     - title: "Dependency Injection & Service Lookup"
       url: "dependency-injection-and-service-lookup"
+
+- title: "Understanding Ember Data"
+  url: 'understanding-ember-data'
+  chapters:
+    - title: "Record Lifecycle"
+      url: "record-lifecycle"
 
 - title: "Contributing to Ember.js"
   url: 'contributing'

--- a/data/guides.yml
+++ b/data/guides.yml
@@ -270,6 +270,9 @@
     - title: "Resetting scroll on route changes"
       url: "user_interface_and_interaction/resetting_scroll_on_route_changes"
       skip_sidebar_item: true
+    - title: "Basic Form Validations"
+      url: "user_interface_and_interaction/basic_form_validations"
+      skip_sidebar_item: true
     # events and bindings
     - title: "Event Handling & Data Binding"
       url: "event_handling_and_data_binding/index"

--- a/data/guides.yml
+++ b/data/guides.yml
@@ -303,6 +303,13 @@
     - title: "Continuous Redrawing of Views"
       url: "working_with_objects/continuous_redrawing_of_views"
       skip_sidebar_item: true
+    # Ember data
+    - title: "Ember Data"
+      url: "ember_data/index"
+    - title: "Displaying Only Committed DS.Model Records"
+      url: "ember_data/displaying_only_committed_records"
+    - title: "Linking To Slugs"
+      url: "ember_data/linking_to_slugs"
 
 - title: "Understanding Ember.js"
   url: 'understanding-ember'

--- a/source/cookbook/ember_data/index.md
+++ b/source/cookbook/ember_data/index.md
@@ -1,1 +1,2 @@
 1. [Displaying Only Committed DS.Model Records](./displaying_only_committed_records)
+1. [Linking to Slugs](./linking_to_slugs)

--- a/source/cookbook/user_interface_and_interaction/basic_form_validations.md
+++ b/source/cookbook/user_interface_and_interaction/basic_form_validations.md
@@ -33,7 +33,7 @@ into a div, which would have the class of `has-error` bound to
 
 ```app/templates/components/validated-input.hbs
 <div class="{{if hasError 'has-error'}} form-group">
-    {{input type=type value=value size=size pattern=pattern name=name placeholder=placeholder disaled=disabled maxlength=maxlength tabindex=tabindex class=input-class}}
+    {{input type=type value=value size=size pattern=pattern name=name placeholder=placeholder disabled=disabled maxlength=maxlength tabindex=tabindex class=input-class}}
   </div>
 ```
 

--- a/source/cookbook/user_interface_and_interaction/index.md
+++ b/source/cookbook/user_interface_and_interaction/index.md
@@ -7,3 +7,4 @@ Here are some recipes that will help you provide a better user experience.
 1. [Specifying Data-Driven Areas of Templates That Do Not Need To Update](./specifying_data_driven_areas_of_templates_that_do_not_need_to_update)
 1. [Using Modal Dialogs](./using_modal_dialogs)
 1. [Resetting scroll on route changes](./resetting_scroll_on_route_changes)
+1. [Basic Form Validations](./basic_form_validations)

--- a/source/cookbook/working_with_objects/index.md
+++ b/source/cookbook/working_with_objects/index.md
@@ -2,4 +2,3 @@ Here are some recipes to help you understand working with Ember Objects.
 
 1. [Incrementing Or Decrementing A Property](./incrementing_or_decrementing_a_property)
 1. [Setting Multiple Properties At Once](./setting_multiple_properties_at_once)
-1. [Continuous Redrawing of Views](./continuous_redrawing_of_views)

--- a/source/models/frequently-asked-questions.md
+++ b/source/models/frequently-asked-questions.md
@@ -64,7 +64,7 @@ This will offload searching all of the possible records to the server,
 while still creating a live updating list that includes records created
 and modified on the client.
 
-```app/routes/posts/favourited.js
+```app/routes/posts/favorited.js
 export default Ember.Route.extend({
   model: function() {
     var store = this.store;

--- a/source/routing/defining-your-routes.md
+++ b/source/routing/defining-your-routes.md
@@ -300,7 +300,7 @@ Router.map(function() {
 ```
 
 Like all routes with a dynamic segment, you must provide a context when using a `{{link-to}}`
-or `transitionTo` to programatically enter this route.
+or `transitionTo` to programmatically enter this route.
 
 ```app/routes/application.js
 export default Ember.Route.extend({

--- a/source/understanding-ember-data/record-lifecycle.md
+++ b/source/understanding-ember-data/record-lifecycle.md
@@ -29,14 +29,14 @@ When you request a record using `store.find('person', 1)`, Ember Data
 will ask the store to find the record.
 
 <figure>
-  <img src="../images/ember-data-guide/step1.png">
+  <img width="675" src="../../images/ember-data-guide/step1.png">
 </figure>
 
 If the adapter has not already loaded the record into the store, the
 store will ask the adapter to fetch it.
 
 <figure>
-  <img src="../images/ember-data-guide/step2.png">
+  <img width="675" src="../../images/ember-data-guide/step2.png">
 </figure>
 
 Since the adapter's request is asynchronous, the store will return a new
@@ -44,7 +44,7 @@ Since the adapter's request is asynchronous, the store will return a new
 data.
 
 <figure>
-  <img src="../images/ember-data-guide/step3.png">
+  <img width="675" src="../../images/ember-data-guide/step3.png">
 </figure>
 
 ## Step 2: Adapter Loads Data Into the Store
@@ -52,7 +52,7 @@ data.
 At some point later, the server will return some data to the adapter.
 
 <figure>
-  <img src="../images/ember-data-guide/step5.png">
+  <img width="675" src="../../images/ember-data-guide/step5.png">
 </figure>
 
 Once the adapter receives the data hash, it loads it into the store.
@@ -63,7 +63,7 @@ This will, in turn, notify all attributes (`DS.attr`) and relationships
 (`DS.hasMany` and `DS.belongsTo`).
 
 <figure>
-  <img src="../images/ember-data-guide/step6.png">
+  <img width="675" src="../../images/ember-data-guide/step6.png">
 </figure>
 
 ## Step 3: Getting an Attribute
@@ -83,7 +83,7 @@ data hash loads in from the server, the registered observer will call
 `person.get('firstName')`.
 
 <figure>
-  <img src="../images/ember-data-guide/step7.png">
+  <img width="675" src="../../images/ember-data-guide/step7.png">
 </figure>
 
 ## Step 4: Materialization
@@ -92,7 +92,7 @@ Because this is the first time the record needs its backend-provided
 data, it will ask the store to load it in using `materializeData`.
 
 <figure>
-  <img src="../images/ember-data-guide/step8.png">
+  <img width="675" src="../../images/ember-data-guide/step8.png">
 </figure>
 
 The store will, in turn, ask the adapter to materialize the data. This
@@ -100,7 +100,7 @@ allows the adapter to apply adapter-specific mappings to the
 backend-provided data hash.
 
 <figure>
-  <img src="../images/ember-data-guide/step9.png">
+  <img width="675" src="../../images/ember-data-guide/step9.png">
 </figure>
 
 Finally, the adapter asks its serializer object to perform the
@@ -110,7 +110,7 @@ backend-provided data hashes into records, and serializing records into
 JSON hashes for the backend.
 
 <figure>
-  <img src="../images/ember-data-guide/step10.png">
+  <img width="675" src="../../images/ember-data-guide/step10.png">
 </figure>
 
 The serializer is now responsible for extracting the information from
@@ -118,19 +118,19 @@ the backend-provided data hash and hydrating the record object. First,
 it populates the record's `id`.
 
 <figure>
-  <img src="../images/ember-data-guide/step11.png">
+  <img width="675" src="../../images/ember-data-guide/step11.png">
 </figure>
 
 Next, it populates the record's attributes.
 
 <figure>
-  <img src="../images/ember-data-guide/step12.png">
+  <img width="675" src="../../images/ember-data-guide/step12.png">
 </figure>
 
 Finally, it populates the `belongsTo` association.
 
 <figure>
-  <img src="../images/ember-data-guide/step13.png">
+  <img width="675" src="../../images/ember-data-guide/step13.png">
 </figure>
 
 Once the adapter finishes materializing the record, it returns the


### PR DESCRIPTION
This pull request fixes a few typos and adds a missing link to an orphaned cookbook recipe.

Please note, the commit message for `Fix typo in Models FAQ ... cbc4416` should say "we use favorite and favorited", not favourited. I made the same mistake the commit fixed!