### PR TITLE
Add survey reminder bar under the main header

### DIFF
--- a/source/_survey-reminder.erb
+++ b/source/_survey-reminder.erb
@@ -1,0 +1,7 @@
+<div class="survey-reminder-wrapper">
+  <div class="survey-reminder-container">
+    Only <strong>4 days left</strong> to
+    <% link_to 'http://emberjs.com/ember-community-survey-2016/' do %>
+      submit your community survey&nbsp;response<% end %>&nbsp;!
+  </div>
+</div>

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -29,6 +29,7 @@
 
     <%= partial "header" %>
 
+    <%= partial "survey-reminder" %>
 
     <%= yield_content :outside_wrapper %>
 

--- a/source/stylesheets/components/_all.scss
+++ b/source/stylesheets/components/_all.scss
@@ -6,4 +6,5 @@
 @import "back-to-top";
 @import "highlight";
 @import "toc";
-@import "old-version-warning"
+@import "old-version-warning";
+@import "survey-reminder";

--- a/source/stylesheets/components/_survey-reminder.scss
+++ b/source/stylesheets/components/_survey-reminder.scss
@@ -1,0 +1,22 @@
+.survey-reminder-wrapper {
+  background: white;
+  color: $ember-orange;
+  text-align: center;
+  line-height: 2.2;
+  font-size: 0.8rem;
+  border-bottom: 1px solid #e5dbd6;
+  a {
+    border-bottom: 1px dotted #f23818;
+  }
+}
+
+.survey-reminder-container {
+  width: inherit;
+  line-height: 1.5;
+  padding: 0.8rem 1rem;
+
+  @include media($large-screen) {
+    line-height: 2.2;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
This relates to: https://github.com/emberjs/website/pull/2503

Preview Large Screen:
![ember_js_-_tutorial__creating_a_new_app_and_1__tmux](https://cloud.githubusercontent.com/assets/1318878/13885003/7db23bd0-ecfe-11e5-9674-deb9173b3ae8.jpg)

Preview Mobile:
![ember_js_-_tutorial__creating_a_new_app_and_slack](https://cloud.githubusercontent.com/assets/1318878/13885008/83dd88de-ecfe-11e5-9c12-aa00c40ded08.jpg)

Notes:
https://github.com/emberjs/guides/compare/master...ryanlabouve:survey-reminder?expand=1#diff-dd5ceb3941961ed4ab0ee3cff3c01cfdR5
I know this looks like poor style, but the `&nbsp;`'s keep there from being typographic orphans at some widths (i.e. never one rando thing floating on next line)