### PR TITLE
Add missing slash in Swiftype search overlay workaround urls

### DIFF
--- a/source/javascripts/app/swiftype.js.erb
+++ b/source/javascripts/app/swiftype.js.erb
@@ -43,7 +43,7 @@ $(function() {
     var searchLink = $(this).find('a');
     var originalUrl = searchLabel.data('dest-url');
     if(originalUrl.indexOf(currentRevision) === -1) {
-      var searchUrl = currentRevision + originalUrl;
+      var searchUrl = '/' + currentRevision + originalUrl;
       searchLabel.attr('data-dest-url', searchUrl);
       searchLink.attr('href', searchUrl);
     }


### PR DESCRIPTION
This adds a slash in the beginning of urls in the Swiftype search overlay (in the previously introduced workaround). It was missing before, as I had the forward slash in my local dev configuration, whereas there is no slash in production.