### PR TITLE
add pods loading substate

### DIFF
--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -56,14 +56,18 @@ Router.map(function() {
   });
 });
 ```
+For projects using pods, a custom `loading` substate can be defined
+for each route by creating a directory, `foo/bar/slow-model-loading`, 
+with a template (and optional route) inside. 
 
-Ember will try to find a `loading` route in the hierarchy
-above `foo.bar.slow-model` that it can transition into, starting with
-`foo.bar.slow-models`'s sibling:
+Ember will automatically try to find a `loading` route that it can
+transition into in the following order:
 
-1. `foo.bar.loading`
-2. `foo.loading`
-3. `loading`
+1. `foo.bar.slow-model-loading`
+2. `foo.bar.loading`
+3. `foo.loading`
+4. `loading`
+
 
 ### The `loading` event
 


### PR DESCRIPTION
I have been thinking about this a lot and I don't think it's a good idea to ignore pods for this topic. I spent quite a lot of trying to figure out how to get the substates to work with pods and from talking about it in the Slack, I'm not the only one. Even some of the less nooby people had trouble getting this completely undocumented functionality to work. 

The current version also doesn't explain per-route custom loading routes which this addition does.

refs #328 