### PR TITLE
typo and links to API doc

### DIFF
--- a/source/object-model/index.md
+++ b/source/object-model/index.md
@@ -1,18 +1,18 @@
-You'll notice that standard JavaScript class patterns, and the new ES2015
-classes, aren't used widely in Ember. Plain objects can still be found,
-and sometimes they are referred to as "hashes".
+You'll notice standard JavaScript class patterns and the new ES2015
+classes aren't widely used in Ember. Plain objects can still be found,
+and sometimes they're referred to as "hashes".
 
 JavaScript objects don't support the observation of property value changes.
 Consequently, if an object is going to participate in Ember's binding
-system you may see an `Ember.Object` instead of a plan object.
+system you may see an `Ember.Object` instead of a plain object.
 
-`Ember.Object` also provides a class system, supporting features like mixins
+[Ember.Object](http://emberjs.com/api/classes/Ember.Object.html) also provides a class system, supporting features like mixins
 and constructor methods. Some features in Ember's object model are not present in
 JavaScript classes or common patterns, but all are aligned as much as possible
 with the language and proposed additions.
 
 Ember also extends the JavaScript `Array` prototype with its
-`Ember.Enumerable` interface to provide change observation for arrays.
+[Ember.Enumerable](http://emberjs.com/api/classes/Ember.Enumerable.html) interface to provide change observation for arrays.
 
 Finally, Ember extends the `String` prototype with a few [formatting and
 localization methods](http://emberjs.com/api/classes/Ember.String.html).


### PR DESCRIPTION
Fixes a typo and replaces `used widely` with the more common `widely used` :smile: 

Links to `Ember.Object` and `Ember.Enumerable` seemed appropriate based on the [style guide](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md).