### PR TITLE
Move version for version switching to publishing step

### DIFF
--- a/source/javascripts/app/guides/version-select.js.erb
+++ b/source/javascripts/app/guides/version-select.js.erb
@@ -4,8 +4,7 @@ $.ajax('/versions.json')
     versionSelectBox.select2({
       data: data
     });
-    var slugs = window.location.href.split('/');
-    var currentRevision = slugs[slugs.length - 2];
+    var currentRevision = 'CURRENT_REVISION_WILL_APPEAR_HERE_WHEN_DEPLOYED';
     versionSelectBox.val(currentRevision).change();
 
     versionSelectBox.on('change', function() {


### PR DESCRIPTION
This will be just like we do for the version number for search. In the publishing step, we will replace `'CURRENT_REVISION_WILL_APPEAR_HERE_WHEN_DEPLOYED'` with the current version. Corresponding PR coming soon.