### PR TITLE
Removing unnecessary generate command in example

### DIFF
--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -7,10 +7,6 @@ ensures Ember detects the components automatically.
 
 A sample component template would look like this:
 
-```bash
-ember generate component blog-post
-```
-
 ```app/templates/components/blog-post.hbs
 <h1>Blog Post</h1>
 <p>Lorem ipsum dolor sit amet.</p>


### PR DESCRIPTION
Having the command there was confusing to me because we're supposed to be seeing a sample component, not learning how to generate one.