### PR TITLE
Update Factory Lookup section.

### DIFF
--- a/source/applications/dependency-injection.md
+++ b/source/applications/dependency-injection.md
@@ -189,11 +189,11 @@ export default Ember.Component.extend({
 });
 ```
 
-## Factory Lookups
+## Factory Instance Lookups
 
 The vast majority of Ember registrations and lookups are performed implicitly.
 
-In the rare cases in which you want to perform an explicit lookup of a
+In the rare cases in which you want to perform an explicit lookup of an instance of a
 registered factory, you can do so on an application instance in its associated
 instance initializer. For example:
 


### PR DESCRIPTION
This section is talking about how to get a singleton instance from the container, and not how to grab the factory itself (so that you might later be able to instantiate it yourself).  

Before this change, based on the title alone I would have expected it to discuss `appInstance._lookupFactory` (or `container.lookupFactory`), which is private.

After this change, it seems clearer that we are looking up an instance not the class itself.