### PR TITLE
Fixed typo in Services guide

### DIFF
--- a/source/localizable/applications/services.md
+++ b/source/localizable/applications/services.md
@@ -90,7 +90,7 @@ Therefore you need to access services in your component using the `get` function
 
 Once loaded, a service will persist until the application exits.
 
-Below we add a remove action to the `cart-contacts` component.
+Below we add a remove action to the `cart-contents` component.
 Notice that below we access the `cart` service with a call to`this.get`.
 
 ```app/components/cart-contents.js


### PR DESCRIPTION
In the Services section of Application Concerns - Accessing Services, there seems to be a typo wherein instead of referring to a component named _**cart-contents**_ it refers to _**cart-contacts**_...