### PR TITLE
Update terminology when describing wildcard routes

### DIFF
--- a/source/routing/defining-your-routes.md
+++ b/source/routing/defining-your-routes.md
@@ -446,7 +446,7 @@ replace the `{{outlet}}` in the `posts` template with the
 
 ### Wildcard / globbing routes
 
-You can define wildcard routes that will match multiple routes. This could be used, for example,
+You can define wildcard routes that will match multiple URL segments. This could be used, for example,
 if you'd like a catch-all route which is useful when the user enters an incorrect URL not managed
 by your app.
 


### PR DESCRIPTION
This is an attempt to be slightly more clear about wildcard routes.

Unless I'm way off mark, I think folks would agree that wildcards do not match multiple *routes*, because they match *URL strings*, and an Ember.Route is not a URL string.

I headed over to [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3) to see if I could find a name for whatever *the thing between the backslashes* is within a URL path, and they are called "segments." However, it's implied in the Ember docs, and explicitly stated in route recognizer, that the DSL syntax refers to the static / dynamic / wildcard *things* themselves as segments. For this reason, I specify that we are referring to "URL segments" here, as opposed to "route recognizer DSL segments."

This is a pretty minor thing, though, and it may be the case that nobody is confused by it. Shrug.