### PR TITLE
Example correction

### DIFF
--- a/source/object-model/computed-properties-and-aggregate-data.md
+++ b/source/object-model/computed-properties-and-aggregate-data.md
@@ -93,7 +93,7 @@ const Hamster = Ember.Object.extend({
   excitingChores: Ember.computed('chores.[]', function() {
     return this.get('chores').map(function(chore, index) {
       return `CHORE ${index}: ${chore.toUpperCase()}!`;
-    }
+    });
   })
 });
 
@@ -102,7 +102,7 @@ const hamster = Hamster.create({
 });
 
 hamster.get('excitingChores'); // ['CHORE 1: CLEAN!', 'CHORE 2: WRITE MORE UNIT TESTS!']
-hamster.get('excitingChores').pushObject('review code');
+hamster.get('chores').pushObject('review code');
 hamster.get('excitingChores'); // ['CHORE 1: CLEAN!', 'CHORE 2: WRITE MORE UNIT TESTS!', 'CHORE 3: REVIEW CODE!']
 ```
 


### PR DESCRIPTION
* Line 96: missing a `)`

* Line 105: Updating the `chores` property instead of the computed to make it mapped correctly otherwise the computed property will be:
`['CHORE 1: CLEAN!', 'CHORE 2: WRITE MORE UNIT TESTS!', 'review code']`
instead of
`['CHORE 1: CLEAN!', 'CHORE 2: WRITE MORE UNIT TESTS!', 'CHORE 3: REVIEW CODE!']`
