### PR TITLE
Add Example Uses of `[]` in Computed Properties

### DIFF
--- a/data/pages.yml
+++ b/data/pages.yml
@@ -24,7 +24,7 @@
       url: "reopening-classes-and-instances"
     - title: "Computed Properties"
       url: "computed-properties"
-    - title: "Computed Properties and Aggregate Data with @each"
+    - title: "Computed Properties and Aggregate Data"
       url: "computed-properties-and-aggregate-data"
     - title: "Observers"
       url: "observers"

--- a/source/object-model/computed-properties-and-aggregate-data.md
+++ b/source/object-model/computed-properties-and-aggregate-data.md
@@ -57,3 +57,65 @@ todosController.get('remaining');
 
 Note that `@each` only works one level deep. You cannot use nested forms like
 `todos.@each.owner.name` or `todos.@each.owner.@each.name`.
+
+Sometimes, you may only care if the items of an array have been added, removed, or replaced, 
+rather than changes to properties on the items themselves. For example, items may have been 
+added to or removed from the array. In this case, you can create a computed property as follows:
+
+
+```app/controllers/todos.js
+export default Ember.Controller.extend({
+  todos: [
+    Ember.Object.create({ isDone: true }),
+    Ember.Object.create({ isDone: false }),
+    Ember.Object.create({ isDone: true })
+  ],
+
+  selectedTodo: null,
+  indexOfSelectedTodo: Ember.computed('selectedTodo', 'todos.[]', function () {
+    return this.get('todos').indexOf(this.get('selectedTodo'));
+  })
+});
+```
+
+Note here that we use the special key `[]` instead of `@each.foo` (which is used for observing 
+a specific dependent key, such as `foo`, on each item). This instructs Ember.js to only care about 
+the array itself changing (such as adding/removing items), rather than changes to the items themselves.
+
+Several of the [Ember.computed](http://emberjs.com/api/classes/Ember.computed.html) macros 
+utilize the `[]` key to implement common use-cases as well. For example, if you wanted to 
+create a computed property that mapped properties from an array, you could use 
+[Ember.computed.map](http://emberjs.com/api/classes/Ember.computed.html#method_map)
+or build the computed yourself:
+
+```javascript
+const Hamster = Ember.Object.extend({
+  excitingChores: Ember.computed('chores.[]', function () {
+    return this.get('chores').map(function (chore, index) {
+      return `CHORE ${index}: ${chore.toUpperCase()}!`;
+    }
+  })
+});
+
+const hamster = Hamster.create({
+  chores: ['clean', 'write more unit tests']
+});
+
+hamster.get('excitingChores'); // ['CHORE 1: CLEAN!', 'CHORE 2: WRITE MORE UNIT TESTS!']
+hamster.get('excitingChores').pushObject('review code');
+hamster.get('excitingChores'); // ['CHORE 1: CLEAN!', 'CHORE 2: WRITE MORE UNIT TESTS!', 'CHORE 3: REVIEW CODE!']
+```
+
+By comparison, using the computed macro abstracts some of this away:
+
+```javascript
+const Hamster = Ember.Object.extend({
+  excitingChores: Ember.computed.map('chores', function (chore, index) {
+    return `CHORE ${index}: ${chore.toUpperCase()}!`;
+  })
+});
+```
+
+The computed macros expect you to use an array, so there is no need to use the '[]' key in these cases. 
+However, building your own custom computed property requires you to tell Ember.js that it is watching 
+for array changes, which is where the `[]` key comes in handy.


### PR DESCRIPTION
Given the deprecation of `@each` for leaf node observing in computed properties, adds examples to the guides that show users how to utilize the `[]` key for those scenarios
Updates the title of the page to remove specific mention of `@each` to avoid confusion (per @rwjblue)