### PR TITLE
Update example to use ES6 template-strings

### DIFF
--- a/source/routing/asynchronous-routing.md
+++ b/source/routing/asynchronous-routing.md
@@ -23,7 +23,7 @@ var promise = fetchTheAnswer();
 promise.then(fulfill, reject);
 
 function fulfill(answer) {
-  console.log('The answer is ' + answer);
+  console.log(`The answer is ${answer}`);
 }
 
 function reject(reason) {


### PR DESCRIPTION
It seems to me that the Guide is using ES6 template-strings.