### PR TITLE
Update Mirage Config entry

### DIFF
--- a/source/tutorial/ember-data.md
+++ b/source/tutorial/ember-data.md
@@ -64,43 +64,35 @@ Let's now configure Mirage to send back our rentals that we had defined above by
 
 ```app/mirage/config.js
 export default function() {
+
   this.get('/rentals', function() {
-    return {
-      data: [{
-        type: 'rentals',
+    return ({
+      "rentals": [{
         id: 1,
-        attributes: {
-          title: 'Grand Old Mansion',
-          owner: 'Veruca Salt',
-          city: 'San Francisco',
-          type: 'Estate',
-          bedrooms: 15,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg'
-        }
+        title: 'Grand Old Mansion',
+        owner: 'Veruca Salt',
+        city: 'San Francisco',
+        type: 'Estate',
+        bedrooms: 15,
+        image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg'
       }, {
-        type: 'rentals',
         id: 2,
-        attributes: {
-          title: 'Urban Living',
-          owner: 'Mike Teavee',
-          city: 'Seattle',
-          type: 'Condo',
-          bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
-        }
+        title: 'Urban Living',
+        owner: 'Mike Teavee',
+        city: 'Seattle',
+        type: 'Condo',
+        bedrooms: 1,
+        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
       }, {
-        type: 'rentals',
         id: 3,
-        attributes: {
-          title: 'Downtown Charm',
-          owner: 'Violet Beauregarde',
-          city: 'Portland',
-          type: 'Apartment',
-          bedrooms: 3,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg'
-        }
+        title: 'Downtown Charm',
+        owner: 'Violet Beauregarde',
+        city: 'Portland',
+        type: 'Apartment',
+        bedrooms: 3,
+        image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg'
       }]
-    }
+    });
   });
 }
 ```


### PR DESCRIPTION
After looking around a little, I found that Ember's default adapter is http://emberjs.com/api/data/classes/DS.RESTAdapter.html which is very particular about the REST responses it is expecting back.  The current mirage file in the walkthrough doesn't follow the structure detailed in this file here: http://emberjs.com/api/data/classes/DS.RESTAdapter.html  and renders nothing in the template, which was kind of a bummer.  Re-organizing the structure of what mirage returns make it work just fine though.