### PR TITLE
Disable ligatures inside code tag

### DIFF
--- a/source/stylesheets/components/_highlight.scss
+++ b/source/stylesheets/components/_highlight.scss
@@ -157,6 +157,7 @@ code {
   font-size: 0.9em;
   padding: 0.2em 0.5em;
   margin: 0 0.1em;
+  @include font-feature-settings("kern", "tnum");
 }
 
 a code {


### PR DESCRIPTION
Similar to #1369, but applied to `<code>` rather than `<pre>` (I didn't realize this issue affected both, as the hierarchy is slightly different).

### Before
Note the spacing issue around the code block caused by the "fl" ligatures in "inflector":

![before](https://cloud.githubusercontent.com/assets/2403023/14529472/aea8ab8c-0222-11e6-9301-34abc4c89873.png)

### After
Note the non-ligature "fl" in "inflector":

![after](https://cloud.githubusercontent.com/assets/2403023/14529477/b68c3f12-0222-11e6-9f0e-be6d143d5cb0.png)
