### PR TITLE
fix js object typos

### DIFF
--- a/source/localizable/templates/displaying-a-list-of-items.ja-JP.md
+++ b/source/localizable/templates/displaying-a-list-of-items.ja-JP.md
@@ -17,9 +17,9 @@ The template inside of the `{{#each}}` block will be repeated once for each item
 Given an input array like:
 
 ```js
-[ {name: 'Yehuda'},
-  {name: 'Tom'   },
-  {name: 'Trek'  } ]
+[ { name: 'Yehuda' },
+  { name: 'Tom' },
+  { name: 'Trek' } ]
 ```
 
 The above template will render HTML like this:

--- a/source/localizable/templates/displaying-a-list-of-items.md
+++ b/source/localizable/templates/displaying-a-list-of-items.md
@@ -25,9 +25,9 @@ each item in the array, with the each item set to the `person` block param.
 Given an input array like:
 
 ```js
-[ {name: 'Yehuda'},
-  {name: 'Tom'   },
-  {name: 'Trek'  } ]
+[ { name: 'Yehuda' },
+  { name: 'Tom' },
+  { name: 'Trek' } ]
 ```
 
 The above template will render HTML like this:

--- a/source/localizable/templates/displaying-a-list-of-items.pt-BR.md
+++ b/source/localizable/templates/displaying-a-list-of-items.pt-BR.md
@@ -17,9 +17,9 @@ The template inside of the `{{#each}}` block will be repeated once for each item
 Given an input array like:
 
 ```js
-[ {name: 'Yehuda'},
-  {name: 'Tom'   },
-  {name: 'Trek'  } ]
+[ { name: 'Yehuda' },
+  { name: 'Tom' },
+  { name: 'Trek' } ]
 ```
 
 The above template will render HTML like this:

--- a/source/localizable/templates/displaying-a-list-of-items.zh-CN.md
+++ b/source/localizable/templates/displaying-a-list-of-items.zh-CN.md
@@ -17,9 +17,9 @@ The template inside of the `{{#each}}` block will be repeated once for each item
 Given an input array like:
 
 ```js
-[ {name: 'Yehuda'},
-  {name: 'Tom'   },
-  {name: 'Trek'  } ]
+[ { name: 'Yehuda' },
+  { name: 'Tom' },
+  { name: 'Trek' } ]
 ```
 
 The above template will render HTML like this:


### PR DESCRIPTION
This PR just fixes up some of JS Object syntax typos.

For example, `{key: value}` should be `{ key: value }`.