### PR TITLE
Make a note about undasherized helpers

### DIFF
--- a/source/templates/writing-helpers.md
+++ b/source/templates/writing-helpers.md
@@ -29,6 +29,14 @@ If the `name` property on the current context changes, Ember.js will
 automatically execute the helper again and update the DOM with the new
 value.
 
+### Undasherized helpers
+
+Helpers without a dash in their name won't be autoloaded by Ember. You can still use them, but you'll need to register them in an initializer, or in `app/app.js`.
+
+```app/app.js
+Ember.Handlerbars.registerHelper('highlight', highlight);
+```
+
 ### Dependencies
 
 Imagine you want to render the full name of a `Person`. In this


### PR DESCRIPTION
I might be completely off my rocker, but I had a bit of difficulty while trying to register a helper named 'thumbnail' today. This documentation fix should save other weirdos some time, assuming it's correct and they want to register single word helpers. It appears to be correct on my end, and the [ember-cli docs](https://ember-cli.com) agree with me, but I would love a few more eyeballs on this. Some things that concerns me about the current documentation: The Ember API docs indicate that [`Ember.Handlebars.makeBoundHelper`](mbh) and [`Ember.Handlebars.registerBoundHelper`](rbh) are private. Is that true? If so, what should we use instead? Additionally, I couldn't find any API documentation about `Ember.Handlebars.registerHelper`, but it's what I have to use to register a helper. Is there another method of registering single word helpers I'm unaware of?

Here's what I'm got locally:
```
> ember -v
version: 0.2.7
node: 0.12.1
npm: 2.11.0
```

[mbh]: http://emberjs.com/api/classes/Ember.Handlebars.html#method_makeBoundHelper
[rbh]: http://emberjs.com/api/classes/Ember.Handlebars.html#method_registerBoundHelper