### PR TITLE
Use post.js instead of posts.js

### DIFF
--- a/source/routing/rendering-a-template.md
+++ b/source/routing/rendering-a-template.md
@@ -28,7 +28,7 @@ export default Ember.Route.extend({
 If you want to use a different controller than the route handler's
 controller, pass the controller's name in the `controller` option:
 
-```app/routes/posts.js
+```app/routes/post.js
 export default Ember.Route.extend({
   renderTemplate: function() {
     this.render({ controller: 'favoritePost' });


### PR DESCRIPTION
It seems to me that this route is referring to something that is called with a dynamic segment, so it should be post.js instead of posts.js. The sample above this also uses post.js, so it seems it should be consistent with that.