### PR TITLE
Added links to API details on models pages

### DIFF
--- a/source/models/creating-updating-and-deleting-records.md
+++ b/source/models/creating-updating-and-deleting-records.md
@@ -1,6 +1,8 @@
 ## Creating Records
 
-You can create records by calling the `createRecord` method on the store.
+You can create records by calling the
+[`createRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_createRecord)
+method on the store.
 
 ```js
 store.createRecord('post', {
@@ -56,7 +58,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-`incrementProperty` helper:
+[`incrementProperty`](http://emberjs.com/api/classes/Ember.Object.html#method_incrementProperty) helper:
 
 ```js
 person.incrementProperty('age'); // Happy birthday!
@@ -65,7 +67,8 @@ person.incrementProperty('age'); // Happy birthday!
 ## Persisting Records
 
 Records in Ember Data are persisted on a per-instance basis.
-Call `save()` on any instance of `DS.Model` and it will make a network request.
+Call [`save()`](http://emberjs.com/api/data/classes/DS.Model.html#method_save)
+on any instance of `DS.Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
 you. This allows Ember Data to treat newly created records differently
@@ -95,11 +98,13 @@ store.findRecord('post', 1).then(function(post) {
 ```
 
 You can tell if a record has outstanding changes that have not yet been
-saved by checking its `hasDirtyAttributes` property. You can also see what parts of
+saved by checking its
+[`hasDirtyAttributes`](http://emberjs.com/api/data/classes/DS.Model.html#property_hasDirtyAttributes)
+property. You can also see what parts of
 the record were changed and what the original value was using the
-`changedAttributes` function.  `changedAttributes` returns an object,
-whose keys are the changed properties and values are an array of values
-`[oldValue, newValue]`.
+[`changedAttributes()`](http://emberjs.com/api/data/classes/DS.Model.html#method_changedAttributes)
+method. `changedAttributes` returns an object, whose keys are the changed
+properties and values are an array of values `[oldValue, newValue]`.
 
 ```js
 person.get('isAdmin');            //=> false
@@ -110,9 +115,10 @@ person.changedAttributes();       //=> { isAdmin: [false, true] }
 ```
 
 At this point, you can either persist your changes via `save()` or you can roll
-back your changes. Calling `rollbackAttributes()` for a saved record reverts all
-the `changedAttributes` to their original value. If the record `isNew` it will
-be removed from the store.
+back your changes. Calling
+[`rollbackAttributes()`](http://emberjs.com/api/data/classes/DS.Model.html#method_rollbackAttributes)
+for a saved record reverts all the `changedAttributes` to their original value.
+If the record `isNew` it will be removed from the store.
 
 ```js
 person.get('hasDirtyAttributes'); //=> true
@@ -127,8 +133,9 @@ person.changedAttributes();       //=> {}
 
 ## Promises
 
-`save()` returns a promise, which makes easy to asynchronously handle
- success and failure scenarios.  Here's a common pattern:
+[`save()`](http://emberjs.com/api/data/classes/DS.Model.html#method_save) returns
+a promise, which makes easy to asynchronously handle success and failure 
+scenarios.  Here's a common pattern:
 
 ```javascript
 var post = store.createRecord('post', {
@@ -155,10 +162,10 @@ post.save().then(transitionToPost).catch(failure);
 ## Deleting Records
 
 Deleting records is just as straightforward as creating records. Just
-call `deleteRecord()` on any instance of `DS.Model`. This flags the
-record as `isDeleted`. The deletion can then be persisted using
-`save()`.  Alternatively, you can use the `destroyRecord` method to
-delete and persist at the same time.
+call [`deleteRecord()`](http://emberjs.com/api/data/classes/DS.Model.html#method_deleteRecord)
+on any instance of `DS.Model`. This flags the record as `isDeleted`. The 
+deletion can then be persisted using `save()`.  Alternatively, you can use 
+the `destroyRecord` method to delete and persist at the same time.
 
 ```js
 store.findRecord('post', 1).then(function(post) {
@@ -174,5 +181,5 @@ store.findRecord('post', 2).then(function(post) {
 ```
 
 Deleted records will still show up in RecordArrays returned by
-`store.peekAll` and `hasMany` relationships until they have been
-successfully saved.
+[`store.peekAll()`](http://emberjs.com/api/data/classes/DS.Store.html#method_peekAll)
+and `hasMany` relationships until they have been successfully saved.

--- a/source/models/customizing-serializers.md
+++ b/source/models/customizing-serializers.md
@@ -137,8 +137,8 @@ export default DS.JSONSerializer.extend({});
 ```
 
 To change the format of the data that is sent to the backend store, you can use
-the `serialize` hook. Let's say that we have this JSON API response from Ember
-Data:
+the [`serialize()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_serialize)
+hook. Let's say that we have this JSON API response from Ember Data:
 
 ```json
 {
@@ -195,8 +195,10 @@ export default DS.JSONSerializer.extend({
 ```
 
 Similarly, if your backend store provides data in a format other than JSON API,
-you can use the `normalizeResponse` hook. Using the same example as above, if
-the server provides data that looks like:
+you can use the
+[`normalizeResponse()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_normalizeResponse)
+hook. Using the same example as above, if the server provides data that looks
+like:
 
 ```json
 {
@@ -247,7 +249,9 @@ export default DS.JSONSerializer.extend({
 });
 ```
 
-To normalize only a single model, you can use the `normalize` hook similarly.
+To normalize only a single model, you can use the
+[`normalize()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_normalize)
+hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
 API documentation](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#index).
@@ -299,10 +303,12 @@ in the document payload returned by your server:
 ```
 
 If the attributes returned by your server use a different convention
-you can use the serializer's `keyForAttribute` method to convert an
-attribute name in your model to a key in your JSON payload. For
-example, if your backend returned attributes that are `under_scored`
-instead of `dash-cased` you could override the `keyForAttribute`
+you can use the serializer's
+[`keyForAttribute()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer
+.html#method_keyForAttribute)
+method to convert an attribute name in your model to a key in your JSON 
+payload. For example, if your backend returned attributes that are 
+`under_scored` instead of `dash-cased` you could override the `keyForAttribute`
 method like this.
 
 ```app/serializers/application.js
@@ -398,7 +404,9 @@ The JSON should encode the relationship as an ID to another record:
 }
 ```
 If needed these naming conventions can be overwritten by implementing
-the `keyForRelationship` method.
+the
+[`keyForRelationship()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_keyForRelationship)
+method.
 
 ```app/serializers/application.js
 export default DS.JSONAPISerializer.extend({
@@ -625,7 +633,7 @@ Its also important to know about the `normalized` JSON form that Ember
 Data expects as an argument to `store.push()`.
 
 `store.push` accepts a JSON API document. However, unlike the
-JSONAPISerializer store.push does not do any transformation of the
+JSONAPISerializer, store.push does not do any transformation of the
 record's type name or attributes. It is important to make sure that
 the type name matches the name of the file where it is defined
 exactly. Also attribute and relationship names in the JSON API

--- a/source/models/finding-records.md
+++ b/source/models/finding-records.md
@@ -3,16 +3,17 @@ type.
 
 ### Retrieving a Single Record
 
-Use `store.findRecord()` to retrieve a record by its type and ID. This will
-return a promise that fulfills with the requested record:
+Use [`store.findRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_findRecord)
+to retrieve a record by its type and ID. This will return a promise that
+fulfills with the requested record:
 
 ```javascript
 var post = this.store.findRecord('post', 1); // => GET /posts/1
 ```
 
-Use [`store.peekRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_peekRecord) to retrieve a record by its type and ID, without making
-a network request. This will return the record only if it is already present in
-the store:
+Use [`store.peekRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_peekRecord)
+to retrieve a record by its type and ID, without making a network request.
+This will return the record only if it is already present in the store:
 
 ```javascript
 var post = this.store.peekRecord('post', 1); // => no network request
@@ -20,14 +21,16 @@ var post = this.store.peekRecord('post', 1); // => no network request
 
 ### Retrieving Multiple Records
 
-Use `store.findAll()` to retrieve all of the records for a given type:
+Use [`store.findAll()`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll)
+to retrieve all of the records for a given type:
 
 ```javascript
 var posts = this.store.findAll('post'); // => GET /posts
 ```
 
-Use `store.peekAll()` to retrieve all of the records for a given type that are
-already loaded into the store, without making a network request:
+Use [`store.peekAll()`](http://emberjs.com/api/data/classes/DS.Store.html#method_peekAll)
+to retrieve all of the records for a given type that are already loaded into 
+the store, without making a network request:
 
 ```javascript
 var posts = this.store.peekAll('post'); // => no network request
@@ -45,7 +48,8 @@ not work--you'll have to use `objectAt(index)` instead.
 
 ### Querying for Multiple Records
 
-Ember Data provides the ability to query for records that meet certain criteria. Calling `store.query()`
+Ember Data provides the ability to query for records that meet certain criteria. Calling
+[`store.query()`](http://emberjs.com/api/data/classes/DS.Store.html#method_query)
 will make a `GET` request with the passed object serialized as query params. This method returns
 `DS.PromiseArray` in the same way as `find`.
 
@@ -63,8 +67,9 @@ this.store.query('person', { filter: { name: 'Peter' } }).then(function(peters) 
 
 If you know your query will return only one result Ember Data provides
 a convenience method that will return a promise that resolves with a
-single record. Calling `store.queryRecord()` will make a `GET` request
-with the passed object serialized as query params.
+single record. Calling
+[`store.queryRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_queryRecord)
+will make a `GET` request with the passed object serialized as query params.
 
 For example, if we know that an email uniquely identifies a person, we could search for a `person` model that has an email address of
 `tomster@example.com`:

--- a/source/models/pushing-records-into-the-store.md
+++ b/source/models/pushing-records-into-the-store.md
@@ -19,7 +19,7 @@ you want to update the UI immediately.
 
 ### Pushing Records
 
-To push a record into the store, call the store's `push()` method.
+To push a record into the store, call the store's [`push()`](http://emberjs.com/api/data/classes/DS.Store.html#method_push) method.
 
 For example, imagine we want to preload some data into the store when
 the application boots for the first time.
@@ -73,8 +73,8 @@ example above the type is `album` because the model is defined in
 the casing of the properties defined on the Model class.
 
 If you would like to the data to be normalized by the serializer
-before pushing it into the store you can use the `store.pushPayload`
-method.
+before pushing it into the store you can use the
+[`store.pushPayload()`](http://emberjs.com/api/data/classes/DS.Store.html#method_pushPayload) method.
 
 ```app/routes/application.js
 export default Ember.Route.extend({

--- a/source/stylesheets/guides.css.scss
+++ b/source/stylesheets/guides.css.scss
@@ -25,6 +25,10 @@ body.guides, body.blog, body.api {
     @include border-radius(5px);
   }
 
+  a code {
+    color: $orange-color;
+  }
+
   pre.code {
     font-family: Menlo, Courier, monospace;
     font-size: 90%;


### PR DESCRIPTION
I've removed the code back ticks, as it was hard to distinguish that we had links with our old `code` styling.

But I've got a CSS suggestion.  Here's a picture of what we've got and what I'm proposing:
![screen shot 2015-10-12 at 9 11 25 pm](https://cloud.githubusercontent.com/assets/802505/10444633/06e2bc0e-7126-11e5-94b8-ddd590215411.png)

Thoughts?  I'll update the CSS and amend this commit if we like that idea ...