### PR TITLE
Instructions to reboot serve after addon install

### DIFF
--- a/source/tutorial/ember-data.md
+++ b/source/tutorial/ember-data.md
@@ -58,6 +58,8 @@ Let's start by installing Mirage:
 ember install ember-cli-mirage
 ```
 
+If you were running `ember serve` in another shell, restart the server to include Mirage in your build.
+
 Let's now configure Mirage to send back our rentals that we had defined above by updating `app/mirage/config.js`:
 
 ```app/mirage/config.js


### PR DESCRIPTION
I think one possible hang up that people working through the guides might have is that they do not restart the `ember serve` command after installing addons. 

This adds a note after installing mirage, but should also be considered when looking at #1023 and #1024