### PR TITLE
Add missing comma to serializer example

### DIFF
--- a/source/models/customizing-serializers.md
+++ b/source/models/customizing-serializers.md
@@ -456,7 +456,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
       deserialize: 'records'
     },
     comments: {
-      deserialize: 'records'
+      deserialize: 'records',
       serialize: 'ids'
     }
   }


### PR DESCRIPTION
Currently the hi-lighting is off because the comma is missing.
<img width="719" alt="screen shot 2015-09-24 at 5 01 29 pm" src="https://cloud.githubusercontent.com/assets/54056/10086717/f30f7b50-62dd-11e5-8280-91f3ab883478.png">