### PR TITLE
Inject stub service as proper property name

### DIFF
--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -245,7 +245,7 @@ moduleForComponent('location-indicator', 'Integration | Component | location ind
 
   beforeEach: function () {
     this.register('service:location-service', locationStub);
-    this.inject.service('location-service', { as: 'location' });
+    this.inject.service('location-service', { as: 'locationService' });
   }
 });
 ```


### PR DESCRIPTION
The component uses the `locationService` to inject the location service, while the test injects it as `location`.