### PR TITLE
To keep disco dead

### DIFF
--- a/source/routing/preventing-and-retrying-transitions.md
+++ b/source/routing/preventing-and-retrying-transitions.md
@@ -54,7 +54,7 @@ destination routes to abort attempted transitions.
 ```app/routes/disco.js
 export default Ember.Route.extend({
   beforeModel: function(transition) {
-    if (new Date() < new Date("January 1, 1980")) {
+    if (new Date() > new Date("January 1, 1980")) {
       alert("Sorry, you need a time machine to enter this route.");
       transition.abort();
     }


### PR DESCRIPTION
'Aborting transition' example was excluding the wrong decades.