### PR TITLE
Fix missing header for "View all registered templates"

### DIFF
--- a/source/localizable/configuring-ember/debugging.md
+++ b/source/localizable/configuring-ember/debugging.md
@@ -24,7 +24,7 @@ export default Ember.Application.extend({
 ```config/environment.js
 ENV.APP.LOG_VIEW_LOOKUPS = true;
 ```
-
+#### View all registered templates
 ```javascript
 Ember.keys(Ember.TEMPLATES)
 ```


### PR DESCRIPTION
This header was present in in the documentation for 1.10 but was somehow lost along the way. 