### PR TITLE
Added `type` to acceptable input attributes

### DIFF
--- a/source/templates/input-helpers.md
+++ b/source/templates/input-helpers.md
@@ -35,7 +35,7 @@ helper:
   <tr><td>`formmethod`</td><td>`formnovalidate`</td><td>`formtarget`</td></tr>
   <tr><td>`height`</td><td>`inputmode`</td><td>`multiple`</td></tr>
   <tr><td>`step`</td><td>`width`</td><td>`form`</td></tr>
-  <tr><td>`selectionDirection`</td><td>`spellcheck`</td><td>&nbsp;</td></tr>
+  <tr><td>`selectionDirection`</td><td>`spellcheck`</td><td>`type`</td></tr>
 </table>
 
 If these attributes are set to a quoted string, their values will be set


### PR DESCRIPTION
Type is obviously accepted as an attribute to the {{input}} helper, since it's used in an example below. I feel like it should be included in the list of accepted attributes, for sake of completeness.