### PR TITLE
Prevent text wrapping on TOC hover animation

### DIFF
--- a/source/stylesheets/components/_sidebar.scss
+++ b/source/stylesheets/components/_sidebar.scss
@@ -111,7 +111,7 @@ ol.toc-level-1 {
 
   li {
     border-left: 3px solid transparent;
-    transition: border-width $duration;
+    transition: border-width $duration, margin-right $duration;
 
     &.selected,
     &:hover {
@@ -120,6 +120,7 @@ ol.toc-level-1 {
 
     &:hover {
       border-left-width: 6px;
+      margin-right: -3px;
     }
   }
 


### PR DESCRIPTION
Resolves #1174 

Old behavior:
![old](https://cloud.githubusercontent.com/assets/250934/12441153/1332bc4a-bf12-11e5-937b-5253f3d7b023.gif)

New behavior:
![new](https://cloud.githubusercontent.com/assets/250934/12441158/1aa9e5a2-bf12-11e5-84bf-43c68ae0f86b.gif)
