### PR TITLE
Remove resetNamespace from defining routes guide

### DIFF
--- a/source/routing/defining-your-routes.md
+++ b/source/routing/defining-your-routes.md
@@ -196,30 +196,6 @@ Router.map(function() {
 });
 ```
 
-## Resetting Nested Route Namespace
-
-When nesting routes, it may be beneficial for a child route to not inherit its ancestors name. This allows you to reference and reuse a given route in multiple route trees as well as keep the class name short.
-
-You can reset the current "namespace" with the aptly named `resetNamespace: true` option.
-
-```app/router.js
-Router.map(function() {
-  this.route('post', { path: '/post/:post_id' }, function() {
-    this.route('edit');
-    this.route('comments', { resetNamespace: true }, function() {
-      this.route('new');
-    });
-  });
-});
-```
-
-Just like before, the `comments` template will be rendered in the `post`
-template's `{{outlet}}`, and all templates under `comments` (`comments/index`
-and `comments/new`) will be rendered in the `comments` outlet.
-
-However, the `/post/:id/comments` path will load the `comments.hbs` template,
-rather than the `post/comments.hbs` template.
-
 ## Route Handlers
 
 To have your route do something beyond render a template with the same name, you'll


### PR DESCRIPTION
So the first paragraph here is just plain wrong - you can't reuse routes in multiple route trees because routes have to be uniquely named.

But I think that there is only one edge case where resetNamespace actually makes sense, and even then it's only out of laziness: Moving a route under a new parent route without having to update link-to's and transitionTos. But (a) that only covers one case of moving a route, if you want to move a route out from under a parent it doesn't help, and (b) it's actually a bit of a hack because it removes the conventional mapping of route nesting &rarr; file location, which I suspect will become even more annoying as pods mature.

So I propose removing this section from the guide entirely rather than correcting it as the use case for it is quite narrow and it's just confusing and not really necessary.