### PR TITLE
Fix camelized event names in template/actions.

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -160,15 +160,13 @@ You can specify an alternative event by using the `on` option.
 
 ```handlebars
 <p>
-  <button {{action "select" post on="mouseUp"}}>✓</button>
+  <button {{action "select" post on="mouse-up"}}>✓</button>
   {{post.title}}
 </p>
 ```
 
-You should use the normalized event names [listed in the View guide][1].
-In general, two-word event names (like `keypress`) become `keyPress`.
-
-[1]: http://emberjs.com/api/classes/Ember.View.html#toc_event-names
+You should use the dasherized event names.
+In general, two-word event names (like `keypress`) become `key-press`.
 
 ### Specifying Whitelisted Modifier Keys
 


### PR DESCRIPTION
Event names were camelized in actions instead of dasherized. This fix also
expects emberjs/ember.js#11711 (or similar) to fix the API documentation as
well.

This is the actual fix for emberjs/ember.js#10713 continuing the discussion in
emberjs/guides#83.