### PR TITLE
Make clear that `fullNameChanged` fires if `fullName` is consumed first

### DIFF
--- a/source/object-model/observers.md
+++ b/source/object-model/observers.md
@@ -22,6 +22,7 @@ Person = Ember.Object.extend({
 
   fullNameChanged: Ember.observer('fullName', function() {
     // deal with the change
+    console.log(`fullName changed to: ${this.get('fullName')}`);
   })
 });
 
@@ -30,7 +31,9 @@ var person = Person.create({
   lastName: 'Katz'
 });
 
-person.set('firstName', 'Brohuda'); // observer will fire
+// observer won't fire until `fullName` is consumed first
+person.get('fullName'); // "Yehuda Katz"
+person.set('firstName', 'Brohuda'); // fullName changed to: Brohuda Katz
 ```
 
 Because the `fullName` computed property depends on `firstName`,


### PR DESCRIPTION
Fixes https://github.com/emberjs/guides/issues/893#issuecomment-148925813