### PR TITLE
Ignores translated files during build

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -5,6 +5,8 @@ require 'support-for'
 
 Dir['./lib/*'].each { |f| require f }
 
+ignore /[a-z]{2}-[A-Z]{2}$/
+
 # Debugging
 set(:logging, ENV['RACK_ENV'] != 'production')
 


### PR DESCRIPTION
Translated files have a problem with code blocks. They lose the closing
backticks of code blocks, rendering the project unbuildable.
Ignoring those files is a necessary temporary measure while we sort the
actual problem and continue working on the translations themselves.