### PR TITLE
Add double-quotes in templates to styleguide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Liberally use examples in your writing. For example, the sentence "Templates can
 In code samples:
 
 * Follow the [Ember Style Guide](https://github.com/emberjs/ember.js/blob/master/STYLEGUIDE.md).
+* Use double-quotes in templates, i.e., `<div class="awesome">{{foo-bar title="Tomster"}}</div>`.
 * Omit the boilerplate that Ember CLI generates, especially the `import Ember from 'ember'` at the top of every file.
 * In fenced code blocks, include the filename or language after the triple-backticks, like <code>&#96;&#96;&#96;routes/kittens.js</code> or <code>&#96;&#96;&#96;hbs</code>.
 * Write paths relative to the `app` folder, except when talking about any other folder (like `config`), in which case make them relative to the project root.


### PR DESCRIPTION
Adds a double-quotes in templates rule to the style guide in response to https://github.com/emberjs/guides/issues/634 and https://github.com/emberjs/guides/pull/638