### PR TITLE
Fix link to "services"

### DIFF
--- a/source/routing/redirection.md
+++ b/source/routing/redirection.md
@@ -26,7 +26,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../services/).
+you might use a [service](../../services-and-initializers/services).
 
 ## Transitioning After the Model is Known
 


### PR DESCRIPTION
On page `routing/redirection`, "services" should link to `services-and-initializers/services`.