### PR TITLE
Update autocomplete-component.md

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -109,7 +109,7 @@ export default Ember.Controller.extend({
           this.set('filteredList',result);
         });
       } else {
-        this.set('filteredList');
+        this.get('filteredList').clear();
       }
     },
     search(param) {
@@ -118,7 +118,7 @@ export default Ember.Controller.extend({
           this.set('model',result);
         });
       } else {
-        this.set('model');
+        this.get('model').clear();
       }
     }
   }

--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -109,7 +109,7 @@ export default Ember.Controller.extend({
           this.set('filteredList',result);
         });
       } else {
-        this.set('filteredList').clear();
+        this.set('filteredList');
       }
     },
     search(param) {
@@ -118,7 +118,7 @@ export default Ember.Controller.extend({
           this.set('model',result);
         });
       } else {
-        this.set('model').clear();
+        this.set('model');
       }
     }
   }


### PR DESCRIPTION
There was an issue with calling `clear()` on the result of `this.set(...)`. It's possible the intention here was to use `this.get(...).clear()`, but for me getting rid of `clear()` resulted in better behavior in the example.