### PR TITLE
a11y related tweaks to Templates -> Actions page

### DIFF
--- a/source/localizable/templates/actions.md
+++ b/source/localizable/templates/actions.md
@@ -4,11 +4,11 @@ that shows a blog title, and supports expanding the post to show the body.
 
 If you add the
 [`{{action}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_action)
-helper to an HTML element, when a user clicks the element, the named event
+helper to any HTML DOM element, when a user clicks the element, the named event
 will be sent to the template's corresponding component or controller.
 
 ```app/templates/components/single-post.hbs
-<h3 {{action "toggleBody"}}>{{title}}</h3>
+<h3><button {{action "toggleBody"}}>{{title}}</button></h3>
 {{#if isShowingBody}}
   <p>{{{body}}}</p>
 {{/if}}
@@ -158,3 +158,5 @@ For example:
   cursor: pointer;
 }
 ```
+
+Keep in mind that even with this workaround in place, the `click` event will not automatically trigger via keyboard driven `click` equivalents (such as the `enter` key when focused). Browsers will trigger this on clickable elements only by default.


### PR DESCRIPTION
Hello! :wave: 

The first example on the Actions page contains an accessibility anti-pattern. Specifically, placing the `action` on the `<h3>`. While the example is really effective at communicating "you can place an action on any DOM element" (which is powerful), I'd love to see the code snippet set a better example for good accessibility standards. It also doesn't strictly work as intended.

**So what's the accessibility problem, anyway?**

A couple of things: 

1. The heading on its own is not focusable without adding a `tabindex` property. 

2. Even when focusable, essentially only users utilizing a mouse can activate the `click` event and subsequent `toggleBody` action, whereas keyboard equivalents that normally also trigger the same `click` event will not work. 

The above issues break the default browser behaviour, which is why sticking to 'clickable' elements is best for a correctly working example. See this [additional information](http://webaim.org/techniques/javascript/eventhandlers#onclick) if curious to know more.

I created a [jsbin prototype](http://jsbin.com/riyoyo/edit?html,js,console,output) to illustrate exactly what I mean.

I also proposed a clarification warning of this within the "'Non-Clickable' Elements" section at the bottom.

Thanks! :grin: 