### PR TITLE
`cursor:pointer` shouldn't hit `disabled` elements

### DIFF
--- a/source/localizable/templates/actions.md
+++ b/source/localizable/templates/actions.md
@@ -154,7 +154,7 @@ elements, a CSS workaround exists to make them clickable, `cursor: pointer`.
 For example:
 
 ```css
-[data-ember-action] {
+[data-ember-action]:not(:disabled) {
   cursor: pointer;
 }
 ```


### PR DESCRIPTION
`cursor: pointer` is a mixed bag: on the one hand it can enable otherwise unavailable click handler functionality on certain elements; on the other, it forces a pointer cursor regardless of other factors that might disable this functionality.

Given the blanket `[data-ember-action]` selector, `<button>`s, for instance, will retain a pointer cursor even when they are `disabled`.

This qualification guards against that.