### PR TITLE
Move chapter heading and github links into layout

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -55,22 +55,6 @@ module TOC
       current_titles.last
     end
 
-    def chapter_heading
-      name = page_title.strip
-      return if name.blank?
-
-      %Q{
-        <h1>
-          #{name}
-          <a href="#{chapter_github_source_url}" target="_blank" class="edit-page icon-pencil">Edit Page</a>
-        </h1>
-      }
-    end
-
-    def chapter_github_source_url
-      "https://github.com/emberjs/guides/edit/master/source/#{current_page.path.gsub('.html', '.md')}"
-    end
-
     def chapter_links
       %Q{
       <footer>

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -71,7 +71,11 @@
       </div>
       <div id="content" class="has-sidebar">
         <div class="chapter">
-          <%= chapter_heading %>
+          <h1>
+            <%= page_title %>
+            <a href="https://github.com/emberjs/guides/edit/master/source/<%= current_page.path.gsub('html', 'md') %>"
+               target="_blank" class="edit-page icon-pencil">Edit Page</a>
+          </h1>
           <hr>
 
           <%= yield %>

--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -123,25 +123,6 @@ describe TOC::Helpers do
     end
   end
 
-  describe "#chapter_heading" do
-    it "is nil if chapter name is blank" do
-      allow(helper).to receive(:page_title).and_return("")
-
-      expect(helper.chapter_heading).to be_nil
-    end
-
-    it "is header markup with name & source URL when chapter name is specified" do
-      expect(helper.chapter_heading).to include(basic_chapter_title)
-      expect(helper.chapter_heading).to include("https://github.com/emberjs/guides/edit")
-    end
-  end
-
-  describe "#chapter_github_source_url" do
-    it "is the github URL to the source file for current page" do
-      expect(helper.chapter_github_source_url).to eq("https://github.com/emberjs/guides/edit/master/source/middleman-basics/index.md")
-    end
-  end
-
   describe "#chapter_links" do
     it "is markup that consists of previous & next chapter links" do
       allow(helper).to receive(:current_page).and_return(double(path: "secret"))


### PR DESCRIPTION
As part of extracting the TOC and Pagination helpers into a general-purpose gem (#10), we need to move out Ember Guides-specific code. This PR moves links to Github out of the helper and into the application layout.