### PR TITLE
Templates cleanup, tweaks

### DIFF
--- a/source/templates/conditionals.md
+++ b/source/templates/conditionals.md
@@ -1,7 +1,49 @@
-Sometimes you may only want to display part of your template if a property
-exists.
+Conditional statements bring a minimum of logic into Ember templating.
+Statements like `if` and `unless` are implemented as built-in helpers. Helpers
+can be invoked three ways.
 
-We can use the `{{#if}}` helper to conditionally render a block:
+The first style of invocation is **inline invocation**. This looks similar to
+displaying a property, but helpers accept arguments. For example:
+
+```handlebars
+<div>
+  {{if isFast "zoooom" "putt-putt-putt"}}
+</div>
+```
+
+`{{if}}` in this case returns `"zoooom"` when `isFast` is true and
+`"putt-putt-putt"` when `isFast` is false. Helpers invoked as inline expressions
+render a single value, the same way that properties are a single value.
+
+Inline helpers don't need to be used inside HTML tags. They can also be used
+inside attribute values:
+
+```handlebars
+<div class="is-car {{if isFast "zoooom" "putt-putt-putt"}}">
+</div>
+```
+
+**Nested invocation** is another way to use a helper. Just like inline helpers,
+nested helpers generate and return a single value. For example, this template
+only renders `"zoooom"` if both `isFast` and `isFueled` are true:
+
+```handlebars
+<div>
+  {{if isFast (if isFueled "zoooom")}}
+</div>
+```
+
+The nested helper is called first returning `"zoooom"` only if `isFueled` is
+true. Then the inline expression is called, rendering the nested helper's
+value (`"zoooom"`) only if `isFast` is true.
+
+The third form of helper usage is **block invocation**. Use block helpers
+to render only part of a template. Block invocation of a helper can be
+recognized by the `#` before the helper name, and the closing `{{/` double
+curly brace at the end of the invocation.
+
+For example, this template conditionally shows
+properties on `person` only if that it is present:
 
 ```handlebars
 {{#if person}}
@@ -9,11 +51,12 @@ We can use the `{{#if}}` helper to conditionally render a block:
 {{/if}}
 ```
 
-Handlebars will not render the block if the argument passed evaluates to
-`false`, `undefined`, `null` or `[]` (i.e., any "falsy" value or an empty array).
+`{{if}}` checks for truthiness, which means all values except `false`,
+`undefined`, `null`, `''`  or `[]` (i.e., any JavaScript falsy value or an
+empty array).
 
-If the expression evaluates to falsy, we can also display an alternate template
-using `{{else}}`:
+If a value passed to `{{#if}}` evaluates to falsy, the `{{else}}` block
+of that invocation is rendered:
 
 ```handlebars
 {{#if person}}
@@ -23,7 +66,8 @@ using `{{else}}`:
 {{/if}}
 ```
 
-Handlebars also supports chained else helpers, the most common use being else if. An example:
+`{{else}}` can chain helper invocation, the most common usecase for this being
+`{{else if}}`:
 
 ```handlebars
 {{#if isAtWork}}
@@ -33,26 +77,12 @@ Handlebars also supports chained else helpers, the most common use being else if
 {{/if}}
 ```
 
-To only render a block if a value is falsy, use `{{#unless}}`:
+The inverse of `{{if}}` is `{{unless}}`, which can be used in the same three
+styles of invocation. For example, this template only shows an amount due when the
+user has not paid:
 
 ```handlebars
 {{#unless hasPaid}}
   You owe: ${{total}}
 {{/unless}}
 ```
-
-`{{#if}}` and `{{#unless}}` are examples of block expressions. These allow you
-to invoke a helper with a portion of your template. Block expressions look like
-normal expressions except that they contain a hash (#) before the helper name,
-and require a closing expression.
-
-You can also use the inline `{{if}}` helper:
-
-```handlebars
-<span class={{if isEnabled "enabled" "disabled"}}>Warning!</span>
-```
-
-In this case, if the `isEnabled` property is `true`, the `enabled` class will be
-added. The second argument is optional and only necessary if you want to handle
-the `false` case. Here, if the property is `false`, the class `disabled` will be
-added.

--- a/source/templates/displaying-a-list-of-items.md
+++ b/source/templates/displaying-a-list-of-items.md
@@ -1,4 +1,10 @@
-If you need to enumerate over a list of objects, use Handlebars' `{{#each}}` helper:
+To iterate over a list of items, use the `{{#each}}` helper. The first
+argument to this helper is the array to be iterated, and the value being
+iterated is yielded as a block param. Block params are only available inside
+the block of their helper.
+
+For example, this template iterates an array named `people` that contains
+objects. Each item in the array is provided as the block param `person`.
 
 ```handlebars
 <ul>
@@ -8,10 +14,22 @@ If you need to enumerate over a list of objects, use Handlebars' `{{#each}}` hel
 </ul>
 ```
 
-The template inside of the `{{#each}}` block will be repeated once for
-each item in the array, with the each item set to the `person` keyword.
+Block params, like function arguments in JavaScript, are positional. `person`
+is what each item is named in the above template, but `human` would work just
+as well.
 
-The above example will print a list like this:
+The template inside of the `{{#each}}` block will be repeated once for
+each item in the array, with the each item set to the `person` block param.
+
+Given an input array like:
+
+```js
+[ {name: 'Yehuda'},
+  {name: 'Tom'   },
+  {name: 'Trek'  } ]
+```
+
+The above template will render HTML like this:
 
 ```html
 <ul>
@@ -21,15 +39,19 @@ The above example will print a list like this:
 </ul>
 ```
 
-The `{{#each}}` helper is bindings-aware.  If your
-application adds a new item to the array, or removes an item, the DOM
-will be updated without having to write any code. Note that a `[].push()`
-will not update the helper. Adding items need to be done with `[].pushObject`,
-and related [Ember Mutable Array methods](http://emberjs.com/api/classes/Ember.MutableArray.html) so that Ember can observe the change.
+Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
+or removed from the iterated array, the DOM will be updated without having to
+write any additional code.
 
-### Accessing the list item's `index`
+Ember requires that you use special methods to update bound arrays, for example
+`[].pushObject` instead of `[].push`. See the
+[Ember.MutableArray documentation](http://emberjs.com/api/classes/Ember.MutableArray.html)
+for more details on these methods.
 
-If you would like to have access to the list item's index in your template, simply add it to the params list:
+### Accessing an item's `index`
+
+During iteration, the index of each item in an the array is provided as a second
+block param. Block params are space-seperated, without commas. For example:
 
 ```handlebars
 <ul>
@@ -39,29 +61,11 @@ If you would like to have access to the list item's index in your template, simp
 </ul>
 ```
 
-### Specifying Keys
-
-Ember is able to determine if the array being iterated over with `{{#each}}` has
-changed between renders and only touch the affected DOM elements. This
-significantly improves rendering speeds by reducing unnecessary DOM
-manipulation. It does so by keying the array to each item's `@identity`, which
-for Numbers or Strings is the item itself or a generated guid for an object. For
-most scenarios, there should be no need to change this.
-
-The `{{#each}}` helper does provide the ability to override the `key` to use the
-array's `@index` for situations where you would need this.
-
-```handlebars
-{{#each people key="@index" as |person|}}
-{{/each}}
-```
-
-Remember: the `key` is only used in helping Ember determine how to re-render. It
-is different from accessing the index as specified in the previous section.
-
 ### Empty Lists
-The `{{#each}}` helper can have a matching `{{else}}`.
-The contents of this block will render if the collection is empty:
+
+The `{{#each}}` helper can have a corresponding `{{else}}`.
+The contents of this block will render if the array passed to `{{#each}}` is
+is empty:
 
 ```handlebars
 {{#each people as |person|}}

--- a/source/templates/handlebars-basics.md
+++ b/source/templates/handlebars-basics.md
@@ -1,64 +1,73 @@
 Ember.js uses the [Handlebars templating library](http://www.handlebarsjs.com)
-to power your app's user interface. Handlebars templates are just like
-regular HTML, but also give you the ability to embed expressions that
-change what is displayed.
+to power your app's user interface. Handlebars templates contain static HTML and
+dynamic content inside Handlebars expressions, which are invoked with double
+curly braces: `{{}}`.
 
-Ember takes Handlebars and extends it with many powerful features. It may
-help to think of your Handlebars templates as an HTML-like DSL for
-describing the user interface of your app. And, once you've told
-Ember.js to render a given template on the screen, you don't need to
-write any additional code to make sure it keeps up-to-date.
+Dynamic content inside a Handlebars expression is rendered with data-binding. This means if
+you update a property, your usage of that property in a template will be
+automatically updated to the latest value.
 
 ### Defining Templates
 
-The first thing you should change is your [application template](../the-application-template) that is created
-automatically for you and is displayed when your app loads.
-
-Next, you can define templates in the `app/templates` folder. By default,
-a route will render a template with the same name as the route.
+Templates in an Ember CLI app are stored in the `app/templates` folder.
+By default, a route will render a template with the same name as the route. For
+example this template would render for the `kittens` route:
 
 ```app/templates/kittens.hbs
 <h1>Kittens</h1>
 <p>Kittens are the cutest!</p>
 ```
 
-If you would like to create a template that is shared across many areas of your site, you should investigate [components](../../components/defining-a-component/).
+The `app/templates/application.hbs` file is the main template for your
+application. If you have a new Ember app, you can change the contents of that
+file and that content should appear in the browser. As a new user, you
+may want to experiment with content in the application template before diving
+in to routing.
 
-### Handlebars Expressions
+If you want to learn more about how routes and templates work together in
+Ember, jump to
+[The Application Route](../../routing/defining-your-routes/#toc_the-application-route)
+section of the guides.
 
-Each template has an associated _controller_: this is where the template
-finds the properties that it displays.
+### Displaying Properties
 
-You can display a property from your controller by wrapping the property
-name in curly braces, like this:
+Templates are backed with a context. A context is an object from which
+Handlebars expressions read their properties. In Ember this is often a component. For
+templates rendered by a route (like `application.hbs`), the context is a
+controller.
 
-```handlebars
+For example, this `application.hbs` template will render a first and last name:
+
+```app/templates/application.hbs
 Hello, <strong>{{firstName}} {{lastName}}</strong>!
 ```
 
-This would look up the `firstName` and `lastName` properties from the
-controller, insert them into the HTML described in the template, then
-put them into the DOM.
+The `firstName` and `lastName` properties are read from the
+context (the application controller in this case), and rendered inside the
+`<strong>` HTML tag.
 
-By default, your top-most application template is bound to your application controller. Note that this file is not shown by default because it is created behind the scenes by Ember CLI. To customize the controller, create the following file:
+To provide a `firstName` and `lastName` to the above template, properties
+must be added to the application controller. If you are following along with
+an Ember CLI application, you may need to create this file:
 
 ```app/controllers/application.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   firstName: 'Trek',
   lastName: 'Glowacki'
 });
 ```
 
-The above template and controller would combine to display the following
-rendered HTML:
+The above template and controller render as the following HTML:
 
 ```html
 Hello, <strong>Trek Glowacki</strong>!
 ```
 
-These expressions (and the other Handlebars features you will learn
-about next) are _bindings aware_. That means that if the values used
-by your templates ever change, your HTML will be updated automatically.
+Remember that `{{firstName}}` and `{{lastName}}` are bound data. That means
+if the value of one of those properties changes, the DOM will be updated
+automatically.
 
-As your application grows in size, it will have many templates, each
-bound to different controllers.
+As an application grows in size, it will have many templates backed by
+controllers and components.


### PR DESCRIPTION
* Update "Handlebars Basics" to use more modern terminology (binding-aware is not a thing we ever say now)
* "Handlebars Basics" linked to "application template", removed in https://github.com/emberjs/guides/pull/566. This leaves us with no examples of basic `{{outlet}}` usage, only the text explanations on http://guides.emberjs.com/v2.0.0/routing/defining-your-routes/#toc_the-application-route. I think it would be nice to have some simple example of `{{outlet}}` usage in templates. Good followup issue.
* I propose removing the "specifying keys" section of `{{#each}}` guides http://guides.emberjs.com/v2.0.0/templates/displaying-a-list-of-items/#toc_specifying-keys
  * "The {{#each}} helper does provide the ability to override the key to use the array's @index for situations where you would need this." is not actually helpful. What situations?
  * The description of default behavior is inaccurate, we currently do a combo of identity + binning
  * `@index` should really never be needed in 1.13.8 or 2.0+. Possibly you want a custom key, but it would be a property
  * Sufficient documentation exists in the [API docs](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys).
  * Really, we do not want new users to need to reach for this functionality. Seems more confusing than helpful.
* Introduce helper invocation styles of inline, nested, and block during the conditionals section. That there are three ways to call a helper is cross-cutting knowledge useful across the rest of the templates section. For example it is much easier to teach here than to teach while going over actions. Also, it flows nicely that we can talk about properties (display a value), inline helpers (display a value), nested helper (return a value), then get to block helpers (manage DOM, yield to blocks).
