### PR TITLE
Grammar, wording, punctuation, example, and terminology fixes

### DIFF
--- a/source/configuring-ember/debugging.md
+++ b/source/configuring-ember/debugging.md
@@ -110,7 +110,7 @@ difficult to track down where a given issue is coming from. Thankfully,
 `RSVP` has a solution for this problem built in.
 
 You can provide an `onerror` function that will be called with the error
-details if any errors occur within your promise. This function can be anything
+details if any errors occur within your promise. This function can be anything,
 but a common practice is to call `console.assert` to dump the error to the
 console.
 

--- a/source/configuring-ember/feature-flags.md
+++ b/source/configuring-ember/feature-flags.md
@@ -16,9 +16,9 @@ Beta features that receive negative feedback from the community are disabled in 
 release, and are not included in the next stable release. They may still be included
 in the next beta cycle if the issues/concerns are resolved.
 
-Once the beta cycle has completed the next stable release will include any features that
+Once the beta cycle has completed, the next stable release will include any features that
 were enabled during the beta cycle. At this point the feature flags will be removed from
-the canary and future beta branches and the feature becomes of the framework.
+the canary and future beta branches, and the feature becomes part of the framework.
 
 ## Flagging Details
 The flag status in the generated build is controlled by the [`features.json`](https://github.com/emberjs/ember.js/blob/master/features.json)
@@ -38,15 +38,15 @@ handled by [`defeatureify`](https://github.com/thomasboyt/defeatureify).
 
 ## Feature Listing ([`FEATURES.md`](https://github.com/emberjs/ember.js/blob/master/FEATURES.md))
 
-When a developer adds a new feature `canary` channel (i.e. the `master` branch on github), they
+When a developer adds a new feature to the `canary` channel (i.e. the `master` branch on github), they
 also add an entry to [`FEATURES.md`](https://github.com/emberjs/ember.js/blob/master/FEATURES.md)
-explaining what the feature does and linking to their originating pull request.
+explaining what the feature does, and linking to their originating pull request.
 This list is kept current, and reflects what is available in each channel
-(`stable`, `beta`, and `master`).
+(`release`, `beta`, and `canary`).
 
 ## Enabling At Runtime
-When using the Ember.js canary or beta builds you can enable any "**present** but **disabled**"
-by setting its flag value to `true` before your application boots:
+When using the Ember.js canary or beta builds you can enable a "**present** but **disabled**"
+feature by setting its flag value to `true` before your application boots:
 
 ```config/environment.js
 var ENV = {

--- a/source/configuring-ember/handling-deprecations.md
+++ b/source/configuring-ember/handling-deprecations.md
@@ -68,9 +68,9 @@ window.deprecationWorkflow.config = {
 You might notice that you have a lot of duplicated messages in your workflow file, like the 3 messages in the above example that start with
 `Accessing 'template' in...`.  This is because some of the deprecation messages provide context to the specific deprecation, making them
 different than the same deprecation in other parts of the app.  If you want to consolidate the
-duplication, you can use a simple regular expression and a wildcard (`.*`) for the part of the message that varies per instance.
+duplication, you can use a simple regular expression with a wildcard (`.*`) for the part of the message that varies per instance.
 
-Below is the same deprecation-workflow file as above now with a regular expression on line 11 to remove some redundant messages
+Below is the same deprecation-workflow file as above, now with a regular expression on line 7 to remove some redundant messages. Note that the double quotes around `matchMessage` have also been replaced with forward slashes.
 
 ``` /config/deprecation-workflow.js
 window.deprecationWorkflow = window.deprecationWorkflow || {};
@@ -114,20 +114,20 @@ window.deprecationWorkflow.config = {
 ### 3. Fix and Repeat
 After fixing a deprecation and getting your scenarios working again, you might want to leave the deprecation message in the workflow file with the
 throw handler enabled.  This will ensure you haven't missed anything, and ensure no new deprecated calls of that type are introduced to your project.
-Next its just a matter of going down the list, updating the handler, and fixing each remaining deprecation.
+Next, it's just a matter of going down the list, updating the handler, and fixing each remaining deprecation.
 
-In the end your deprecations can be fully turned on as "throw" and you should be able to use your application without error.  At this point you can
+In the end, your deprecations can be fully turned on as "throw" and you should be able to use your application without error.  At this point, you can
 go ahead and update your Ember version!  When you upgrade, be sure you remove the deprecations you've fixed from the deprecation workflow file,
 so that you can start the process over for the next release.
 
 ## Silencing Deprecation Warnings During Compile
 
-You might also notice as you upgrade between releases that your terminal log begins to stream template-related deprecation warnings during the compile process, making
+As you upgrade between releases, you might also notice that your terminal log begins to stream template-related deprecation warnings during the compile process, making
 it difficult to review your compilation logs.
 
 <img width="675px" src="../../images/guides/configuring-ember/handling-deprecations/compile-deprecations.png" title="Compile Deprecations Clouding Log"/>
 
-If you are using the deprecation workflow process above you will likely prefer to gather these same warnings during runtime execution.  The way to hide these
+If you are using the deprecation workflow process above, you will likely prefer to gather these warnings during runtime execution instead.  The way to hide these
 warnings during compile is to install the [ember-cli-template-lint](http://emberobserver.com/addons/ember-cli-template-lint) addon.  It suppresses
 template deprecation warnings during compile in favor of showing them in the browser console during test suite execution or application usage.
 
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).

--- a/source/ember-inspector/data.md
+++ b/source/ember-inspector/data.md
@@ -1,4 +1,4 @@
-You can inspect your models by clicking on the `Data` menu. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
 [building-data-adapter]:#toc_building-a-data-custom-adapter
 
 When you open the Data tab, you will see a list of model types defined

--- a/source/ember-inspector/object-inspector.md
+++ b/source/ember-inspector/object-inspector.md
@@ -1,4 +1,4 @@
-The Inspector includes an panel that allows you to view and interact with your Ember objects. 
+The Inspector includes a panel that allows you to view and interact with your Ember objects. 
 To open it, click on any Ember object. You can then view the object's properties.
 
 

--- a/source/testing/acceptance.md
+++ b/source/testing/acceptance.md
@@ -159,7 +159,7 @@ export default Ember.Test.registerAsyncHelper(
 });
 ```
 
-[`Ember.Test.registerAsyncHelper`][10] and [`Ember.Test.registerHelper`][11] 
+[`Ember.Test.registerAsyncHelper`][10] and [`Ember.Test.registerHelper`][11]
 are used to register test helpers that will be injected when `startApp` is
 called. The difference between `Ember.Test.registerHelper` and
 `Ember.Test.registerAsyncHelper` is that the latter will not run until any
@@ -176,11 +176,14 @@ first parameter. Other parameters need to be provided when calling the helper. H
 Here is an example of a non-async helper:
 
 ```tests/helpers/should-have-element-with-count.js
-export default Ember.Test.registerHelper('shouldHaveElementWithCount', function(app, assert, selector, n, context) {
-  const el = findWithAssert(selector, context);
-  const count = el.length;
-  assert.equal(n, count, `found ${count} times`);
-});
+export default Ember.Test.registerHelper('shouldHaveElementWithCount',
+  function(app, assert, selector, n, context) {
+    const el = findWithAssert(selector, context);
+    const count = el.length;
+    assert.equal(n, count, `found ${count} times`);
+  }
+);
+
 // shouldHaveElementWithCount(assert, 'ul li', 3);
 ```
 

--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -3,7 +3,7 @@
 Components can be tested with integration tests using the `moduleForComponent` helper.
 
 Let's assume we have a component with a `style` property that is updated
-whenever the value for its `name` property changes. The `style` attribute of the
+whenever the value of the `name` property changes. The `style` attribute of the
 component is bound to its `style` property.
 
 > You can follow along by generating your own component with `ember generate
@@ -186,7 +186,7 @@ test('should trigger external action on form submit', function(assert) {
 ### Stubbing Services
 
 In cases where components have dependencies on Ember services, it is possible to stub these
-dependencies for integration tests. Stub Ember services by using the built-in register
+dependencies for integration tests. You stub Ember services by using the built-in `register()`
 function to register your stub service in place of the default.
 
 Imagine you have the following component that uses a location service to display the city
@@ -199,7 +199,7 @@ and country of your current location:
 export default Ember.Component.extend({
   locationService: Ember.inject.service('location-service'),
 
-  //when the coordinates change, call the location service to evaluate what the city and country would be
+  // when the coordinates change, call the location service to get the current city and country
   city: Ember.computed('locationService.currentLocation', function () {
     return this.get('locationService').getCurrentCity();
   }),

--- a/source/testing/testing-controllers.md
+++ b/source/testing/testing-controllers.md
@@ -6,8 +6,8 @@ of the ember-qunit framework.
 
 ### Testing Controller Actions
 
-Here we have a controller `PostsController` with some computed properties and an
-action `setProps`.
+Here we have a controller `PostsController` with two properties, a method that
+sets one of those properties, and an action named `setProps`.
 
 > You can follow along by generating your own controller with `ember generate
 > controller posts`.
@@ -30,8 +30,8 @@ export default Ember.Controller.extend({
 });
 ```
 
-`setProps` sets a property on the controller and also calls a method. In our 
-generated test, ember-cli already uses the `moduleFor` helper to setup a test 
+The `setProps` action directly sets one property, and calls the method to set the other.
+In our generated test, ember-cli already uses the `moduleFor` helper to set up a test
 container:
 
 ```tests/unit/controllers/posts-test.js

--- a/source/testing/testing-routes.md
+++ b/source/testing/testing-routes.md
@@ -12,7 +12,7 @@ our application. The alert function `displayAlert` should be put into the
 `ApplicationRoute` because all actions and events bubble up to it from 
 sub-routes and controllers.
 
-> By default Ember CLI does not generate a file for its application route.  To
+> By default, Ember CLI does not generate a file for its application route.  To
 > extend the behavior of the ember application route we will run the command
 > `ember generate route application`.  Ember CLI does however generate an application
 > template, so when asked whether we want to overwrite `app/templates/application.hbs`

--- a/source/testing/unit-testing-basics.md
+++ b/source/testing/unit-testing-basics.md
@@ -6,7 +6,7 @@ As it is the basic object type in Ember, being able to test a simple
 [`Ember.Object`][1] sets the foundation for testing more specific parts of your
 Ember application such as controllers, components, etc. Testing an `Ember.Object`
 is as simple as creating an instance of the object, setting its state, and
-running assertions against the object. By way of example lets look at a few
+running assertions against the object. By way of example, let's look at a few
 common cases.
 
 [1]: http://emberjs.com/api/classes/Ember.Object.html


### PR DESCRIPTION
I previously submitted two PRs for fixing guides. I hindsight I should have waited until I finished reading everything. Oh well, I finished reading everything now, and have fixed up the bits and pieces I found.

These are mostly missing commas, missing words, incorrect grammar, or wrong terminology. In a couple of cases, I changed code examples to prevent horizontal scrolling.