### PR TITLE
Refactor component integration test action example.

### DIFF
--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -168,7 +168,10 @@ of a test double (dummy function):
 test('should trigger external action on form submit', function(assert) {
 
   // test double for the external action
-  this.set('externalAction', (attributes) => assert.deepEqual(attributes, { comment: 'You are not a wizard!' }, 'submitted input value gets passed to external action'));
+  this.set('externalAction', (actual) => {
+    let expected = { comment: 'You are not a wizard!' };
+    assert.deepEqual(actual, expected, 'submitted value is passed to external action');
+  });
 
   this.render(hbs`{{comment-form submitComment=(action externalAction)}}`);
 


### PR DESCRIPTION
The length of the line makes the example hard for me to grok, this just splits up the long line length with a helpfully named variable.