### PR TITLE
Update rendering-a-template.md

### DIFF
--- a/source/routing/rendering-a-template.md
+++ b/source/routing/rendering-a-template.md
@@ -17,7 +17,7 @@ the `posts.new` route will render `posts/new.hbs`.
 
 Each template will be rendered into the `{{outlet}}` of its parent route's
 template. For example, the `posts.new` route will render its template into the
-`post.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
+`posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
 If you want to render a template other than the default one, implement the


### PR DESCRIPTION
I believe this documentation should read that the `posts.new` route will render into the `posts.hbs`'s `{{outlet}}` not `post.hbs`'s.