### PR TITLE
Fix link to jsonapi.org

### DIFF
--- a/source/models/index.md
+++ b/source/models/index.md
@@ -157,7 +157,7 @@ designed to work out of the box with [JSON API][json-api]. JSON API is a
 formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
 
-[json-api]: http://www.jsonapi.org
+[json-api]: http://jsonapi.org
 
 JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have


### PR DESCRIPTION
`www.jsonapi.org` is not a registered domain. The correct domain is `jsonapi.org`:

    $ host www.jsonapi.org
    Host www.jsonapi.org not found: 3(NXDOMAIN)
    Host www.jsonapi.org not found: 3(NXDOMAIN)
    $ host jsonapi.org
    jsonapi.org has address 192.30.252.154
    jsonapi.org has address 192.30.252.153