### PR TITLE
Minor nitpick - callout empty arrays are not falsy

### DIFF
--- a/source/templates/conditionals.md
+++ b/source/templates/conditionals.md
@@ -10,7 +10,7 @@ We can use the `{{#if}}` helper to conditionally render a block:
 ```
 
 Handlebars will not render the block if the argument passed evaluates to
-`false`, `undefined`, `null` or `[]` (i.e., any "falsy" value).
+`false`, `undefined`, `null` or `[]` (i.e., any "falsy" value or an empty array).
 
 If the expression evaluates to falsy, we can also display an alternate template
 using `{{else}}`:


### PR DESCRIPTION
I thought it would be helpful (especially to those new to JS) to be (slightly) more explicit about Ember treating ```[]``` differently here than "vanilla JS". A minor point I realize - do with it what you will.

As a new Ember user I'm impressed with the guides - great work! Thanks for all the work that went into these!