### PR TITLE
Replace usages of testem.json with testem.js

### DIFF
--- a/source/localizable/testing/index.de-DE.md
+++ b/source/localizable/testing/index.de-DE.md
@@ -48,4 +48,4 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 
 Tests can also be executed when you are running a local development server (started by running `ember server`), at the `/tests` URI which renders the `tests/index.html` template. A word of caution using this approach: Tests run using `ember server` have the environment configuration `development`, whereas tests executed under `ember test --server` are run with the configuration `test`. This could cause differences in execution, such as which libraries are loaded and available. Therefore its recommended that you use `ember test --server` for test execution.
 
-These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.json` file in your application root.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.js` file in your application root.

--- a/source/localizable/testing/index.es-ES.md
+++ b/source/localizable/testing/index.es-ES.md
@@ -48,4 +48,4 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 
 Tests can also be executed when you are running a local development server (started by running `ember server`), at the `/tests` URI which renders the `tests/index.html` template. A word of caution using this approach: Tests run using `ember server` have the environment configuration `development`, whereas tests executed under `ember test --server` are run with the configuration `test`. This could cause differences in execution, such as which libraries are loaded and available. Therefore its recommended that you use `ember test --server` for test execution.
 
-These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.json` file in your application root.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.js` file in your application root.

--- a/source/localizable/testing/index.ja-JP.md
+++ b/source/localizable/testing/index.ja-JP.md
@@ -48,4 +48,4 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 
 Tests can also be executed when you are running a local development server (started by running `ember server`), at the `/tests` URI which renders the `tests/index.html` template. A word of caution using this approach: Tests run using `ember server` have the environment configuration `development`, whereas tests executed under `ember test --server` are run with the configuration `test`. This could cause differences in execution, such as which libraries are loaded and available. Therefore its recommended that you use `ember test --server` for test execution.
 
-These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.json` file in your application root.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.js` file in your application root.

