### PR TITLE
[WIP] Check for unused spelling exceptions, resolves #1105

### DIFF
--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -116,7 +116,7 @@ event listeners and enables to work with one-way bindings.
 
 ```handlebars
 <label>What's your favorite band?</label>
-<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange"}}/>
+<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange"}} />
 ```
 
 Let's assume we have an action handler that prints its first parameter:

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -138,7 +138,7 @@ the event object:
 
 ```handlebars
 <label>What's your favorite band?</label>
-<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange" value="target.value"}}/>
+<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange" value="target.value"}} />
 ```
 
 The `newValue` parameter thus becomes the `target.value` property of the event

--- a/spec/spelling_spec.rb
+++ b/spec/spelling_spec.rb
@@ -1,0 +1,17 @@
+documentation_files = Dir.glob('./source/**/*.md')
+spelling_exceptions = File.read("./data/spelling-exceptions.txt").split("\n")
+
+corpus = documentation_files.reduce { |c, f| c << File.read(f) }.downcase
+
+describe "Spelling Exceptions" do
+
+  it "should only include words actually found in the guides" do
+    spelling_exceptions.each do |word|
+      expect(corpus.scan(word.downcase)).not_to be_empty,
+      %Q{
+         "#{word}" was included in the list of spelling exceptions, but was not found in the guides.
+      }.strip
+    end
+  end
+
+end


### PR DESCRIPTION
This is a first pass at addressing #1105. It does a quick scan through the documentation for a particular word. If it is not found, the expectation fails and the developer is notified as to which word was not found.

To my surprise, scanning the entire set of guides is relatively quick. I tried it with 1,000 words and there was no performance issue.

I also removed all of the unused spelling words.