### PR TITLE
Update "rollback()" and "isDirty" references

### DIFF
--- a/source/models/creating-updating-and-deleting-records.md
+++ b/source/models/creating-updating-and-deleting-records.md
@@ -110,14 +110,14 @@ person.changedAttributes(); //=> { isAdmin: [false, true] }
 ```
 
 At this point, you can either persist your changes via `save()` or you
-can rollback your changes. Calling `rollback()` reverts all the
+can rollback your changes. Calling `rollbackAttributes()` reverts all the
 `changedAttributes` to their original value.
 
 ```js
 person.get('isDirty');      //=> true
 person.changedAttributes(); //=> { isAdmin: [false, true] }
 
-person.rollback();
+person.rollbackAttributes();
 
 person.get('isDirty');      //=> false
 person.get('isAdmin');      //=> false

--- a/source/models/creating-updating-and-deleting-records.md
+++ b/source/models/creating-updating-and-deleting-records.md
@@ -95,18 +95,18 @@ store.findRecord('post', 1).then(function(post) {
 ```
 
 You can tell if a record has outstanding changes that have not yet been
-saved by checking its `isDirty` property. You can also see what parts of
+saved by checking its `hasDirtyAttributes` property. You can also see what parts of
 the record were changed and what the original value was using the
 `changedAttributes` function.  `changedAttributes` returns an object,
 whose keys are the changed properties and values are an array of values
 `[oldValue, newValue]`.
 
 ```js
-person.get('isAdmin');      //=> false
-person.get('isDirty');      //=> false
+person.get('isAdmin');            //=> false
+person.get('hasDirtyAttributes'); //=> false
 person.set('isAdmin', true);
-person.get('isDirty');      //=> true
-person.changedAttributes(); //=> { isAdmin: [false, true] }
+person.get('hasDirtyAttributes'); //=> true
+person.changedAttributes();       //=> { isAdmin: [false, true] }
 ```
 
 At this point, you can either persist your changes via `save()` or you
@@ -114,14 +114,14 @@ can rollback your changes. Calling `rollbackAttributes()` reverts all the
 `changedAttributes` to their original value.
 
 ```js
-person.get('isDirty');      //=> true
-person.changedAttributes(); //=> { isAdmin: [false, true] }
+person.get('hasDirtyAttributes'); //=> true
+person.changedAttributes();       //=> { isAdmin: [false, true] }
 
 person.rollbackAttributes();
 
-person.get('isDirty');      //=> false
-person.get('isAdmin');      //=> false
-person.changedAttributes(); //=> {}
+person.get('hasDirtyAttributes'); //=> false
+person.get('isAdmin');            //=> false
+person.changedAttributes();       //=> {}
 ```
 
 ## Promises


### PR DESCRIPTION
Ember Data renamed `Model.rollback()` to `Model.rollbackAttributes()`. (https://github.com/emberjs/data/pull/3305)

The `isDirty` attribute has been deprecated in favor of `hasDirtyAttributes`. (https://github.com/emberjs/data/pull/3351)