### PR TITLE
Add workaround for unversioned search links in Swiftype overlay

### DIFF
--- a/source/javascripts/app/swiftype.js.erb
+++ b/source/javascripts/app/swiftype.js.erb
@@ -37,4 +37,15 @@ $(function() {
     documentTypes: Swiftype.searchDocumentTypes,
     onComplete: onComplete
   });
+
+  $(document).on('DOMNodeInserted', '.st-result', function() {
+    var searchLabel = $(this).find('h3');
+    var searchLink = $(this).find('a');
+    var originalUrl = searchLabel.data('dest-url');
+    if(originalUrl.indexOf(currentRevision) === -1) {
+      var searchUrl = currentRevision + originalUrl;
+      searchLabel.attr('data-dest-url', searchUrl);
+      searchLink.attr('href', searchUrl);
+    }
+  });
 });


### PR DESCRIPTION
This temporarily resolves #514 

This will modify links in the Swiftype overlay whenever they appear, adding the currentRevision to the URL. It's a temporary workaround which will hopefully be removed in the future, once we find a more permanent solution.