### PR TITLE
Add brace expansion to computed properties

### DIFF
--- a/source/localizable/object-model/computed-properties.md
+++ b/source/localizable/object-model/computed-properties.md
@@ -31,6 +31,20 @@ This declares the function to be a computed property, and the arguments tell Emb
 
 Whenever you access the `fullName` property, this function gets called, and it returns the value of the function, which simply calls `firstName` + `lastName`.
 
+When you want to depend on a property which belongs to an object, you can setup multiple dependent keys by using brace expansion:
+
+```javascript
+var obj = Ember.Object.extend({
+  baz: {foo: 'BLAMMO', bar: 'BLAZORZ'},
+
+  something: Ember.computed('baz.{foo, bar}') {
+    return this.get('baz.foo') + ' ' + this.get('baz.bar');
+  }
+```
+
+This allows you to observe both `foo` and `bar` on `baz` with much less duplication/redundancy
+when your dependent keys are mostly similar.
+
 ### Chaining computed properties
 
 You can use computed properties as values to create new computed properties. Let's add a `description` computed property to the previous example, and use the existing `fullName` property and add in some other properties:


### PR DESCRIPTION
Fixes https://github.com/emberjs/guides/issues/1340
Takes [description of property brace expansion](http://emberjs.com/blog/2014/02/12/ember-1-4-0-and-ember-1-5-0-beta-released.html#toc_property-brace-expansion) and adds to the guides.

<img width="708" alt="screen shot 2016-03-28 at 12 29 47 pm" src="https://cloud.githubusercontent.com/assets/4362696/14087836/ca0616b6-f4e0-11e5-83a0-14ca2b7c73a0.png">
