### PR TITLE
Remove imports

### DIFF
--- a/source/components/composing-components.md
+++ b/source/components/composing-components.md
@@ -202,8 +202,6 @@ We'll be looking at a `{{user-profile}}` component that implements a save action
 Here's our component's definition:
 
 ```app/components/user-profile/component.js
-import Ember from 'ember';
-
 export default Ember.Component.extend({
   actions: {
     saveUser() {

--- a/source/components/passing-properties-to-a-component.md
+++ b/source/components/passing-properties-to-a-component.md
@@ -83,8 +83,6 @@ Apart from passing attributes to a component, you can also pass in positional pa
 You can access these parameters by setting the `positionalParams` attribute in your component.
 
 ```app/components/x-visit.js
-import Ember from 'ember';
-
 export default Ember.Component.extend({
   positionalParams: ['name', 'model']
 });

--- a/source/models/connecting-to-an-http-server.md
+++ b/source/models/connecting-to-an-http-server.md
@@ -53,8 +53,6 @@ REST adapter:
 Given the following models:
 
 ```app/models/post.js
-import DS from 'ember-data';
-
 export default DS.Model.extend({
   title:    DS.attr(),
   comments: DS.hasMany('comment'),
@@ -63,8 +61,6 @@ export default DS.Model.extend({
 ```
 
 ```app/models/comment.js
-import DS from 'ember-data';
-
 export default DS.Model.extend({
   body: DS.attr()
 });

--- a/source/models/index.md
+++ b/source/models/index.md
@@ -78,9 +78,7 @@ You might be tempted to make the component responsible for fetching that
 data and storing it:
 
 ```app/components/list-of-drafts.js
