### PR TITLE
Modify data attribute bindings example to support bound attrs

### DIFF
--- a/source/templates/binding-element-attributes.md
+++ b/source/templates/binding-element-attributes.md
@@ -90,7 +90,7 @@ export default Ember.View.reopen({
 
     // bind attributes beginning with 'data-'
     Ember.keys(this).forEach(function(key) {
-      if (key.substr(0, 5) === 'data-') {
+      if (key.substr(0, 5) === 'data-' && key.substr(key.length - 7) !== 'Binding') {
         self.get('attributeBindings').pushObject(key);
       }
     });


### PR DESCRIPTION
This fixes an issue in the existing code example for adding a `data-` attribute to an core Ember View, such as LinkView. Currently the code supports assigning strings to data attributes just fine. But if one tries to bind a property a data attribute on a view, e.g.:
```handlebars
 {{#link-to route id data-result-number=dataResultNumber}}
```
You end up with an anchor such as:
```html
<a id="ember1670" class="ember-view" href="/xyz/123" data-result-number="1" data-result-numberBinding=[Object object]> 
```
This modification to the example avoids that problem.