### PR TITLE
testing guide updates

### DIFF
--- a/source/testing/acceptance.md
+++ b/source/testing/acceptance.md
@@ -10,26 +10,23 @@ This generates this file:
 ```tests/acceptance/login-test.js
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import startApp from 'ember-test/tests/helpers/start-app';
+import startApp from 'testing-guide-examples/tests/helpers/start-app';
 
-var application;
+let application;
 
 module('Acceptance | login', {
-  beforeEach: function() {
+  beforeEach() {
     application = startApp();
   },
 
-  afterEach: function() {
+  afterEach() {
     Ember.run(application, 'destroy');
   }
 });
 
 test('visiting /login', function(assert) {
   visit('/login');
-
-  andThen(function() {
-    assert.equal(currentURL(), '/login');
-  });
+  andThen(() => assert.equal(currentURL(), '/login'));
 });
 ```
 
@@ -42,14 +39,11 @@ Almost every test has a pattern of visiting a route, interacting with the page
 For example:
 
 ```tests/acceptance/new-post-appears-first-test.js
-test('add new post', function(assert) {
+test('should add new post', function(assert) {
   visit('/posts/new');
   fillIn('input.title', 'My new post');
   click('button.submit');
-
-  andThen(function() {
-    assert.equal(find('ul.posts li:first').text(), 'My new post');
-  });
+  andThen(() => assert.equal(find('ul.posts li:first').text(), 'My new post'));
 });
 ```
 
@@ -128,24 +122,17 @@ complete prior to progressing forward. Let's take a look at the following
 example.
 
 ```tests/acceptance/new-post-appears-first-test.js
-test('simple test', function(assert) {
-  assert.expect(1); // Ensure that we will perform one assertion
-
+test('should add new post', function(assert) {
   visit('/posts/new');
   fillIn('input.title', 'My new post');
   click('button.submit');
-
-  // Wait for asynchronous helpers above to complete
-  andThen(function() {
-    assert.equal(find('ul.posts li:first').text(), 'My new post');
-  });
+  andThen(() => assert.equal(find('ul.posts li:first').text(), 'My new post'));
 });
 ```
 
