### PR TITLE
Making sure that long table scrolls

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -783,7 +783,8 @@ a.toc-anchor {
 
   table {
     width: 100%;
-
+    display: block;
+    overflow-x: auto;
     margin: 1em 0;
     tbody tr{
       background: rgba(255, 249, 249, 0.56);


### PR DESCRIPTION
The table in the naming-conventions page doesn't scroll..

![image](https://cloud.githubusercontent.com/assets/968912/8222759/1ce25bee-1524-11e5-9088-3163da0f3b80.png)