### PR TITLE
Ember.run.scheduleOnce does not work with anonymous function arg.

### DIFF
--- a/source/understanding-ember/run-loop.md
+++ b/source/understanding-ember/run-loop.md
@@ -190,15 +190,18 @@ As mentioned above, you should wrap any non-Ember async callbacks in
 Consider the following callback:
 
 ```javascript
+function sayHi() {
+  console.log('hi');
+}
+
 $('a').click(function(){
   console.log('Doing things...');
 
   Ember.run.schedule('actions', this, function() {
     // Do more things
   });
-  Ember.run.scheduleOnce('afterRender', this, function() {
-    // Yet more things
-  });
+
+  Ember.run.scheduleOnce('afterRender', this, sayHi);
 });
 ```
 
@@ -210,6 +213,10 @@ runloops we call _autoruns_.
 Here is some pseudocode to describe what happens using the example above:
 
 ```javascript
+function sayHi() {
+  console.log('hi');
+}
+
 $('a').click(function(){
   // 1. autoruns do not change the execution of arbitrary code in a callback.
   //    This code is still run when this callback is executed and will not be
@@ -237,10 +244,7 @@ $('a').click(function(){
 
   // 4. scheduleOnce sees the autorun created by schedule above as an available
   //    runloop and adds its item to the given queue.
-  Ember.run.scheduleOnce('afterRender', this, function() {
-    // Yet more things
-  });
-
+  Ember.run.scheduleOnce('afterRender', this, sayHi);
 });
 ```
 


### PR DESCRIPTION
`Ember.run.scheduleOnce` cannot ensure that the provided function is called only once if an anonymous function is passed in. This commit adjusts the examples to show passing a named function.
