### PR TITLE
Avoid JSHint unused error when importing helpers

### DIFF
--- a/source/testing/test-helpers.md
+++ b/source/testing/test-helpers.md
@@ -198,8 +198,8 @@ import Ember from 'ember';
 import Application from '../../app';
 import Router from '../../router';
 import config from '../../config/environment';
-import shouldHaveElementWithCount from "./should-have-element-with-count";
-import dblclick from "./dblclick";
-import addContact from "./add-contact";
+import "./should-have-element-with-count";
+import "./dblclick";
+import "./add-contact";
 ```
 


### PR DESCRIPTION
Currently the documentation suggests that you need to import your custom test helper in `start-app.js`.
While this is true, the documented import syntax will cause a failing JSHint test on `start-app.js` because the imported test helper is not directly begin used.
I think the documentation should suggest to import using `import "./helper"` instead of `import "helper" from "./helper"`.