### PR TITLE
Fix reference-style links

### DIFF
--- a/source/localizable/object-model/bindings.md
+++ b/source/localizable/object-model/bindings.md
@@ -3,10 +3,8 @@ bindings in Ember.js can be used with any object. That said, bindings are most
 often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`][1],
+The easiest way to create a two-way binding is to use a [`computed.alias()`](http://emberjs.com/api/classes/Ember.computed.html#method_alias),
 that specifies the path to another object.
-
-[1]: http://emberjs.com/api/classes/Ember.computed.html#method_alias
 
 ```javascript
 wife = Ember.Object.create({
@@ -36,14 +34,12 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`][1]. Often, one-way bindings are a performance 
+[`computed.oneWay()`](http://emberjs.com/api/classes/Ember.computed.html#method_oneWay). Often, one-way bindings are a performance 
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behaviour such as a
 default that is the same as another property but can be overridden (e.g. a
 shipping address that starts the same as a billing address but can later be 
 changed)
-
-[1]: http://emberjs.com/api/classes/Ember.computed.html#method_oneWay
 
 ```javascript
 user = Ember.Object.create({

--- a/source/localizable/object-model/enumerables.md
+++ b/source/localizable/object-model/enumerables.md
@@ -50,10 +50,9 @@ reference documentation.](http://emberjs.com/api/classes/Ember.Enumerable.html)
 
 ### Iterating Over an Enumerable
 
-To enumerate all the values of an enumerable object, use the [`forEach()`][1]
+To enumerate all the values of an enumerable object, use the [`forEach()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_forEach)
 method:
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_forEach
 
 ```javascript
 var food = ['Poi', 'Ono', 'Adobo Chicken'];
@@ -69,11 +68,10 @@ food.forEach(function(item, index) {
 
 ### First and Last Objects
 
-All enumerables expose [`firstObject`][1] and [`lastObject`][2] properties
+All enumerables expose [`firstObject`](http://emberjs.com/api/classes/Ember.Enumerable.html#property_firstObject) and [`lastObject`](http://emberjs.com/api/classes/Ember.Enumerable.html#property_lastObject) properties
 that you can bind to.
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#property_firstObject
-[2]: http://emberjs.com/api/classes/Ember.Enumerable.html#property_lastObject
+
 
 ```javascript
 var animals = ['rooster', 'pig'];
@@ -90,10 +88,9 @@ animals.get('lastObject');
 ### Map
 
 You can easily transform each item in an enumerable using the
-[`map()`][1] method, which creates a new array with results of calling a
+[`map()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_map) method, which creates a new array with results of calling a
 function on each item in the enumerable.
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_map
 
 ```javascript
 var words = ['goodbye', 'cruel', 'world'];
@@ -104,11 +101,10 @@ var emphaticWords = words.map(function(item) {
 // ["goodbye!", "cruel!", "world!"]
 ```
 
-If your enumerable is composed of objects, there is a [`mapBy()`][1]
+If your enumerable is composed of objects, there is a [`mapBy()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_mapBy)
 method that will extract the named property from each of those objects
 in turn and return a new array:
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_mapBy
 
 ```javascript
 var hawaii = Ember.Object.create({
@@ -131,11 +127,10 @@ Another common task to perform on an enumerable is to take the
 enumerable as input, and return an Array after filtering it based on
 some criteria.
 
-For arbitrary filtering, use the [`filter()`][1] method.  The filter method
+For arbitrary filtering, use the [`filter()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_filter) method.  The filter method
 expects the callback to return `true` if Ember should include it in the
 final Array, and `false` or `undefined` if Ember should not.
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_filter
 
 ```javascript
 var arr = [1,2,3,4,5];
@@ -147,9 +142,8 @@ arr.filter(function(item, index, self) {
 // returns [1,2,3]
 ```
 
-When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`][1] method provides a shortcut.
+When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_filterBy) method provides a shortcut.
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_filterBy
 
 ```javascript
 Todo = Ember.Object.extend({
@@ -168,18 +162,15 @@ todos.filterBy('isDone', true);
 ```
 
 If you only want to return the first matched value, rather than an Array
-containing all of the matched values, you can use [`find()`][1] and [`findBy()`][2],
+containing all of the matched values, you can use [`find()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_find) and [`findBy()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_findBy),
 which work like `filter()` and `filterBy()`, but return only one item.
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_find
-[2]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_findBy
 
 ### Aggregate Information (Every or Any)
 
 To find out whether every item in an enumerable matches some condition, you can
-use the [`every()`][1] method:
+use the [`every()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_every) method:
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_every
 
 ```javascript
 Person = Ember.Object.extend({
@@ -200,9 +191,8 @@ people.every(function(person, index, self) {
 ```
 
 To find out whether at least one item in an enumerable matches some condition,
-you can use the [`any()`][1] method:
+you can use the [`any()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_any) method:
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html#method_any
 
 ```javascript
 people.any(function(person, index, self) {

--- a/source/localizable/object-model/observers.md
+++ b/source/localizable/object-model/observers.md
@@ -70,11 +70,10 @@ person.set('firstName', 'John');
 person.set('lastName', 'Smith');
 ```
 
-To get around these problems, you should make use of [`Ember.run.once()`][1].
+To get around these problems, you should make use of [`Ember.run.once()`](http://emberjs.com/api/classes/Ember.run.html#method_once).
 This will ensure that any processing you need to do only happens once, and
 happens in the next run loop once all bindings are synchronized:
 
-[1]: http://emberjs.com/api/classes/Ember.run.html#method_once
 
 ```javascript
 Person.reopen({
@@ -99,9 +98,8 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`][1]:
+should also run after `init` by using [`Ember.on()`](http://emberjs.com/api/classes/Ember.html#method_on):
 
-[1]: http://emberjs.com/api/classes/Ember.html#method_on
 
 ```javascript
 Person = Ember.Object.extend({
@@ -132,9 +130,8 @@ get it in your `init()` method.
 ### Outside of class definitions
 
 You can also add observers to an object outside of a class definition
-using [`addObserver()`][1]:
+using [`addObserver()`](http://emberjs.com/api/classes/Ember.Object.html#method_addObserver):
 
-[1]: http://emberjs.com/api/classes/Ember.Object.html#method_addObserver
 
 ```javascript
 person.addObserver('fullName', function() {

--- a/source/localizable/routing/asynchronous-routing.md
+++ b/source/localizable/routing/asynchronous-routing.md
@@ -8,14 +8,13 @@ heavy use of the concept of Promises. In short, promises are objects that
 represent an eventual value. A promise can either _fulfill_
 (successfully resolve the value) or _reject_ (fail to resolve the
 value). The way to retrieve this eventual value, or handle the cases
-when the promise rejects, is via the promise's [`then()`][1] method, which
+when the promise rejects, is via the promise's [`then()`](http://emberjs.com/api/classes/RSVP.Promise.html#method_then) method, which
 accepts two optional callbacks, one for fulfillment and one for
 rejection. If the promise fulfills, the fulfillment handler gets called
 with the fulfilled value as its sole argument, and if the promise rejects,
 the rejection handler gets called with a reason for the rejection as its
 sole argument. For example:
 
-[1]: http://emberjs.com/api/classes/RSVP.Promise.html#method_then
 
 ```js
 var promise = fetchTheAnswer();
@@ -75,10 +74,9 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`][1] hook for each route
+resolved. The values passed to the [`setupController()`](http://emberjs.com/api/classes/Ember.Route.html#method_setupController) hook for each route
 will be the fulfilled values from the promises.
 
-[1]: http://emberjs.com/api/classes/Ember.Route.html#method_setupController
 
 A basic example:
 


### PR DESCRIPTION
Links on the following pages point to wrong sections of the api doc:
https://guides.emberjs.com/v2.3.0/object-model/bindings/
https://guides.emberjs.com/v2.3.0/object-model/enumerables/
https://guides.emberjs.com/v2.3.0/object-model/observers/
https://guides.emberjs.com/v2.3.0/routing/asynchronous-routing/
