### PR TITLE
Remove js and css for jsbins

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -111,7 +111,6 @@
     <%= yield_content :foot %>
 
     <%= javascript_include_tag 'guides' %>
-    <script src="http://static.jsbin.com/js/embed.js"></script>
 
     <script type="text/javascript">
       var _gaq = _gaq || [];

--- a/source/stylesheets/guides.css.scss
+++ b/source/stylesheets/guides.css.scss
@@ -34,10 +34,6 @@ body.guides, body.blog, body.api {
     @include border-radius(5px);
   }
 
-  .highlight { // jsbin includes
-    margin-bottom: 20px;
-  }
-
   h1 {
     font-size: 22px;
     color: $orange-color;


### PR DESCRIPTION
Now that we don't use them, we don't need this code. Just about wraps up #483.