### PR TITLE
Improve version switching

### DIFF
--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -6,7 +6,7 @@ $.ajax('/versions.json')
     });
     var slugs = window.location.href.split('/');
     var currentRevision = slugs[slugs.length - 2];
-    versionSelectBox.select2('val', currentRevision);
+    versionSelectBox.val(currentRevision).change();
 
     versionSelectBox.on('change', function() {
       var version = this.value;

--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -1,11 +1,11 @@
-var currentRevision = '<%= data.search.revision %>';
-
 $.ajax('/versions.json')
   .done(function(data) {
     var versionSelectBox = $(".version-select");
     versionSelectBox.select2({
       data: data
     });
+    var slugs = window.location.href.split('/');
+    var currentRevision = slugs[slugs.length - 2];
     versionSelectBox.select2('val', currentRevision);
 
     versionSelectBox.on('change', function() {


### PR DESCRIPTION
1. Use the URL rather than the version from `search.yml`. That bit of JavaScript shouldn't rely on a YAML file for Swiftype, since the two don't have anything to do with each other other than the version. (Down the road, I hope to simplify the build/release process so that we don't have to change anything in this repo.)

2. Stop using a deprecated select2 method.