### PR TITLE
Add guide about {{component}} helper

### DIFF
--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -81,3 +81,63 @@ example, if you have a component called `blog-post`, you would create a
 file at `app/components/blog-post.js`. If your component was called
 `audio-player-controls`, the file name would be at
 `app/components/audio-player-controls.js`.
+
+### Dynamically rendering a component
+
+The `{{component}}` helper can be used to defer the selection of a component to
+run time. The `{{my-component}}` syntax would always render the same component,
+whereas using the `{{component}}` helper allows swapping the component rendered
+on the fly. This is useful in cases where, for example, you want to interact
+with different external libraries depending on the data. Using the `{{component}}`
+helper would allow you to keep those different logic well-separated.
+
+The first parameter of the helper is the name of a component to render, as a string. So if you have `{{component 'blog-post'}}`, that is just the same as just `{{blog-post}}`.
+
+The real value of `{{component}}` comes from being able to dynamically pick
+the component being rendered. Below is an example of using the helper as a
+mean to dispatch to different components for displaying different kinds of posts:
+
+
+```app/templates/components/foo-component.hbs
+<h3>Hello from foo!</h3>
+<p>{{post.body}}</p>
+```
+
+```app/templates/components/bar-component.hbs
+<h3>Hello from bar!</h3>
+<div>{{post.author}}</div>
+```
+
+```app/routes/index.js
+var posts = [{
+    componentName: 'foo-component',  // key used to determine the rendered component
+    body: "There are lots of à la carte software environments in this world."
+  }, {
+    componentName: 'bar-component',
+    author: "Drew Crawford"
+}];
+
+export default Ember.Route.extend({
+  model() {
+    return posts;
+  }
+});
+```
+
+```app/templates/index.hbs
+{{#each model as |post|}}
+  {{!-- either foo-component or bar-component --}}
+  {{component post.componentName post=post}}
+{{/each}}
+```
+
+For brevity, `componentName` is hardcoded inside each post, but it can very
+well be a computed property that deduces the target component based on the data.
+
+When the parameter passed to `{{component}}` evaluates to `null` or `undefined`,
+the helper renders nothing. When the parameter changes, the currently rendered
+component is destroyed and the new component is created and brought in.
+
+Picking different components to render in response to the data allows you to
+have different template and behavior for each case. The `{{component}}` helper
+is a powerful tool for improving code modularity.

--- a/source/components/passing-properties-to-a-component.md
+++ b/source/components/passing-properties-to-a-component.md
@@ -82,3 +82,10 @@ create a component for each item and bind it to each model in the loop.
 ```
 <!---<a class="jsbin-embed" href="http://jsbin.com/kobakujejo/1//embed?live">JS Bin</a>
 <script src="http://static.jsbin.com/js/embed.js"></script>-->
+
+If you are using the `{{component}}` helper to render your component, you can
+pass properties to the chosen component the same manner:
+
+```handlebars
+{{component componentName title=title name=name}}
+```


### PR DESCRIPTION
Please check my writing. Hopefully I didn't make any technical mistakes. I did not read the source of `{{component}}`, all of this is from my personal experience with the helper.

Another thing to consider is whether these sections are well placed. Are they too advance at their current location? If the guide is even intended to be read top down, that is.

Here is a [jsbin](http://emberjs.jsbin.com/hefugojuya/edit?html,css,js,output) that has the code inside this patch.