### PR TITLE
Replaced second observer

### DIFF
--- a/source/localizable/object-model/observers.md
+++ b/source/localizable/object-model/observers.md
@@ -81,11 +81,11 @@ Person.reopen({
     Ember.run.once(this, 'processFullName');
   }),
 
-  processFullName: Ember.observer('fullName', function() {
+  processFullName() {
     // This will only fire once if you set two properties at the same time, and
     // will also happen in the next run loop once all properties are synchronized
     console.log(this.get('fullName'));
-  })
+  }
 });
 
 person.set('firstName', 'John');


### PR DESCRIPTION
According to my testing, looks like the `processFullName` was called three-times (on modification of `firstname`, `lastName` and by `Ember.run.once(this, 'processFullName')`), not as expected by the surrounding text. 

Maybe author meant something like what I propose?