### PR TITLE
[Redesign] Tweak line numbers background to match code block

### DIFF
--- a/source/stylesheets/components/_highlight.scss
+++ b/source/stylesheets/components/_highlight.scss
@@ -58,11 +58,12 @@
         color: $medium-gray;
         text-align: center;
         width: 2em;
+        background-color: $code-background;
       }
 
       &.code {
         background-color: $code-background;
-        padding: 0.5em 0 0.5em 1em;
+        padding: 0.5em 0 0.5em 0.5em;
       }
     }
 


### PR DESCRIPTION
## Before
<img width="759" alt="screen shot 2015-11-06 at 10 45 20 pm" src="https://cloud.githubusercontent.com/assets/230476/11013981/3a3b8d40-84d8-11e5-8004-23e110184501.png">

## After
<img width="765" alt="screen shot 2015-11-06 at 10 45 51 pm" src="https://cloud.githubusercontent.com/assets/230476/11013982/3a4fb5e0-84d8-11e5-8ab8-8321e1cf0932.png">

