### PR TITLE
Removed webkit-font-smoothing to ensure legibility

### DIFF
--- a/source/stylesheets/components/_highlight.scss
+++ b/source/stylesheets/components/_highlight.scss
@@ -1,4 +1,5 @@
 .highlight {
+  -webkit-font-smoothing: auto;
   border-radius: $base-border-radius;
   font-family: $monospace-font-family;
   font-size: 0.8em;


### PR DESCRIPTION
Since the new Guides now use light on dark code blocks, the `-webkit-font-smoothing` property makes thinner fonts really thin. While that might look good in certain settings it also reduces readability.