### PR TITLE
Edits to Core Concepts

### DIFF
--- a/source/getting-started/core-concepts.md
+++ b/source/getting-started/core-concepts.md
@@ -1,58 +1,95 @@
-To get started with Ember.js, there are a few core concepts you
-should understand.
+Ember.js is a big framework with a large API surface. Learning a few core
+concepts will help you be successful understanding more detailed sections of
+the guides.
 
 ## Templates
 
-Templates, written in the Handlebars language, describe the user interface of
-your application. In addition to plain HTML, templates can contain expressions,
-like `{{title}}` or `{{author}}`, which take information from a component or
-controller and put it into HTML. They can also contain helpers, such as
-`{{#if isAdmin}}30 people have viewed your blog today.{{/if}}.` Finally, they
-can contain components such as a template listing blog posts rendering a
-component for each post.
+Ember.js uses templates to organize the layout of HTML in an application. Most
+templates in an Ember codebase are instantly familiar, and look like any
+fragment of HTML. For example:
+
+```handlebars
+<div>Hi, this is a valid Ember template!</div>
+```
+
+Ember templates use the syntax of [Handlebars](http://handlebarsjs.com)
+templates. Anything that is valid Handlebars syntax is valid Ember syntax.
+
+Each template has a context, and properties you access are read off that context.
+For example this template shows a welcome message with a name:
+
+```handlebars
+<div>Hi {{name}}, this is a valid Ember template!</div>
+```
+
+The Handlebars expression `{{name}}` refers to a bound property.
+Besides properties, double curly braces (`{{}}`) may also contain
+helpers and components.
 
 ## Components
 
 Components are the primary way user interfaces are organized in Ember. They
-consist of two parts: a template, and a source file written in JavaScript that
-defines the component's behavior. For example, a blog application might have a
-component for displaying a list of blog posts called `all-posts`, and another
-component for displaying an individual post called `view-post`. If users can
-upvote a post, the `view-post` component might define a behavior like _when the
-user clicks the upvote button, increase the `vote` property's value by 1_.
+consist of two parts:
 
-## Controllers
+* A template, for example `app/templates/components/welcome-message.hbs`
+* Optionally a source file written in JavaScript, for example
+  `app/components/welcome-message.js`.
+* **Components must contain a - in their name**. More about that later.
 
-Controllers are very much like components, so much so that in future versions of
-Ember, controllers will be replaced entirely with components. At the moment,
-components cannot be routed to (see below), but when this changes, it will be
-recommended to replace all controllers with components.
+Components differ from helpers in that they can output not only a value, but
+also manage DOM. An important property of components is that they are **isolated**.
+For example, a component's DOM is called "shadow" DOM.
+
+In this example, a component's template adds a div around some other DOM:
+
+```app/templates/components/my-component.hbs
+<div class="inner">
+  {{yield}}
+</div>
+```
+
+```handlebars
+<span>Hello</span>
+<div class="outer">
+  {{#my-component}}
+    Hello there!
+  {{/my-component}}
+</div>
+```
+
+Because components deal with DOM, they are also responsible for maintaining
+the bulk of an application's state. Additionally they handle events like
+clicks, keyUp, and other more semantic actions.
+
+## The Router and Routes
+
+The router maps a URL to a template. For example, when a user visits the `/posts`
+URL, a configured router may load the `posts` route and template. The router can also load
+nested routes. For example, if a blogging app had a list of blog posts on the
+left of the screen and showed the current blog post on the right, we'd say
+that the `posts/show` route was nested inside the `posts` route.
+
+Perhaps the most important thing to remember about Ember is that **the URL drives
+the application state**. URLs determine what template and route to load, and
+that in turn determines what model must be fetched.
+
+Ember routes are classes responsible for describing the entrance and exit to
+a specific URL path. For example, a route class may decide what data to load before
+a route is rendered, or cancel navigation away from a route if a form is
+unsaved.
 
 ## Models
 
-Models represent _persistent state_. For example, a blog application would want
-to save the content of a blog post when a user publishes it, and so the blog
-post would have a model defining it, perhaps called the `Post` model. A model
-typically persists information to a server, although models can be configured to
-save to anywhere else, such as the browser's Local Storage.
+Models represent persistent state. For example, a blog application would
+persist the content of a blog post when a user publishes it. A blog post model
+would represent the state of that persisted content (such as the post itself,
+the title, and the author).
 
-## Routes
+The data backing a model
+is typically persisted to a server via AJAX, although models can be configured
+to persist anywhere. For example, some applications will save data to
+the localStorage API, or to IndexedDB.
 
-Routes load a controller and a template. They can also load one or more models
-to provide data to the controller that can then be displayed by the template.
-For example, an `all-posts` route might load all the blog posts from the `Post`
-model, load the `all-posts` controller, and render the `all-posts` template.
-Similarly, a `view-post` route might load the model for the blog post to be
-shown, load the `view-post` controller, and render the `view-post` template.
-
-## The Router
-
-The router maps a URL to a route. For example, when a user visits the `/posts`
-URL, the router might load the `all-posts` route. The router can also load
-nested routes. For example, if our blogging app had a list of blog posts on the
-left of the screen and then showed the current blog post on the right, we'd say
-that the `view-post` route was nested inside the `all-posts` route.
-
-Perhaps the most important thing to remember about Ember is that the URL drives
-the state of the application. The URL determines what route to load, which in
-turn determines what model, controller, and template to load.
+When visiting a URL, Ember attempts to be smart about what models should be
+loaded. For example, if you visit the `/posts/the-viral-one` URL Ember will
+fetch a `Post` with the id `the-viral-one`.


### PR DESCRIPTION
Changes to Core Concepts.

* Focus prose, edit for visual pacing (intersperse examples and explanation instead of long paragraphs, use lists)
* Introduce Helpers as a first-class part of the framework. Since they are a simple concept (a function resulting in a value), use them as a stepping stone to components (a more complex concept).
* Provide more a more idiomatic description of routes, and their usage
* Defer Model and Routes, the two less likely to be used facets, to the bottom
* Bump all commentary on controllers to the controller section

TODO:

* [ ] ~~Services should likely be introduced~~ Nope, deferring to keep things shallow here.
* [x] Routes section inaccurately tells the user about default behavior, and basically repeats the end of the models section.

Split from https://github.com/emberjs/guides/pull/556