### PR TITLE
Reference using a serializer not a adapter in JSONSerializer section

### DIFF
--- a/source/models/customizing-serializers.md
+++ b/source/models/customizing-serializers.md
@@ -477,7 +477,7 @@ serializer that ships with Ember Data that can be used along side the
 `RESTAdapter` to serialize these simpler APIs.
 
 To use it in your application you will need to define an
-`adapter:application` that extends the `JSONSerializer`.
+`serializer:application` that extends the `JSONSerializer`.
 
 ```app/serializers/application.js
 export default DS.JSONSerializer.extend({


### PR DESCRIPTION
Customizing Serializers referenced creating a adapter instead of a serializer.