### PR TITLE
Remove hyphen from "well separated" after noun.

### DIFF
--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -76,7 +76,7 @@ run time. The `{{my-component}}` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
 external libraries depending on the data. Using the `{{component}}` helper would
-allow you to keep different logic well-separated.
+allow you to keep different logic well separated.
 
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `{{blog-post}}`.


### PR DESCRIPTION
When a compound adjective comes after the noun, it generally shouldn't be hyphenated: http://www.grammarly.com/handbook/punctuation/hyphen/4/hyphen-with-noun-adjective-or-adverb-and-present-p/.