### PR TITLE
Correct custom inflector example

### DIFF
--- a/source/models/customizing-adapters.md
+++ b/source/models/customizing-adapters.md
@@ -113,7 +113,9 @@ import './models/custom-inflector-rules';
 ```
 
 ```app/models/custom-inflector-rules.js
-var inflector = Ember.Inflector.inflector;
+import Inflector from 'ember-inflector';
+
+const inflector = Inflector.inflector;
 
 inflector.irregular('formula', 'formulae');
 inflector.uncountable('advice');


### PR DESCRIPTION
The `Inflector` isn't available on `Ember` at the point which this example is loaded.

This change imports directly from the inflector library and changes to ES6 const syntax.