### PR TITLE
Remove JSBin from components/handling-user-interaction-with-actions

### DIFF
--- a/source/components/handling-user-interaction-with-actions.md
+++ b/source/components/handling-user-interaction-with-actions.md
@@ -35,8 +35,6 @@ export default Ember.Component.extend({
 });
 ```
 
-<!---<a class="jsbin-embed" href="http://jsbin.com/ciwenemedi/1/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>-->
-
 The `{{action}}` helper can accept arguments, listen for different event
 types, control how action bubbling occurs, and more.
 


### PR DESCRIPTION
Commented out since march. Contained code that is still shown on the page as snippets.

Meta PR: https://github.com/emberjs/guides/issues/483