### PR TITLE
Adding clarification on #each array behavior

### DIFF
--- a/source/templates/displaying-a-list-of-items.md
+++ b/source/templates/displaying-a-list-of-items.md
@@ -23,7 +23,9 @@ The above example will print a list like this:
 
 The `{{#each}}` helper is bindings-aware.  If your
 application adds a new item to the array, or removes an item, the DOM
-will be updated without having to write any code.
+will be updated without having to write any code. Note that a [].push()
+will not update the helper. Adding items need to be done with [].pushObject, 
+and related Ember Array mixins so Ember knows to update the resulting HTML.
 
 ### Specifying Keys
 

--- a/source/templates/displaying-a-list-of-items.md
+++ b/source/templates/displaying-a-list-of-items.md
@@ -23,9 +23,9 @@ The above example will print a list like this:
 
 The `{{#each}}` helper is bindings-aware.  If your
 application adds a new item to the array, or removes an item, the DOM
-will be updated without having to write any code. Note that a [].push()
-will not update the helper. Adding items need to be done with [].pushObject, 
-and related Ember Array mixins so Ember knows to update the resulting HTML.
+will be updated without having to write any code. Note that a `[].push()`
+will not update the helper. Adding items need to be done with `[].pushObject`, 
+and related [Ember Mutable Array methods](http://emberjs.com/api/classes/Ember.MutableArray.html) so that Ember can observe the change.
 
 ### Specifying Keys
 


### PR DESCRIPTION
I experienced much pain trying to find out why changing an attribute that was an array was not updating the #each helper result. 

It is not clear from the documentation that such adding and removing needs to be done with pushObject. I hope this change will help save new Ember users some time.

If this is not the correct place to put such documentation, please let me know an alternative.