### PR TITLE
Remove extra columns in tables from "Rendering with Helpers"

### DIFF
--- a/source/templates/rendering-with-helpers.md
+++ b/source/templates/rendering-with-helpers.md
@@ -100,7 +100,6 @@ Note: `{{render}}` cannot be called multiple times for the same route when not s
     <td><code>{{render}}</code></td>
     <td>Template</td>
     <td>Specified Model</td>
-    <td>Specified View</td>
     <td>Specified Controller</td>
   </tr>
   </tbody>
@@ -128,7 +127,6 @@ Note: `{{render}}` cannot be called multiple times for the same route when not s
     <td><code>{{render "author" author}}</code></td>
     <td><code>templates/author.hbs</code></td>
     <td><code>models/author.js</code></td>
-    <td><code>views/author.js</code></td>
     <td><code>controllers/author.js</code></td>
   </tr>
   </tbody>


### PR DESCRIPTION
The tables in that article look like this at 1fc83942d9b58a6612cb11928d5e396794491935
![extra columns](http://i.imgur.com/YHbji1U.png)
I think these are leftovers from the 1.13 `Ember.View` deprecation