-import Component from "ember-component";
-
-export default Component.extend({
+export default Ember.Component.extend({
   willRender() {
     $.getJSON('/drafts').then(data => {
       this.set('drafts', data);
@@ -195,11 +193,9 @@ example, a `Person` model might have a `firstName` attribute that is a
 string, and a `birthday` attribute that is a date:
 
 ```app/models/person.js
-import Model, { attr } from "ember-data/model";
-
-export default Model.extend({
-  firstName: attr('string'),
-  birthday:  attr('date')
+export default DS.Model.extend({
+  firstName: DS.attr('string'),
+  birthday:  DS.attr('date')
 });
 ```
 
@@ -208,18 +204,14 @@ example, an `order` may have many `line-items`, and a
 `line-item` may belong to a particular `order`.
 
 ```app/models/order.js
-import Model, { hasMany } from "ember-data/model";
-
-export default Model.extend({
-  lineItems: hasMany('line-item')
+export default DS.Model.extend({
+  lineItems: DS.hasMany('line-item')
 });
 ```
 
 ```app/models/line-item.js
-import Model, { belongsTo } from "ember-data/model";
-
-export default Model.extend({
-  order: belongsTo('order')
+export default DS.Model.extend({
+  order: DS.belongsTo('order')
 });
 ```
 

--- a/source/templates/displaying-the-keys-in-an-object.md
+++ b/source/templates/displaying-the-keys-in-an-object.md
@@ -3,9 +3,7 @@ JavaScript object in your template, you can use the `{{#each-in}}`
 helper:
 
 ```/app/components/store-categories.js
-import Component from "ember-component";
-
-export Component.extend({
+export Ember.Component.extend({
   willRender() {
     // Set the "categories" property to a JavaScript object
     // with the category name as the key and the value a list

--- a/source/templates/writing-helpers.md
+++ b/source/templates/writing-helpers.md
@@ -40,8 +40,6 @@ ember generate helper format-currency
 That file should export a function wrapped with `Ember.Helper.helper()`:
 
 ```app/helpers/format-currency.js
-import Ember from "ember";
-
 export default Ember.Helper.helper(function(params) {
   let value = params[0],
       dollars = Math.floor(value / 100),
@@ -99,8 +97,6 @@ list after the helper name:
 An array of these arguments is passed to the helper function:
 
 ```app/helpers/my-helper.js
-import Ember from "ember";
-
 export default Ember.Helper.helper(function(params) {
   let arg1 = params[0];
   let arg2 = params[1];
@@ -114,8 +110,6 @@ You can use JavaScript's destructuring assignment shorthand to clean up
 the code. This example is equivalent to the above example (note the function signature):
 
 ```app/helpers/my-helper.js
-import Ember from "ember";
-
 export default Ember.Helper.helper(function([arg1, arg2]) {
   console.log(arg1); // => "hello"
   console.log(arg2); // => "world"
@@ -158,8 +152,6 @@ to the helper function.  Here is our example from above, updated to
 support the optional `sign` option:
 
 ```app/helpers/format-currency.js
-import Ember from "ember";
-
 export default Ember.Helper.helper(function(params, namedArgs) {
   let value = params[0],
       dollars = Math.floor(value / 100),
@@ -180,7 +172,6 @@ world"}}
 ```
 
 ```app/helpers/my-helper.js
-import Ember from "ember";
 export default Ember.Helper.helper(function(params, namedArgs) {
   console.log(namedArgs.option1); // => "hello"
   console.log(namedArgs.option2); // => "world"
@@ -192,7 +183,6 @@ You can use JavaScript's destructuring assignment shorthand in this case
 as well to clean up the above code:
 
 ```app/helpers/my-helper.js
-import Ember from "ember";
 export default Ember.Helper.helper(function(params, { option1, option2, option3 }) {
   console.log(option1); // => "hello"
   console.log(option2); // => "world"
@@ -250,8 +240,6 @@ In fact, we can refactor the above stateless helper into a stateful
 helper just by making the function into a `compute` method on the class:
 
 ```app/helpers/format-currency.js
-import Ember from "ember";
-
 export default Ember.Helper.extend({
   compute(params, hash) {
     let value = params[0],
@@ -277,8 +265,6 @@ Once added, you can call the service's methods or access its properties
 from within the `compute()` method.
 
 ```app/helpers/is-authenticated.js
-import Ember from "ember";
-
 export default Ember.Helper.extend({
   authentication: Ember.inject.service()
   compute() {
@@ -302,7 +288,6 @@ the browser will not interpret it as HTML.
 For example, here's a `make-bold` helper that returns a string containing HTML:
 
 ```app/helpers/make-bold.js
-import Ember from "ember";
 export default Ember.Helper.helper(function(params) {
   return `<b>${params[0]}</b>`;
 });
@@ -326,7 +311,6 @@ escape the return value (that is, that it is _safe_) by using the
 `htmlSafe` string utility:
 
 ```app/helpers/make-bold.js
-import Ember from "ember";
 export default Ember.Helper.helper(function(params) {
   return Ember.String.htmlSafe(`<b>${params[0]}</b>`);
 });
@@ -360,7 +344,6 @@ escape anything that may have come from an untrusted user with the
 `escapeExpression` utility:
 
 ```app/helpers/make-bold.js
-import Ember from "ember";
 export default Ember.Helper.helper(function(params) {
   let value = Handlebars.Utils.escapeExpression(params[0]);
   return Ember.String.htmlSafe(`<b>${value}</b>`);

--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -11,8 +11,6 @@ component is bound to its `style` property.
 > component pretty-color`.
 
 ```app/components/pretty-color.js
-import Ember from 'ember';
-
 export default Ember.Component.extend({
   attributeBindings: ['style'],
 
@@ -108,8 +106,6 @@ clicked on:
 > component magic-title`.
 
 ```app/components/magic-title.js
-import Ember from 'ember';
-
 export default Ember.Component.extend({
   title: 'Hello World',
 
@@ -164,8 +160,6 @@ For example, imagine you have a comment form component that sends a specified
 > component comment-form`.
 
 ```app/components/comment-form.js
-import Ember from 'ember';
-
 export default Ember.Component.extend({
   body: null,
 


### PR DESCRIPTION
There were some imports that used paths allowed by `ember-cli-shims` which aren't final yet.
While I was fixing it I realized the Guides in general omit the imports, so I combed through and removed the ones I could find.