### PR TITLE
`wife` has the income value not `husband`

### DIFF
--- a/source/object-model/bindings.md
+++ b/source/object-model/bindings.md
@@ -23,8 +23,8 @@ husband = Husband.create({
 husband.get('householdIncome'); // 80000
 
 // Someone gets raise.
-husband.set('householdIncome', 90000);
-wife.get('householdIncome'); // 90000
+wife.set('householdIncome', 90000);
+husband.get('householdIncome'); // 90000
 ```
 
 Note that bindings don't update immediately. Ember waits until all of your


### PR DESCRIPTION
The example previously provided set the income on the `wife` object
during initialization and then updated (`.set`) it on the `husband`
object instead of the `wife` object. This fixes the inconsistency.