### PR TITLE
Fix code snippet showing Router definition

### DIFF
--- a/source/tutorial/routes-and-templates.md
+++ b/source/tutorial/routes-and-templates.md
@@ -44,7 +44,7 @@ When we open the router, we can see that the generator has mapped a new _about_ 
 import Ember from 'ember';
 import config from './config/environment';
 
-var Router = Ember.Router.extend({
+const Router = Ember.Router.extend({
   location: config.locationType
 });
 


### PR DESCRIPTION
I noticed a difference in the code that is generated by the ember new command and the example snippet and updated so that it matches what the developer sees. Small change.

(sorry, previously opened against wrong branch)