### PR TITLE
Added gotcha for homebrew users.

### DIFF
--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -55,6 +55,8 @@ Install Ember using npm:
 npm install -g ember-cli
 ```
 
+Mac users that used Homebrew to install node may wish to run `npm config get prefix`, prior installing ember-cli. If the prefix that this command returns is not in your path, then you can add it to your path or change the prefix with something like `npm config set prefix /usr/local`.
+ 
 While you're at it we recommend you also install PhantomJS to run tests from
 the command line (without the need for a browser to be open):
 


### PR DESCRIPTION
When using homebrew to install node, npm's modules were being loaded into `/usr/local/Cellar/node/0.12.7_1/libexec/npm
`.

This meant that ember could not be found. Searching the inter webs lead me to discover the incantations required to find the prefix, change it and then make it work as described by this text. Other, better solutions may be out there.