### PR TITLE
Use quotations consistent with rest of guides

### DIFF
--- a/source/tutorial/ember-data.md
+++ b/source/tutorial/ember-data.md
@@ -60,37 +60,37 @@ export default function() {
   this.get('/rentals', function() {
     return {
       data: [{
-        type: "rentals",
+        type: 'rentals',
         id: 1,
         attributes: {
-          title: "Grand Old Mansion",
-          owner: "Veruca Salt",
-          city: "San Francisco",
-          type: "Estate",
+          title: 'Grand Old Mansion',
+          owner: 'Veruca Salt',
+          city: 'San Francisco',
+          type: 'Estate',
           bedrooms: 15,
-          image: "https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg"
+          image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg'
         }
       }, {
-        type: "rentals",
+        type: 'rentals',
         id: 2,
         attributes: {
-          title: "Urban Living",
-          owner: "Mike Teavee",
-          city: "Seattle",
-          type: "Condo",
+          title: 'Urban Living',
+          owner: 'Mike Teavee',
+          city: 'Seattle',
+          type: 'Condo',
           bedrooms: 1,
-          image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"
+          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
         }
       }, {
-        type: "rentals",
+        type: 'rentals',
         id: 3,
         attributes: {
-          title: "Downtown Charm",
-          owner: "Violet Beauregarde",
-          city: "Portland",
-          type: "Apartment",
+          title: 'Downtown Charm',
+          owner: 'Violet Beauregarde',
+          city: 'Portland',
+          type: 'Apartment',
           bedrooms: 3,
-          image: "https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg"
+          image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg'
         }
       }]
     }

--- a/source/tutorial/model-hook.md
+++ b/source/tutorial/model-hook.md
@@ -11,28 +11,28 @@ import Ember from 'ember';
 
 var rentals = [{
   id: 1,
-  title: "Grand Old Mansion",
-  owner: "Veruca Salt",
-  city: "San Francisco",
-  type: "Estate",
+  title: 'Grand Old Mansion',
+  owner: 'Veruca Salt',
+  city: 'San Francisco',
+  type: 'Estate',
   bedrooms: 15,
-  image: "https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg"
+  image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg'
 }, {
   id: 2,
-  title: "Urban Living",
-  owner: "Mike TV",
-  city: "Seattle",
-  type: "Condo",
+  title: 'Urban Living',
+  owner: 'Mike TV',
+  city: 'Seattle',
+  type: 'Condo',
   bedrooms: 1,
-  image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"
+  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
 }, {
   id: 3,
-  title: "Downtown Charm",
-  owner: "Violet Beauregarde",
-  city: "Portland",
-  type: "Apartment",
+  title: 'Downtown Charm',
+  owner: 'Violet Beauregarde',
+  city: 'Portland',
+  type: 'Apartment',
   bedrooms: 3,
-  image: "https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg"
+  image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg'
 }];
 
 export default Ember.Route.extend({

--- a/source/tutorial/routes-and-templates.md
+++ b/source/tutorial/routes-and-templates.md
@@ -113,7 +113,7 @@ Ember has built-in **helpers** that provide functionality such as linking to oth
   By building a property rental site, we can simultaneously imagine traveling<br>
   AND building Ember applications simultaneously.</p>
 
-{{#link-to 'contact'}}Click here to contact us.{{/link-to}}
+{{#link-to "contact"}}Click here to contact us.{{/link-to}}
 ```
 
 The helper takes an argument with the name of the route to link to, in this case, `contact`.  When we look at our about page, we now have a link to our contact page.
@@ -138,7 +138,7 @@ Now, we'll add one to link to our about page so we can navigate from back and fo
 
 <p>superrentalsrep@superrentals.com</p>
 
-{{#link-to 'about'}}About{{/link-to}}
+{{#link-to "about"}}About{{/link-to}}
 ```
 
 ## An Index Route
@@ -164,6 +164,6 @@ We can update our `index.hbs` with some HTML and we have our welcome home page a
 
 We hope you find exactly what you're looking for in a place to stay.
 
-{{#link-to 'about'}}About{{/link-to}}
-{{#link-to 'contact'}}Click here to contact us.{{/link-to}}
+{{#link-to "about"}}About{{/link-to}}
+{{#link-to "contact"}}Click here to contact us.{{/link-to}}
 ```

--- a/source/tutorial/simple-component.md
+++ b/source/tutorial/simple-component.md
@@ -74,7 +74,7 @@ For the button to make the image show, we will need to add an action that change
 
 ```app/templates/components/rental-listing.hbs
 ...
-<button {{action 'imageShow'}}>Show image</button>
+<button {{action "imageShow"}}>Show image</button>
 ...
 ```
 
@@ -103,9 +103,9 @@ We should let users hide the image again. In our template:
 <p>Number of bedrooms: {{rental.bedrooms}}</p>
 {{#if isImageShowing }}
   <p><img src={{rental.image}} alt={{rental.type}} width="500px"></p>
-  <button {{action 'imageHide'}}>Hide image</button>
+  <button {{action "imageHide"}}>Hide image</button>
 {{else}}
-  <button {{action 'imageShow'}}>Show image</button>
+  <button {{action "imageShow"}}>Show image</button>
 {{/if}}
 ```
 


### PR DESCRIPTION
The rest of the guides use single quotes for javascript and double-quotes in .hbs templates. This makes the updates to keep the tutorial consistent with the rest of the guides.