### PR TITLE
Documenting usage of positional params in reopenClass

### DIFF
--- a/source/components/passing-properties-to-a-component.md
+++ b/source/components/passing-properties-to-a-component.md
@@ -80,12 +80,17 @@ pass properties to the chosen component in the same manner:
 
 Apart from passing attributes to a component, you can also pass in positional parameters, like we've seen with the `{{link-to}}`, e.g. `{{link-to "user" userModel}}`.
 
-You can access these parameters by setting the `positionalParams` attribute in your component.
+You can access these parameters by setting the `positionalParams` attribute in your component class.
 
 ```app/components/x-visit.js
-export default Ember.Component.extend({
+const MyComponent = Ember.Component.extend();
+
+MyComponent.reopenClass({
+>>>>>>> Documenting usage of positional params in reopenClass
   positionalParams: ['name', 'model']
 });
+
+export default MyComponent;
 ```
 
 This will expose the first parameter in your template as the `{{name}}` attribute and the second as `{{model}}`. They will also be available as regular attributes in your component via `this.get('name')` and `this.get('model')`.


### PR DESCRIPTION
updates #482 due to https://github.com/emberjs/ember.js/commits/a7146f443ec611b31d2db8d5cd3bbc6fcc26b3a9
also see https://github.com/emberjs/ember.js/commit/995e2d2e0d5e6ae54afb6f3095c3d1efb20cdcfc#commitcomment-12513902

Should this be based on the 2.0.0 branch since this behavior is already present in v2?