### PR TITLE
issue #533: added fix for page jump when hovered on next/previous link

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -824,10 +824,12 @@ a.toc-anchor {
 
 .previous-guide {
   float: left;
+  border-bottom: 1px solid transparent;
 }
 
 .next-guide {
   float: right;
+  border-bottom: 1px solid transparent;
 }
 
 /**


### PR DESCRIPTION
Added a default `border-bottom` with value as `transparent`
No page re-flow occurs on hover and hence the problem is resolved. 