### PR TITLE
No following example exists

### DIFF
--- a/source/components/passing-properties-to-a-component.md
+++ b/source/components/passing-properties-to-a-component.md
@@ -55,9 +55,9 @@ a named property in the component scope, with the syntax
 `componentProperty=outerProperty`.
 
 It is important to note that these properties stay in sync (technically
-known as being `bound`). In the following example, type some text in the
-text field either in the outer template or inside the component and note
-how the values stay in sync in both places.
+known as being `bound`). That is, if the value of `componentProperty`
+changes in the component, `outerProperty` will be updated to reflect that
+change. The reverse is true as well.
 
 You can also bind properties from inside an `{{#each}}` loop. This will
 create a component for each item and bind it to each model in the loop.


### PR DESCRIPTION
There's no following example to look at that matches this description. I'm not sure the best way to explain this. Providing a simple example might be a good alternative to this suggested change.

I've also wondered why y'all don't provide output examples within this set of documentation as well. I believe that would go a long way in improving these docs.