### PR TITLE
Example code using component contains old (duplicate) code

### DIFF
--- a/source/localizable/getting-started/quick-start.md
+++ b/source/localizable/getting-started/quick-start.md
@@ -211,13 +211,6 @@ curly braces (`{{component}}`). We're going to tell our component:
    provide this route's `model` as the list of people.
 
 ```app/templates/scientists.hbs{-1,-2,-3,-4,-5,-6,-7,+8}
-<h2>List of Scientists</h2>
-
-<ul>
-  {{#each model as |scientist|}}
-    <li>{{scientist}}</li>
-  {{/each}}
-</ul>
 {{people-list title="List of Scientists" people=model}}
 ```
 


### PR DESCRIPTION
The text says: 
Replace all our old code with our new componentized version.

But the example code contains the old (original) code and the component, which would show up duplicated.