-First we tell QUnit that this test should have one assertion made by the end
-of the test by calling `assert.expect` with an argument of `1`. We then visit the new
-posts URL "/posts/new", enter the text "My new post" into an input control
-with the CSS class "title", and click on a button whose class is "submit".
+First we visit the new posts URL "/posts/new", enter the text "My new post"
+into an input control with the CSS class "title", and click on a button whose
+class is "submit".
 
 We then make a call to the `andThen` helper which will wait for the preceding
 asynchronous test helpers to complete (specifically, `andThen` will only be
@@ -184,16 +171,11 @@ first parameter. Other parameters need to be provided when calling the helper. H
 Here is an example of a non-async helper:
 
 ```tests/helpers/should-have-element-with-count.js
-export default Ember.Test.registerHelper(
-    'shouldHaveElementWithCount',
-    function(app, assert, selector, n, context) {
-
-    var el = findWithAssert(selector, context);
-    var count = el.length;
-    assert.equal(n, count, 'found ' + count + ' times');
-  }
-);
-
+export default Ember.Test.registerHelper('shouldHaveElementWithCount', function(app, assert, selector, n, context) {
+  const el = findWithAssert(selector, context);
+  const count = el.length;
+  assert.equal(n, count, `found ${count} times`);
+});
 // shouldHaveElementWithCount(assert, 'ul li', 3);
 ```
 
@@ -202,10 +184,8 @@ Here is an example of an async helper:
 ```tests/helpers/dblclick.js
 export default Ember.Test.registerAsyncHelper('dblclick',
   function(app, assert, selector, context) {
-    var $el = findWithAssert(selector, context);
-    Ember.run(function() {
-      $el.dblclick();
-    });
+    let $el = findWithAssert(selector, context);
+    Ember.run(() => $el.dblclick());
   }
 );
 
@@ -217,7 +197,7 @@ into one helper. For example:
 
 ```tests/helpers/add-contact.js
 export default Ember.Test.registerAsyncHelper('addContact',
-  function(app, assert, name, context) {
+  function(app, assert, name) {
     fillIn('#name', name);
     click('button.create');
   }

--- a/source/testing/testing-models.md
+++ b/source/testing/testing-models.md
@@ -7,6 +7,9 @@ Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
 new `levelName` when the player reaches level 5.
 
+> You can follow along by generating your own model with `ember generate
+> model player`.
+
 ```app/models/player.js
 export default DS.Model.extend({
   level:     DS.attr('number', { defaultValue: 0 }),
@@ -25,19 +28,23 @@ Now let's create a test which will call `levelUp` on the player when they are
 level 4 to assert that the `levelName` changes. We will use `moduleForModel`:
 
 ```tests/unit/models/player-test.js
-moduleForModel('player');
+import { moduleForModel, test } from 'ember-qunit';
+import Ember from 'ember';
 
-test('levelUp', function(assert) {
+moduleForModel('player', 'Unit | Model | player', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('should increment level when told to', function(assert) {
   // this.subject aliases the createRecord method on the model
-  var player = this.subject({ level: 4 });
+  const player = this.subject({ level: 4 });
 
   // wrap asynchronous call in run loop
-  Ember.run(function() {
-    player.levelUp();
-  });
+  Ember.run(() => player.levelUp());
 
-  assert.equal(player.get('level'), 5);
-  assert.equal(player.get('levelName'), 'Professional');
+  assert.equal(player.get('level'), 5, 'level gets incremented');
+  assert.equal(player.get('levelName'), 'Professional', 'new level is called professional');
 });
 ```
 
@@ -48,9 +55,11 @@ declarations are setup properly.
 
 Assume that a `User` can own a `Profile`.
 
+> You can follow along by generating your own user and profile models with `ember
+> generate model user` and `ember generate model profile`.
+
 ```app/models/profile.js
 export default DS.Model.extend({
-
 });
 ```
 
@@ -64,17 +73,20 @@ Then you could test that the relationship is wired up correctly
 with this test.
 
 ```tests/unit/models/user-test.js
-moduleForModel('user', {
+import { moduleForModel, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleForModel('user', 'Unit | Model | user', {
   // Specify the other units that are required for this test.
   needs: ['model:profile']
 });
 
-test('profile relationship', function(assert) {
-  var User = this.store().modelFor('user');
-  var relationship = Ember.get(User, 'relationshipsByName').get('profile');
+test('should own a profile', function(assert) {
+  const User = this.store().modelFor('user');
+  const relationship = Ember.get(User, 'relationshipsByName').get('profile');
 
-  assert.equal(relationship.key, 'profile');
-  assert.equal(relationship.kind, 'belongsTo');
+  assert.equal(relationship.key, 'profile', 'has relationship with profile');
+  assert.equal(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');
 });
 ```
 

--- a/source/testing/testing-routes.md
+++ b/source/testing/testing-routes.md
@@ -12,6 +12,12 @@ our application. The alert function `displayAlert` should be put into the
 `ApplicationRoute` because all actions and events bubble up to it from 
 sub-routes and controllers.
 
+> By default Ember CLI does not generate a file for its application route.  To
+> extend the behavior of the ember application route we will run the command
+> `ember generate route application`.  Ember CLI does however generate an application
+> template, so when asked whether we want to overwrite `app/templates/application.hbs`
+> we will answer 'n'.
+
 ```app/routes/application.js
 export default Ember.Route.extend({
   actions: {
@@ -26,8 +32,6 @@ export default Ember.Route.extend({
 });
 ```
 
-This is made possible by using `moduleFor`.
-
 In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is 
 received, and the private function `_displayAlert` performs the work. While not 
@@ -38,9 +42,11 @@ for testing, which in turn allows you to catch bugs more easily.
 Here is an example of how to unit test this route:
 
 ```tests/unit/routes/application-test.js
+import { moduleFor, test } from 'ember-qunit';
+
 let originalAlert;
 
-moduleFor('route:application', {
+moduleFor('route:application', 'Unit | Route | application', {
   beforeEach() {
     originalAlert = window.alert; // store a reference to window.alert
   },
@@ -50,30 +56,29 @@ moduleFor('route:application', {
   }
 });
 
-test('Alert is called on displayAlert', function(assert) {
+test('should display an alert', function(assert) {
   assert.expect(2);
 
   // with moduleFor, the subject returns an instance of the route
-  var route = this.subject();
-  var expectedText;
+  let route = this.subject();
 
   // stub window.alert to perform a qunit test
-  expectedText = 'foo';
-  window.alert = function(text) {
-    assert.equal(text, expectedText, 'expected ' + text + ' to be ' + expectedText);
+  const expectedTextFoo = 'foo';
+  window.alert = (text) => {
+    assert.equal(text, expectedTextFoo, `expect alert to display ${expectedTextFoo}`);
   };
 
   // call the _displayAlert function which triggers the qunit test above
-  route._displayAlert(expectedText);
-  
-  // set up a second stub to perform a test with the actual action
-  expectedText = 'bar';
-  window.alert = function(text) {
-    assert.equal(text, expectedText, 'expected ' + text + ' to be ' + expectedText);
-  };
+  route._displayAlert(expectedTextFoo);
 
+  // set up a second stub to perform a test with the actual action
+  const expectedTextBar = 'bar';
+  window.alert = (text) => {
+    assert.equal(text, expectedTextBar, `expected alert to display ${expectedTextBar}`);
+  };
+    
   // Now use the routes send method to test the actual action
-  route.send('displayAlert', expectedText);
+  route.send('displayAlert', expectedTextBar);
 });
 ```
 

--- a/source/testing/unit-testing-basics.md
+++ b/source/testing/unit-testing-basics.md
@@ -11,7 +11,7 @@ common cases.
 
 ### Testing Computed Properties
 
-Let's start by looking at an object that has a `computedFoo` computed property
+Let's start by creating an object that has a `computedFoo` computed property
 based on a `foo` property.
 
 ```app/models/some-thing.js
@@ -19,31 +19,35 @@ export default Ember.Object.extend({
   foo: 'bar',
 
   computedFoo: Ember.computed('foo', function() {
-    return 'computed ' + this.get('foo');
+    const foo = this.get('foo');
+    return `computed ${foo}`;
   })
 });
 ```
 
-Within the test we'll create an instance, update the `foo` property (which
+Within the test for this object we'll create an instance, update the `foo` property (which
 should trigger the computed property), and assert that the logic in our
 computed property is working correctly.
 
 ```tests/unit/models/some-thing-test.js
-import SomeThing from '<your-app-name>/models/some-thing';
+import { moduleFor, test } from 'ember-qunit';
 
-moduleFor('model:some-thing', 'Unit: some-thing');
+moduleFor('model:some-thing', 'Unit | some thing', {
+  unit: true
+});
 
-test('computedFoo correctly concats foo', function(assert) {
-  var someThing = SomeThing.create({});
-
+test('should correctly concat foo', function(assert) {
+  const someThing = this.subject();
   someThing.set('foo', 'baz');
-
   assert.equal(someThing.get('computedFoo'), 'computed baz');
 });
 ```
 
-See that we have used `moduleFor` one of the several [unit-test helpers](../unit-test-helpers) provided
-by Ember-Qunit.
+See that we have used `moduleFor`, one of the several [unit-test helpers](../unit-test-helpers) provided by Ember-Qunit.
+Test helpers provide us with some conveniences, such the subject function that handles lookup and instantiation for our object under test.
+Note that in a unit test you can customize the initialization of your object under test by passing to the
+subject function an object containing the instance variables you would like to initialize.  For example, to initialize
+the property 'foo' in our object under test, we would call `this.subject({ foo: 'bar' });`
 
 ### Testing Object Methods
 
@@ -65,15 +69,9 @@ call the `testMethod` method and assert that the internal state is correct as a
 result of the method call.
 
 ```tests/unit/models/some-thing-test.js
-import SomeThing from '<your-app-name>/models/some-thing';
-
-moduleFor('model:some-thing', 'Unit: some-thing');
-
-test('calling testMethod updated foo', function(assert) {
-  var someThing = SomeThing.create({});
-
+test('should update foo on testMethod', function(assert) {
+  const someThing = this.subject();
   someThing.testMethod();
-
   assert.equal(someThing.get('foo'), 'baz');
 });
 ```
@@ -87,7 +85,8 @@ export default Ember.Object.extend({
   count: 0,
   calc() {
     this.incrementProperty('count');
-    return 'count: ' + this.get('count');
+    let count = this.get('count');
+    return `count: ${count}`;
   }
 });
 ```
@@ -95,12 +94,8 @@ export default Ember.Object.extend({
 The test would call the `calc` method and assert it gets back the correct value.
 
 ```tests/unit/models/some-thing-test.js
-import SomeThing from '<your-app-name>/models/some-thing';
-
-moduleFor('model:some-thing', 'Unit: some-thing');
-
-test('calc returns incremented count', function(assert) {
-  var someThing = SomeThing.create({});
+test('should return incremented count on calc', function(assert) {
+  const someThing = this.subject();
   assert.equal(someThing.calc(), 'count: 1');
   assert.equal(someThing.calc(), 'count: 2');
 });
@@ -114,7 +109,7 @@ Suppose we have an object that has a property and a method observing that proper
 export default Ember.Object.extend({
   foo: 'bar',
   other: 'no',
-  doSomething: Ember.observer('foo', function(){
+  doSomething: Ember.observer('foo', function() {
     this.set('other', 'yes');
   })
 });
@@ -124,13 +119,9 @@ In order to test the `doSomething` method we create an instance of `SomeThing`,
 update the observed property (`foo`), and assert that the expected effects are present.
 
 ```tests/unit/models/some-thing-test.js
-import SomeThing from '<your-app-name>/models/some-thing';
-
-moduleFor('model:some-thing', 'Unit: some-thing');
-
-test('doSomething observer sets other prop', function() {
-  var someThing = SomeThing.create();
+test('should set other prop to yes when foo changes', function(assert) {
+  const someThing = this.subject();
   someThing.set('foo', 'baz');
-  equal(someThing.get('other'), 'yes');
+  assert.equal(someThing.get('other'), 'yes');
 });
 ```


### PR DESCRIPTION
Part of guides review for https://github.com/emberjs/guides/issues/602

I've implemented the guides in an ember cli project: https://github.com/toddjordan/ember-testing-guide-examples to ensure they work on ember 2.1 beta, and I've also pulled in ember suave to check style concerns. 

In implementing the examples I've made updates as I go to make sure the instructions are clear and that the examples work.  I've also added some unit test style things like naming tests with 'should...' so that they show up readable and behavior focused in the output, as well as adding assert descriptions, so that the asserts when printed in out put are readable.

Still working on testing intro page.. I'd like to add in the concept of integration test there and more appropriately split out the examples.  

The component guide page is part of issue https://github.com/emberjs/guides/issues/501 and pull request https://github.com/emberjs/guides/pull/774