### PR TITLE
Ember.run.scheduleOnce does not work with anonymous function arg.

### DIFF
--- a/source/components/run-loop.md
+++ b/source/components/run-loop.md
@@ -180,17 +180,12 @@ As mentioned above, you should wrap any non-Ember async callbacks in
 Consider the following callback:
 
 ```javascript
-function sayHi() {
-  console.log('hi');
-}
-
 $('a').click(() => {
   console.log('Doing things...');
 
   Ember.run.schedule('actions', () => {
     // Do more things
   });
-  Ember.run.scheduleOnce('afterRender', sayHi);
 });
 ```
 
@@ -202,10 +197,6 @@ runloops we call _autoruns_.
 Here is some pseudocode to describe what happens using the example above:
 
 ```javascript
-function sayHi() {
-  console.log('hi');
-}
-
 $('a').click(() => {
   // 1. autoruns do not change the execution of arbitrary code in a callback.
   //    This code is still run when this callback is executed and will not be
@@ -231,10 +222,11 @@ $('a').click(() => {
 
   });
 
-  // 4. scheduleOnce sees the autorun created by schedule above as an available
+  // 4. This schedule sees the autorun created by schedule above as an available
   //    runloop and adds its item to the given queue.
-  Ember.run.scheduleOnce('afterRender', sayHi);
-
+  Ember.run.schedule('afterRender', () => {
+    // Do yet more things
+  });
 });
 ```
 

--- a/source/components/run-loop.md
+++ b/source/components/run-loop.md
@@ -180,15 +180,17 @@ As mentioned above, you should wrap any non-Ember async callbacks in
 Consider the following callback:
 
 ```javascript
+function sayHi() {
+  console.log('hi');
+}
+
 $('a').click(() => {
   console.log('Doing things...');
 
   Ember.run.schedule('actions', () => {
     // Do more things
   });
-  Ember.run.scheduleOnce('afterRender', () => {
-    // Yet more things
-  });
+  Ember.run.scheduleOnce('afterRender', sayHi);
 });
 ```
 
@@ -200,6 +202,10 @@ runloops we call _autoruns_.
 Here is some pseudocode to describe what happens using the example above:
 
 ```javascript
+function sayHi() {
+  console.log('hi');
+}
+
 $('a').click(() => {
   // 1. autoruns do not change the execution of arbitrary code in a callback.
   //    This code is still run when this callback is executed and will not be
@@ -227,9 +233,7 @@ $('a').click(() => {
 
   // 4. scheduleOnce sees the autorun created by schedule above as an available
   //    runloop and adds its item to the given queue.
-  Ember.run.scheduleOnce('afterRender', () => {
-    // Yet more things
-  });
+  Ember.run.scheduleOnce('afterRender', sayHi);
 
 });
 ```


### PR DESCRIPTION
`Ember.run.scheduleOnce` cannot ensure that the provided function is
called only once if an anonymous function is passed in.

Replaces PR #781