### PR TITLE
Fixed ember template error

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -116,7 +116,7 @@ event listeners and enables to work with one-way bindings.
 
 ```handlebars
 <label>What's your favorite band?</label>
-<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange"}}/>
+<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange"}} />
 ```
 
 Let's assume we have an action handler that prints its first parameter:

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -138,7 +138,7 @@ the event object:
 
 ```handlebars
 <label>What's your favorite band?</label>
-<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange" value="target.value"}}/>
+<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange" value="target.value"}} />
 ```
 
 The `newValue` parameter thus becomes the `target.value` property of the event


### PR DESCRIPTION
With the '/' character immediately at the end, reports an error:
`An unquoted attribute value must be a string or a mustache, preceeded by whitespace or a '=' character, and followed by whitespace or a '>' character (on line 8)`

Adding a space fixes the error.