### PR TITLE
Fix broken JS TOC expand/collapse

### DIFF
--- a/source/javascripts/app/toc.js
+++ b/source/javascripts/app/toc.js
@@ -1,8 +1,6 @@
 $(function(){
   $(".toc-level-0 .toc-level-0 > a").click(function() {
-    $(this).parent().find('> ol').slideToggle(function() {
-      positionBackToTop(true);
-    });
+    $(this).parent().find('> ol').slideToggle();
 
     return false;
   });


### PR DESCRIPTION
Removing the back to top library caused re-expanding the TOC sections to break. This removes the references to the back to top library and fixes re-expanding.