### PR TITLE
Make example with loading substates for nested routes more consistent

### DIFF
--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -60,7 +60,7 @@ Router.map(function() {
 Ember will alternate trying to find a `routeName-loading` or `loading` template
 in the hierarchy starting with `foo.bar.slow-model-loading`:
 
-1. `slow-model-loading`
+1. `foo.bar.slow-model-loading`
 2. `foo.bar.loading` or `foo.bar-loading`
 3. `foo.loading` or `foo-loading`
 4. `loading` or `application-loading`


### PR DESCRIPTION
The route names that are used in the example should be consistent.