### PR TITLE
Improve code highlighting typography

### DIFF
--- a/source/stylesheets/components/_highlight.scss
+++ b/source/stylesheets/components/_highlight.scss
@@ -35,6 +35,8 @@
   pre {
     margin: 0;
     font-size: 1.2em;
+    font-family: inherit;
+    @include font-feature-settings("kern", "tnum");
   }
 
   table {


### PR DESCRIPTION
- Don't let user agent stylesheet `pre` override fonts set in `.highlight`
- Don't use ligatures in code samples.

### Before
Note the "fi" and "ff" ligatures in "first-name" and "Jeff Atwood" respectively, and the small type size.

![before](https://cloud.githubusercontent.com/assets/2403023/14504999/39edaf06-0185-11e6-8636-7c166deb3fa4.png)

### After
The text is sized properly, and without ligatures.

![after](https://cloud.githubusercontent.com/assets/2403023/14505003/3dcda87e-0185-11e6-976c-eea3ad364c08.png)
