### PR TITLE
Update list of repositories used by Ember.js

### DIFF
--- a/data/spelling-exceptions.txt
+++ b/data/spelling-exceptions.txt
@@ -1,6 +1,7 @@
 accessor
 actionhttp
 activesupport
+acyclic
 addon
 addons
 ajax
@@ -282,3 +283,4 @@ transpiles
 transpiling
 internet
 plugin
+krisselden

--- a/source/localizable/components/block-params.md
+++ b/source/localizable/components/block-params.md
@@ -19,7 +19,7 @@ but anything that the component has access to can be yielded, such as an interna
 ### Consuming yielded values with block params
 
 The block expression can then use block params to bind names to any yielded values for use in the block.
-This allows for template customisation when using a component,
+This allows for template customization when using a component,
 where the markup is provided by the consuming template,
 but any event handling behavior implemented in the component is retained such as `click()` handlers.
 

--- a/source/localizable/contributing/repositories.md
+++ b/source/localizable/contributing/repositories.md
@@ -19,30 +19,40 @@ Ember is made up of several libraries. If you wish to add a feature or fix a bug
 
 # Libraries Used By Ember
 
-These libraries are part of the Ember.js source, but development of them takes place in a separate repository.
+These libraries are part of the Ember.js asset output, but development of them takes place in a separate repository.
 
-## `packages/ember-metal/lib/vendor/backburner.js`
+## `Backburner`
 * **backburner.js** - Implements the Ember run loop.
 * [https://github.com/ebryn/backburner.js](https://github.com/ebryn/backburner.js)
 
+## `DAG Map`
+* **dag-map** - A directed acyclic graph data structure for javascript
+* [https://github.com/krisselden/dag-map](https://github.com/krisselden/dag-map)
 
-## `packages/ember-routing/lib/vendor/route-recognizer.js`
+## `Glimmer 2`
+* **glimmer** - Implements the really fast rendering engine now included in Ember.js
+* [https://github.com/tildeio/glimmer](https://github.com/tildeio/glimmer)
 
-* **route-recognizer.js** - A lightweight JavaScript library that matches paths against registered routes.
+## `HTMLBars`
+* **htmlbars** - The syntax for templating most often used with Ember.js
+* [https://github.com/tildeio/htmlbars](https://github.com/tildeio/htmlbars)
+
+## `morph-range`
+
+* **morph-range** - Used by Ember for manipulating the text nodes known as morphs which are created for HTMLBars to keep track of text that could change.
+* [https://github.com/krisselden/morph-range](https://github.com/krisselden/morph-range)
+
+## `Route Recognizer`
+
+* **route-recognizer** - A lightweight JavaScript library that matches paths against registered routes.
 * [https://github.com/tildeio/route-recognizer](https://github.com/tildeio/route-recognizer)
 
-## `packages/ember-routing/lib/vendor/router.js`
+## `router.js`
 
 * **router.js** - A lightweight JavaScript library that builds on route-recognizer and rsvp to provide an API for handling routes.
 * [https://github.com/tildeio/router.js](https://github.com/tildeio/router.js)
 
-## `packages/metamorph`
+## `RSVP`
 
-* **Metamorph.js** - Used by Ember for databinding handlebars templates
-* [https://github.com/tomhuda/metamorph.js](https://github.com/tomhuda/metamorph.js)
-
-
-## `packages/rsvp`
-
-* **RSVP.js** - Implementation of the of Promises/A+ spec used by Ember.
+* **rsvp.js** - Implementation of the of Promises/A+ spec used by Ember.
 * [https://github.com/tildeio/rsvp.js](https://github.com/tildeio/rsvp.js)


### PR DESCRIPTION
Note: This list used to contain libraries included in ember.js source. No libraries are vendored this way any more. I have changed this to a list of libraries included in the asset output along with ember core. That is, libraries whose modules appear in ember-debug.js