### PR TITLE
Remove `px` from <img> width attribute

### DIFF
--- a/source/tutorial/simple-component.md
+++ b/source/tutorial/simple-component.md
@@ -94,7 +94,7 @@ Let's call this action `imageShow`
 <p>Location: {{rental.city}}</p>
 <p>Number of bedrooms: {{rental.bedrooms}}</p>
 {{#if isImageShowing }}
-  <p><img src={{rental.image}} alt={{rental.type}} width="500px"></p>
+  <p><img src={{rental.image}} alt={{rental.type}} width="500"></p>
 {{else}}
   <button {{action "imageShow"}}>Show image</button>
 {{/if}}

--- a/source/tutorial/simple-component.md
+++ b/source/tutorial/simple-component.md
@@ -127,7 +127,7 @@ In our template, let's add a button with an `imageHide` action:
 <p>Location: {{rental.city}}</p>
 <p>Number of bedrooms: {{rental.bedrooms}}</p>
 {{#if isImageShowing }}
-  <p><img src={{rental.image}} alt={{rental.type}} width="500px"></p>
+  <p><img src={{rental.image}} alt={{rental.type}} width="500"></p>
   <button {{action "imageHide"}}>Hide image</button>
 {{else}}
   <button {{action "imageShow"}}>Show image</button>


### PR DESCRIPTION
As suggested by HTML Tidy. According to MDN reference, the width attribute assumes pixels without a unit. [ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)