### PR TITLE
Makes TOC links Easier to Click

### DIFF
--- a/source/stylesheets/components/_toc.scss
+++ b/source/stylesheets/components/_toc.scss
@@ -1,5 +1,7 @@
 .anchorable-toc {
   position: relative;
+  margin-left: -22px;
+  padding-left: 22px;
 
   &:hover a.toc-anchor {
     display: block;
@@ -11,14 +13,12 @@ a.toc-anchor {
   position: absolute;
   text-decoration: none;
   border: none;
-  left: -1em;
   width: 30px;
   height: 13px;
   background: url('../images/link.png') no-repeat;
   background-size: 18px 9px;
-  left: -22px;
+  left: 0;
   opacity: 0.5;
   top: 50%;
   margin-top: -5px;
 }
-


### PR DESCRIPTION
Currently the TOC links are position absolute and only appear when the parent is hovered.
While this is fine, the issue is that the link is hard to trigger showing up and quite easy to miss and hover away from.

This PR fixes this by making the surrounding header element have padding on the left under the anchor tag, so that the full height of the element is available.