### PR TITLE
[BUGFIX] #399 Improve Naming Conventions table

### DIFF
--- a/source/getting-started/naming-conventions.md
+++ b/source/getting-started/naming-conventions.md
@@ -202,33 +202,61 @@ export default Ember.Router.extend().map(function(){
 Here are the naming conventions for each of the routes defined in
 this router:
 
-<table class="extensive">
-  <thead>
-  <tr>
-    <th>Route Name</th>
-    <th>Controller</th>
-    <th>Route</th>
-    <th>Template</th>
-  </tr>
-  </thead>
-  <tr>
-    <td><code>posts</code></td>
-    <td><code>app/controllers/posts.js</code></td>
-    <td><code>app/routes/posts.js</code></td>
-    <td><code>app/templates/posts.hbs</code></td>
-  </tr>
-  <tr>
-    <td><code>posts.favorites</code></td>
-    <td><code>app/controllers/posts/favorites.js</code></td>
-    <td><code>app/routes/posts/favorites.js</code></td>
-    <td><code>app/templates/posts/favorites.hbs</code></td>
-  </tr>
-  <tr>
-    <td><code>posts.post</code></td>
-    <td><code>app/controllers/posts/post.js</code></td>
-    <td><code>app/routes/posts/post.js</code></td>
-    <td><code>app/templates/posts/post.hbs</code></td>
-  </tr>
+<table>
+    <thead>
+      <tr>
+          <th>Route Name</th>
+          <th>Convention</th>
+      </tr>
+    </thead>
+    <tr>
+        <td><code>posts</code></td>
+        <td>
+            <pre class="code">
+app
+ ├── controllers/
+ │   └── posts.js  
+ ├── routes/
+ │   └── posts.js  
+ └── templates/
+     └── posts.hbs
+            </pre>
+        </td>
+    </tr>
+    <tr>
+        <td><code>posts.favorites</code></td>
+        <td>
+            <pre class="code">
+app
+ ├── controllers/
+ │   └── posts/  
+ │       └── favorites.js  
+ ├── routes/
+ │   └── posts/
+ │       └── favorites.js  
+ └── templates/
+     └── posts/
+         └── favorites.hbs
+          </pre>
+        </td>
+    </tr>
+    <tr>
+        <td><code>posts.post</code></td>
+        <td>
+            <pre class="code">
+app
+ ├── controllers/
+ │   └── posts/  
+ │       └── post.js  
+ ├── routes/
+ │   └── posts/
+ │       └── post.js  
+ └── templates/
+     └── posts/
+         └── post.hbs
+            </pre>
+        </td>
+    </tr>
 </table>
 
 ## The Index Route

--- a/source/stylesheets/guides.css.scss
+++ b/source/stylesheets/guides.css.scss
@@ -25,6 +25,15 @@ body.guides, body.blog, body.api {
     @include border-radius(5px);
   }
 
+  pre.code {
+    font-family: Menlo, Courier, monospace;
+    font-size: 90%;
+    color: #666;
+    background-color: rgba(0, 0, 0, 0.04);
+    padding: 3px;
+    @include border-radius(5px);
+  }
+
   .highlight { // jsbin includes
     margin-bottom: 20px;
   }


### PR DESCRIPTION
The naming conventions table in older guides cuts off the text. And in the current guide making the text smaller is not very elegant.

This commit represents the convention as tree view. Which takes up more vertical space but is easier to visualize at a glance. And doesn't suffer the scroll overflow or font size issues.

I believe this should also be back ported to old versions of the guides. Because #399 was reported again v1.12.0 version of guides

Before

<img width="710" alt="conventions-before" src="https://cloud.githubusercontent.com/assets/497659/8692272/a8c9c6d4-2a81-11e5-9744-efb1be962605.png">

After

<img width="736" alt="conventions-after" src="https://cloud.githubusercontent.com/assets/497659/8692280/b4355420-2a81-11e5-895c-1da445f2c31f.png">
