### PR TITLE
Clean up templates introduction

### DIFF
--- a/data/pages.yml
+++ b/data/pages.yml
@@ -35,6 +35,28 @@
     - title: "Enumerables"
       url: 'enumerables'
 
+- title: "Routing"
+  url: 'routing'
+  pages:
+    - title: "Introduction"
+      url: "index"
+    - title: "Defining Your Routes"
+      url: "defining-your-routes"
+    - title: "Specifying a Route's Model"
+      url: "specifying-a-routes-model"
+    - title: "Rendering a Template"
+      url: "rendering-a-template"
+    - title: "Redirecting"
+      url: "redirection"
+    - title: "Query Parameters"
+      url: "query-params"
+    - title: "Asynchronous Routing"
+      url: "asynchronous-routing"
+    - title: "Loading / Error Substates"
+      url: "loading-and-error-substates"
+    - title: "Preventing and Retrying Transitions"
+      url: "preventing-and-retrying-transitions"
+
 - title: "Templates"
   url: 'templates'
   pages:
@@ -58,28 +80,6 @@
       url: "development-helpers"
     - title: "Writing Helpers"
       url: "writing-helpers"
-
-- title: "Routing"
-  url: 'routing'
-  pages:
-    - title: "Introduction"
-      url: "index"
-    - title: "Defining Your Routes"
-      url: "defining-your-routes"
-    - title: "Specifying a Route's Model"
-      url: "specifying-a-routes-model"
-    - title: "Rendering a Template"
-      url: "rendering-a-template"
-    - title: "Redirecting"
-      url: "redirection"
-    - title: "Query Parameters"
-      url: "query-params"
-    - title: "Asynchronous Routing"
-      url: "asynchronous-routing"
-    - title: "Loading / Error Substates"
-      url: "loading-and-error-substates"
-    - title: "Preventing and Retrying Transitions"
-      url: "preventing-and-retrying-transitions"
 
 - title: "Components"
   url: 'components'

--- a/source/templates/conditionals.md
+++ b/source/templates/conditionals.md
@@ -1,6 +1,5 @@
-Conditional statements bring a minimum of logic into Ember templating.
 Statements like `if` and `unless` are implemented as built-in helpers. Helpers
-can be invoked three ways.
+can be invoked three ways, each of which is illustrated below with conditionals.
 
 The first style of invocation is **inline invocation**. This looks similar to
 displaying a property, but helpers accept arguments. For example:

--- a/source/templates/handlebars-basics.md
+++ b/source/templates/handlebars-basics.md
@@ -7,28 +7,6 @@ Dynamic content inside a Handlebars expression is rendered with data-binding. Th
 you update a property, your usage of that property in a template will be
 automatically updated to the latest value.
 
-### Defining Templates
-
-Templates in an Ember CLI app are stored in the `app/templates` folder.
-By default, a route will render a template with the same name as the route. For
-example this template would render for the `kittens` route:
-
-```app/templates/kittens.hbs
-<h1>Kittens</h1>
-<p>Kittens are the cutest!</p>
-```
-
-The `app/templates/application.hbs` file is the main template for your
-application. If you have a new Ember app, you can change the contents of that
-file and that content should appear in the browser. As a new user, you
-may want to experiment with content in the application template before diving
-in to routing.
-
-If you want to learn more about how routes and templates work together in
-Ember, jump to
-[The Application Route](../../routing/defining-your-routes/#toc_the-application-route)
-section of the guides.
-
 ### Displaying Properties
 
 Templates are backed with a context. A context is an object from which

--- a/source/templates/handlebars-basics.md
+++ b/source/templates/handlebars-basics.md
@@ -71,3 +71,9 @@ automatically.
 
 As an application grows in size, it will have many templates backed by
 controllers and components.
+
+### Helpers
+
+Helpers bring a minimum of logic into Ember templating. Ember ships with several
+built-in helpers, which are explained in the following guides, and also allows
+you to [write your own helpers](../writing-helpers/).


### PR DESCRIPTION
* Improves introduction of helpers by moving the content from Conditionals to Handlebars Basics.
* Removes redundant information on how templates get loaded, since it is covered in Routing.
* Moves Routing before Templates, so that readers know how templates are loaded and we don't have to cover it twice.