### PR TITLE
Search

### DIFF
--- a/data/search.yml
+++ b/data/search.yml
@@ -1,1 +1,1 @@
-engine_key: 'ha9YM1kgBdihxrq_8ZHK'
+engine_key: 'UdruvUp_iEcu2wdYqw9D'

--- a/source/javascripts/swiftype.js.erb
+++ b/source/javascripts/swiftype.js.erb
@@ -1,7 +1,6 @@
 var Swiftype = window.Swiftype || {};
 
-var slugs = window.location.href.split('/');
-var currentRevision = slugs[slugs.length - 2];
+var currentRevision = 'CURRENT_REVISION_WILL_APPEAR_HERE_WHEN_DEPLOYED';
 var documentType = 'guides-' + currentRevision.replace(/\./g,'-');
 
 (function() {


### PR DESCRIPTION
@trek noted that the approach #481 uses will break search if the domain structure of the site changes. Rather than revert to the previous approach of having to update the version number before building (#499), which adds an extra step and thus increases the odds of deploying a build with broken search, this PR simply adds a placeholder string for the version number, which then the `publish-search` task of https://github.com/emberjs/guides.emberjs.com can replace with the version number of the snapshot being deployed (see https://github.com/emberjs/guides.emberjs.com/pull/9).