### PR TITLE
Fix missing link-to on index.hbs

### DIFF
--- a/source/tutorial/model-hook.md
+++ b/source/tutorial/model-hook.md
@@ -60,7 +60,7 @@ Here, we'll use another common Handlebars helper called `{{each}}`.
 This helper will let us loop through each of the objects in our model:
 
 ```app/templates/index.hbs
-<h1> Welcome to Super Rentals </h1>
+<h1>Welcome to Super Rentals</h1>
 
 <p>We hope you find exactly what you're looking for in a place to stay.</p>
 
@@ -71,6 +71,9 @@ This helper will let us loop through each of the objects in our model:
   <p>Location: {{rental.city}}</p>
   <p>Number of bedrooms: {{rental.bedrooms}}</p>
 {{/each}}
+
+{{#link-to "about"}}About{{/link-to}}
+{{#link-to "contact"}}Click here to contact us.{{/link-to}}
 ```
 
 In this template, we loop through each model object and call it _rental_.


### PR DESCRIPTION
On the model hook part of the guides, I noticed that the `link-to` helpers at the bottom of the page went missing.