--- a/source/localizable/testing/index.md
+++ b/source/localizable/testing/index.md
@@ -67,7 +67,7 @@ Tests can also be executed when you are running a local development server (star
 A word of caution using this approach:
 Tests run using `ember server` have the environment configuration `development`, whereas tests executed under `ember test --server` are run with the configuration `test`.  This could cause differences in execution, such as which libraries are loaded and available.  Therefore its recommended that you use `ember test --server` for test execution.
 
-These commands run your tests using [Testem] to make testing multiple browsers very easy. You can configure Testem using the `testem.json` file in your application root.
+These commands run your tests using [Testem] to make testing multiple browsers very easy. You can configure Testem using the `testem.js` file in your application root.
 
 [automated tests]: http://en.wikipedia.org/wiki/Test_automation
 [QUnit]: http://qunitjs.com/

--- a/source/localizable/testing/index.pt-BR.md
+++ b/source/localizable/testing/index.pt-BR.md
@@ -48,4 +48,4 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 
 Tests can also be executed when you are running a local development server (started by running `ember server`), at the `/tests` URI which renders the `tests/index.html` template. A word of caution using this approach: Tests run using `ember server` have the environment configuration `development`, whereas tests executed under `ember test --server` are run with the configuration `test`. This could cause differences in execution, such as which libraries are loaded and available. Therefore its recommended that you use `ember test --server` for test execution.
 
-These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.json` file in your application root.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.js` file in your application root.

--- a/source/localizable/testing/index.zh-CN.md
+++ b/source/localizable/testing/index.zh-CN.md
@@ -48,4 +48,4 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 
 Tests can also be executed when you are running a local development server (started by running `ember server`), at the `/tests` URI which renders the `tests/index.html` template. A word of caution using this approach: Tests run using `ember server` have the environment configuration `development`, whereas tests executed under `ember test --server` are run with the configuration `test`. This could cause differences in execution, such as which libraries are loaded and available. Therefore its recommended that you use `ember test --server` for test execution.
 
-These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.json` file in your application root.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy. You can configure Testem using the `testem.js` file in your application root.

--- a/source/localizable/tutorial/ember-cli.de-DE.md
+++ b/source/localizable/tutorial/ember-cli.de-DE.md
@@ -27,7 +27,7 @@ bower.json
 ember-cli-build.js
 package.json
 README.md
-testem.json
+testem.js
 ```
 
 Let's take a look at the folders and files Ember CLI generates.
@@ -46,7 +46,7 @@ Let's take a look at the folders and files Ember CLI generates.
 
 **vendor**: This directory is where front-end dependencies (such as JavaScript or CSS) that are not managed by Bower go.
 
-**tests / testem.json**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.json`.
+**tests / testem.js**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.js`.
 
 **tmp**: Ember CLI temporary files live here.
 

--- a/source/localizable/tutorial/ember-cli.es-ES.md
+++ b/source/localizable/tutorial/ember-cli.es-ES.md
@@ -27,7 +27,7 @@ bower.json
 ember-cli-build.js
 package.json
 README.md
-testem.json
+testem.js
 ```
 
 Let's take a look at the folders and files Ember CLI generates.
@@ -46,7 +46,7 @@ Let's take a look at the folders and files Ember CLI generates.
 
 **vendor**: This directory is where front-end dependencies (such as JavaScript or CSS) that are not managed by Bower go.
 
-**tests / testem.json**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.json`.
+**tests / testem.js**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.js`.
 
 **tmp**: Ember CLI temporary files live here.
 

--- a/source/localizable/tutorial/ember-cli.ja-JP.md
+++ b/source/localizable/tutorial/ember-cli.ja-JP.md
@@ -27,7 +27,7 @@ bower.json
 ember-cli-build.js
 package.json
 README.md
-testem.json
+testem.js
 ```
 
 Ember CLI が作成した、ファイルとディレクトリを確認してみましょう。
@@ -46,7 +46,7 @@ Ember CLI が作成した、ファイルとディレクトリを確認してみ�
 
 **vendor**: このディレクトリはBower によって管理されていないフロント エンド (JavaScript、CSS など) の依存関係が行きます。
 
-**tests / testem.json**: アプリケーションの自動テストファイルは、`tests` フォルダーに、`testem.json` にはEmber CLI のテスト ランナー **testem** の設定ファイルがあります。.
+**tests / testem.js**: アプリケーションの自動テストファイルは、`tests` フォルダーに、`testem.js` にはEmber CLI のテスト ランナー **testem** の設定ファイルがあります。.
 
 **tmp**: Ember CLI の一時ファイルはここにあります。
 

--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -35,7 +35,7 @@ bower.json
 ember-cli-build.js
 package.json
 README.md
-testem.json
+testem.js
 ```
 
 Let's take a look at the folders and files Ember CLI generates.
@@ -71,8 +71,8 @@ are installed in the node_modules directory.
 **vendor**: This directory is where front-end dependencies (such as JavaScript
 or CSS) that are not managed by Bower go.
 
-**tests / testem.json**: Automated tests for our app go in the `tests` folder,
-and Ember CLI's test runner **testem** is configured in `testem.json`.
+**tests / testem.js**: Automated tests for our app go in the `tests` folder,
+and Ember CLI's test runner **testem** is configured in `testem.js`.
 
 **tmp**: Ember CLI temporary files live here.
 

--- a/source/localizable/tutorial/ember-cli.pt-BR.md
+++ b/source/localizable/tutorial/ember-cli.pt-BR.md
@@ -27,7 +27,7 @@ bower.json
 ember-cli-build.js
 package.json
 README.md
-testem.json
+testem.js
 ```
 
 Let's take a look at the folders and files Ember CLI generates.
@@ -46,7 +46,7 @@ Let's take a look at the folders and files Ember CLI generates.
 
 **vendor**: This directory is where front-end dependencies (such as JavaScript or CSS) that are not managed by Bower go.
 
-**tests / testem.json**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.json`.
+**tests / testem.js**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.js`.
 
 **tmp**: Ember CLI temporary files live here.
 

--- a/source/localizable/tutorial/ember-cli.zh-CN.md
+++ b/source/localizable/tutorial/ember-cli.zh-CN.md
@@ -27,7 +27,7 @@ bower.json
 ember-cli-build.js
 package.json
 README.md
-testem.json
+testem.js
 ```
 
 Let's take a look at the folders and files Ember CLI generates.
@@ -46,7 +46,7 @@ Let's take a look at the folders and files Ember CLI generates.
 
 **vendor**: This directory is where front-end dependencies (such as JavaScript or CSS) that are not managed by Bower go.
 
-**tests / testem.json**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.json`.
+**tests / testem.js**: Automated tests for our app go in the `tests` folder, and Ember CLI's test runner **testem** is configured in `testem.js`.
 
 **tmp**: Ember CLI temporary files live here.
 


### PR DESCRIPTION
The ember 2.4 guides still have references to testem.json, even though this file was replaced with testem.js. This replaces the usages of testem.json with testem.js.