### PR TITLE
Replace versions with note in versions.json

### DIFF
--- a/source/versions.json
+++ b/source/versions.json
@@ -1,1 +1,1 @@
-["v1.10.0", "v1.9.0"]
+["Versions will appear here when deployed"]


### PR DESCRIPTION
At least a couple people have been confused about why versions.json isn't updated in this repo. This change replaces the dummy version numbers with a note documenting that the file is updated in the deployment process. In development, the user sees this note where the version numbers would be in the drop-down menu.