### PR TITLE
Fix ambiguous references to old methods

### DIFF
--- a/source/localizable/models/customizing-adapters.md
+++ b/source/localizable/models/customizing-adapters.md
@@ -93,11 +93,11 @@ JSON API adapter:
     <tr><th>Action</th><th>HTTP Verb</th><th>URL</th></tr>
   </thead>
   <tbody>
-    <tr><th>Find</th><td>GET</td><td>/posts/123</td></tr>
-    <tr><th>Find All</th><td>GET</td><td>/posts</td></tr>
-    <tr><th>Update</th><td>PATCH</td><td>/posts/123</td></tr>
-    <tr><th>Create</th><td>POST</td><td>/posts</td></tr>
-    <tr><th>Delete</th><td>DELETE</td><td>/posts/123</td></tr>
+    <tr><th>findRecord</th><td>GET</td><td>/posts/123</td></tr>
+    <tr><th>findAll</th><td>GET</td><td>/posts</td></tr>
+    <tr><th>update</th><td>PATCH</td><td>/posts/123</td></tr>
+    <tr><th>create</th><td>POST</td><td>/posts</td></tr>
+    <tr><th>delete</th><td>DELETE</td><td>/posts/123</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
In the guides, on [customizing the adapter](https://guides.emberjs.com/v2.5.0/models/customizing-adapters/#toc_url-conventions), under URL conventions. It references old methods, in a way that might still apply, but could be confusing. I have updated this documentation to reference specific methods which are the current methods you would use to perform these requests.

I'm still pretty new to Ember, so maybe the original documentation was intended.