### PR TITLE
component templates are in the templates directory

### DIFF
--- a/source/components/wrapping-content-in-a-component.md
+++ b/source/components/wrapping-content-in-a-component.md
@@ -4,7 +4,7 @@ provided by other templates.
 For example, imagine we are building a `blog-post` component that we can
 use in our application to display a blog post:
 
-```app/components/blog-post.hbs
+```app/templates/components/blog-post.hbs
 <h1>{{title}}</h1>
 <div class="body">{{body}}</div>
 ```


### PR DESCRIPTION
It looks like this was a small typo. I believe component templates are supposed to be in app/templates/components/, as mentioned further on down the page.