### PR TITLE
Fix duplicate reference-style links

### DIFF
--- a/source/object-model/classes-and-instances.md
+++ b/source/object-model/classes-and-instances.md
@@ -22,9 +22,9 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Ember.Component`][1] class:
+of Ember's built-in [`Ember.Component`][3] class:
 
-[1]: http://emberjs.com/api/classes/Ember.Component.html
+[3]: http://emberjs.com/api/classes/Ember.Component.html
 
 ```app/components/todo-item.js
 export default Ember.Component.extend({
@@ -66,11 +66,11 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][3] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 
-[3]: http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_normalizeResponse
+[4]: http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -84,11 +84,11 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][1] method. Any methods, properties and
+class by calling its [`create()`][5] method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[1]: http://emberjs.com/api/classes/Ember.Object.html#method_create
+[5]: http://emberjs.com/api/classes/Ember.Object.html#method_create
 
 ```javascript
 var person = Person.create();
@@ -125,11 +125,11 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][1] method is invoked
+When a new instance is created, its [`init()`][6] method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
 
-[1]: http://emberjs.com/api/classes/Ember.Object.html#method_init
+[6]: http://emberjs.com/api/classes/Ember.Object.html#method_init
 
 ```js
 Person = Ember.Object.extend({
@@ -205,11 +205,11 @@ Person.create({
 
 ### Accessing Object Properties
 
-When accessing the properties of an object, use the [`get()`][1]
-and [`set()`][2] accessor methods:
+When accessing the properties of an object, use the [`get()`][7]
+and [`set()`][8] accessor methods:
 
-[1]: http://emberjs.com/api/classes/Ember.Object.html#method_get
-[2]: http://emberjs.com/api/classes/Ember.Object.html#method_set
+[7]: http://emberjs.com/api/classes/Ember.Object.html#method_get
+[8]: http://emberjs.com/api/classes/Ember.Object.html#method_set
 
 ```js
 var person = Person.create();


### PR DESCRIPTION
Links on the page https://guides.emberjs.com/v2.3.0/object-model/classes-and-instances/ point to wrong sections of the api doc.