### PR TITLE
Update ember-cli.md with `const` instead of `var`

### DIFF
--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -103,7 +103,7 @@ For example, the line `import Ember from 'ember';` gives us access to the actual
 Ember.js library as the variable `Ember`. And the `import config from
 './config/environment';` line gives us access to our app's configuration data
 as the variable `config`. `const` is a way to declare a read-only variable, 
-as to make sure it is not accidently reassigned elsewhere. At the end of the file,
+as to make sure it is not accidentally reassigned elsewhere. At the end of the file,
 `export default Router;` makes the `Router` variable defined in this file available 
 to other parts of the app.
 

--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -87,7 +87,7 @@ unfamiliar to you.
 import Ember from 'ember';
 import config from './config/environment';
 
-var Router = Ember.Router.extend({
+const Router = Ember.Router.extend({
   location: config.locationType
 });
 
@@ -102,9 +102,10 @@ code.
 For example, the line `import Ember from 'ember';` gives us access to the actual
 Ember.js library as the variable `Ember`. And the `import config from
 './config/environment';` line gives us access to our app's configuration data
-as the variable `config`. At the end of the file, `export default Router;
-` makes the `Router` variable defined in this file available to other parts
-of the app.
+as the variable `config`. `const` is a way to declare a read-only variable, 
+as to make sure it is not accidently reassigned elsewhere. At the end of the file,
+`export default Router;` makes the `Router` variable defined in this file available 
+to other parts of the app.
 
 ## Upgrading Ember
 


### PR DESCRIPTION
Teaching myself Ember and wanted to update the example with `const` instead of `var`. Added a quick description on `const` in case the reader was unfamiliar with ES2015.