### PR TITLE
Fix typo

### DIFF
--- a/source/templates/displaying-a-list-of-items.md
+++ b/source/templates/displaying-a-list-of-items.md
@@ -48,7 +48,7 @@ to update bound arrays.
 
 ### Accessing an item's `index`
 
-During iteration, the index of each item in an the array is provided as a second
+During iteration, the index of each item in the array is provided as a second
 block param. Block params are space-separated, without commas. For example:
 
 ```handlebars


### PR DESCRIPTION
The article can either be *"an"* or *"the"*. I think the latter is more appropriate because we're talking about a specific array: the one we're iterating over.