### PR TITLE
Add missing backtick to component-hide-show-image.md

### DIFF
--- a/source/getting-started/component-hide-show-image.md
+++ b/source/getting-started/component-hide-show-image.md
@@ -91,7 +91,7 @@ Now the image will be shown when the button is clicked.
 
 We should let users hide the image again. In our template component:
 
-``app/templates/components/rental-tile.hbs
+```app/templates/components/rental-tile.hbs
 <li>{{#link-to 'listing' listing.id}}{{listing.owner}}'s {{listing.type}}{{/link-to}}
   {{#if isImageShowing}}
     <p><img src={{listing.image}} alt={{listing.type}} {{action 'imageHide'}}></p>


### PR DESCRIPTION
So code snippet for  `app/templates/components/rental-tile.hbs` shows as code.