### PR TITLE
Add HTML Proofer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "builder"
 gem "middleman-alias"
 gem "middleman-swiftype", :git => "https://github.com/LeonB/middleman-swiftype.git"
 gem "underscore-rails"
+gem "html-proofer"
 
 source 'https://rails-assets.org' do
   gem "rails-assets-js-md5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     builder (3.2.2)
     capybara (2.4.4)
       mime-types (>= 1.16)
@@ -39,6 +40,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.0)
+    colored (1.2)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -54,6 +56,8 @@ GEM
     daemons (1.1.9)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    ethon (0.8.0)
+      ffi (>= 1.3.0)
     eventmachine (1.0.7)
     execjs (2.3.0)
     ffi (1.9.6)
@@ -67,6 +71,14 @@ GEM
     hitimes (1.2.2-x86-mingw32)
     hooks (0.4.0)
       uber (~> 0.0.4)
+    html-proofer (2.5.1)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
     i18n (0.6.11)
     json (1.8.3)
     kramdown (1.5.0)
@@ -74,6 +86,7 @@ GEM
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
+    mercenary (0.3.5)
     method_source (0.8.2)
     middleman (3.3.7)
       coffee-script (~> 2.2)
@@ -119,6 +132,7 @@ GEM
       tilt (~> 1.4.1)
     padrino-support (0.12.4)
       activesupport (>= 3.1)
+    parallel (1.6.1)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -178,6 +192,8 @@ GEM
     tilt (1.4.1)
     timers (4.0.1)
       hitimes
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     tzinfo-data (1.2015.1)
@@ -194,6 +210,7 @@ GEM
     win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yell (2.0.5)
 
 PLATFORMS
   ruby
@@ -206,6 +223,7 @@ DEPENDENCIES
   coderay!
   hashie
   highline
+  html-proofer
   listen
   middleman (~> 3.0)
   middleman-alias

--- a/config.rb
+++ b/config.rb
@@ -61,6 +61,7 @@ end
 configure :build do
   activate :minify_css
   activate :minify_javascript, ignore: /.*examples.*js/
+  activate :html_proofer
 end
 
 ###

--- a/lib/proofer.rb
+++ b/lib/proofer.rb
@@ -1,0 +1,17 @@
+require 'html/proofer'
+
+class HtmlProofer < Middleman::Extension
+  def initialize(app, options={}, &block)
+    super
+    app.after_build do
+      HTML::Proofer.new('./build', {
+        :verbose          => true,
+        :alt_ignore       => [/.*/],
+        :href_ignore      => ['#', '/blog/feed.xml'],
+        :disable_external => true,
+      }).run
+    end
+  end
+end
+
+::Middleman::Extensions.register :html_proofer, HtmlProofer


### PR DESCRIPTION
The HTML Proofer is a gem that validates HTML output. It checks for lots of things, for example whether image references are correct, and that images have alt tags. The main reason we're looking into it, is because it checks for dead links, which is great after reorganizing content.

Have a look at the discussion over at #598, as well as the [html-proofer options](https://github.com/gjtorikian/html-proofer#configuration).

There are still a few issues remaining, which I'm hoping to get feedback on:

- What other options should be enabled? I'm thinking ```check_html``` might be good, unless it's completely out of scope.
- The PR in its current form should have Travis complaining about dead links. However, the ```middleman server``` command still needs work.

Fixes #598.