### PR TITLE
The action name should be "select" only

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -222,7 +222,7 @@ For example, given this template that adds the `select` action to a
 button:
 
 ```app/templates/component/show-posts.hbs
-<button {{action "selectPost" model}}>Select Post</button>
+<button {{action "select" model}}>Select Post</button>
 ```
 
 You can implement a function that responds to the button being clicked


### PR DESCRIPTION
> At the moment "selectPost" is there as action name in template, however only `select()` in the component js.
> This was the original version:

```app/templates/component/show-posts.hbs
<button {{action "selectPost" model}}>Select Post</button>
```

You can implement a function that responds to the button being clicked
by adding an `actions` hash to your component with a method called
`select`:


```app/components/show-posts.js
export default Ember.Component.extend({
  actions: {
    select(post) {
      // do your business.
    }
  }
});
```