### PR TITLE
Mention /tests/index.html in Testing Introduction

### DIFF
--- a/source/testing/index.md
+++ b/source/testing/index.md
@@ -67,7 +67,8 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 file-change with `ember test --server`.
 
 Tests can also be executed when you are running a local development server (started by
-running `ember server`), at the `/tests` URI.  A word of caution using this approach:
+running `ember server`), at the `/tests` URI which renders the `tests/index.html` template.
+A word of caution using this approach:
 Tests run using `ember server` have the environment configuration `development`, whereas tests executed
 under `ember test --server` are run with the configuration `test`.  This could cause
 differences in execution, such as which libraries are loaded and available.  Therefore its


### PR DESCRIPTION
I thought it might be worth mentioning that the `/tests` URI renders the `tests/index.html` template, in case someone need to customize it, or add some 3rd party code (test google maps or something similar without stubbing the API?)

I didn't see the file mentioned anywhere else in the docs, I apologize if I missed it!