### PR TITLE
Fixes output example for index route creation

### DIFF
--- a/source/tutorial/routes-and-templates.md
+++ b/source/tutorial/routes-and-templates.md
@@ -179,6 +179,7 @@ ember g route index
 ```
 
 We can see the now familiar output for the route generator:
+
 ```shell
 installing route
   create app/routes/index.js


### PR DESCRIPTION
Small fix of the cli output creation messages in Tutorial: Routes and Templates.