### PR TITLE
Typo: Use get instead of set

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -109,7 +109,7 @@ export default Ember.Controller.extend({
           this.set('filteredList',result);
         });
       } else {
-        this.set('filteredList').clear();
+        this.get('filteredList').clear();
       }
     },
     search(param) {
@@ -118,7 +118,7 @@ export default Ember.Controller.extend({
           this.set('model',result);
         });
       } else {
-        this.set('model').clear();
+        this.get('model').clear();
       }
     }
   }


### PR DESCRIPTION
Disclaimer: I'm new to Ember.

In the line `this.set('filteredList').clear();`, `this.set('filteredList')` returns `undefined`, so `clear()` crashes.

Similarly, I've updated `this.set('model').clear();`.