### PR TITLE
Fixed action for mouseup

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -60,7 +60,7 @@ You can specify an alternative event by using the `on` option.
 
 ```handlebars
 <p>
-  <button {{action "select" post on="mouse-up"}}>✓</button>
+  <button {{action "select" post on="mouseUp"}}>✓</button>
   {{post.title}}
 </p>
 ```


### PR DESCRIPTION
Event dispatcher wants `mouseup` instead of `mouse-up`: 
https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/system/event_dispatcher.js#L62