### PR TITLE
Instance-initializer is used in place of initializer in service injection

### DIFF
--- a/source/services/index.md
+++ b/source/services/index.md
@@ -92,16 +92,34 @@ This also injects the shopping cart service, as the `shoppingCart` property.
 
 Sometimes it makes sense for a service to be available throughout your application without having to inject it into each class individually. Ember Data uses this to give routes access to the shared store.
 
-This can be accomplished with an instance initializer:
+This can be accomplished with an initializer:
 
-```app/instance-initializers/shopping-cart.js
-application.inject('route', 'cart', 'service:shopping-cart');
+```app/initializers/shopping-cart.js
+export default {
+  name: 'shopping-cart',
+  initialize: function (container, application) {
+    application.inject('route', 'cart', 'service:shopping-cart');
+  } 
+};
 ```
 
 The `shopping-cart` service will be injected as the `cart` property into every `route` in your application.
 
 You can also inject a service into a specific class:
 
-```app/instance-initializers/shopping-cart.js
+```app/initializers/shopping-cart.js
 application.inject('route:checkout', 'cart', 'service:shopping-cart');
+```
+
+If your eagerly-injected service requires some first-time setup that depends on other services, you can set this up in an instance-initializer:
+
+```app/instance-initializers/shopping-cart.js
+export default {
+  name: 'shopping-cart',
+  initialize: function (instance) {
+    var store = instance.container.lookup('service:store');
+    var cart = instance.container.lookup('service:shopping-cart');
+    cart.add(store.findRecord('item', 'plunger'));
+  }
+};
 ```


### PR DESCRIPTION
In reference this issue:

https://github.com/emberjs/guides/issues/681#issuecomment-136225799

I changed changed "instance-initializer" to "initializer", made it a little more explicitly exactly what got passed to an initializer function, and added an example on when an instance-initializer is used.