### PR TITLE
Removed erroneous key=

### DIFF
--- a/source/templates/displaying-the-keys-in-an-object.md
+++ b/source/templates/displaying-the-keys-in-an-object.md
@@ -22,7 +22,7 @@ export default Ember.Component.extend({
   {{#each-in categories as |category products|}}
     <li>{{category}}
       <ol>
-        {{#each products key="@item" as |product|}}
+        {{#each products as |product|}}
           <li>{{product}}</li>
         {{/each}}
       </ol>


### PR DESCRIPTION
With keys="@item", I get an error in the browser console:
`Error: You must provide a string key when calling `yieldItem`; you provided undefined`

This issue emberjs/ember.js#12109 mentions deleting `key=`, which fixed the issue.