### PR TITLE
[DOC] JSON definition of Sideloaded Data is wrong

### DIFF
--- a/source/models/customizing-serializers.md
+++ b/source/models/customizing-serializers.md
@@ -73,7 +73,7 @@ should look like this:
 
 ```js
 {
-  "data": [{
+  "data": {
     "type": "articles",
     "id": "1",
     "attributes": {
@@ -90,7 +90,7 @@ should look like this:
         ]
       }
     }
-  }],
+  },
   "included": [{
     "type": "comments",
     "id": "5",


### PR DESCRIPTION
The JSON is now valid,
but the data is wrong ... the ']' needed to be removed instead of added ...

(sorry)