### PR TITLE
Update name of slack room for to #-learning

### DIFF
--- a/source/localizable/index.de-DE.md
+++ b/source/localizable/index.de-DE.md
@@ -32,6 +32,6 @@ Clicking the pencil icon will bring you to GitHub's editor for that guide so you
 
 If you wish to make a more significant contribution be sure to check our [issue tracker](https://github.com/emberjs/guides/issues) to see if your issue is already being addressed. If you don't find an active issue, open a new one.
 
-If you have any styling questions, or about the contributing process you can check out our [contributing guide](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). If your question persists, reach us at `#documentation` on the [Slack group](https://ember-community-slackin.herokuapp.com/).
+If you have any styling questions, or about the contributing process you can check out our [contributing guide](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). If your question persists, reach us at `#-learning` on the [Slack group](https://ember-community-slackin.herokuapp.com/).
 
 Good luck!

--- a/source/localizable/index.es-ES.md
+++ b/source/localizable/index.es-ES.md
@@ -32,6 +32,6 @@ Clicking the pencil icon will bring you to GitHub's editor for that guide so you
 
 If you wish to make a more significant contribution be sure to check our [issue tracker](https://github.com/emberjs/guides/issues) to see if your issue is already being addressed. If you don't find an active issue, open a new one.
 
-If you have any styling questions, or about the contributing process you can check out our [contributing guide](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). If your question persists, reach us at `#documentation` on the [Slack group](https://ember-community-slackin.herokuapp.com/).
+If you have any styling questions, or about the contributing process you can check out our [contributing guide](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). If your question persists, reach us at `#-learning` on the [Slack group](https://ember-community-slackin.herokuapp.com/).
 
 Good luck!

--- a/source/localizable/index.fr-FR.md
+++ b/source/localizable/index.fr-FR.md
@@ -32,6 +32,6 @@ Clicking the pencil icon will bring you to GitHub's editor for that guide so you
 
 If you wish to make a more significant contribution be sure to check our [issue tracker](https://github.com/emberjs/guides/issues) to see if your issue is already being addressed. If you don't find an active issue, open a new one.
 
-If you have any styling questions, or about the contributing process you can check out our [contributing guide](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). If your question persists, reach us at `#documentation` on the [Slack group](https://ember-community-slackin.herokuapp.com/).
+If you have any styling questions, or about the contributing process you can check out our [contributing guide](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). If your question persists, reach us at `#-learning` on the [Slack group](https://ember-community-slackin.herokuapp.com/).
 
 Good luck!

--- a/source/localizable/index.ja-JP.md
+++ b/source/localizable/index.ja-JP.md
@@ -32,6 +32,6 @@ Ember.jsガイドへようこそ! このドキュメントはあなたを完全�
 
 もし、もっと貢献することが大きな場合は、すでにその問題が[issue tracker](https://github.com/emberjs/guides/issues) にあがっていないか、必ず確認してください。 アクティブなイシューが見つからない場合には、新たなイシューを開けてください。
 
-スタイリングや、コントリビューションプロセスについて、疑問があるときは [コントリビューション ガイド](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md)を確認してください。 疑問が解決できない場合は、 [Slack group](https://ember-community-slackin.herokuapp.com/)内の`#documentation` に質問を投稿してください。.
+スタイリングや、コントリビューションプロセスについて、疑問があるときは [コントリビューション ガイド](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md)を確認してください。 疑問が解決できない場合は、 [Slack group](https://ember-community-slackin.herokuapp.com/)内の`#-learning` に質問を投稿してください。.
 
 がんばってね！

--- a/source/localizable/index.md
+++ b/source/localizable/index.md
@@ -58,7 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any styling questions, or about the contributing process you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#documentation` on the [Slack
+question persists, reach us at `#-learning` on the [Slack
 group][slackin].
 
 Good luck!

--- a/source/localizable/index.pt-BR.md
+++ b/source/localizable/index.pt-BR.md
@@ -32,6 +32,6 @@ Ao clicar no ícone de lápis você será levado ao editor do GitHub para que vo
 
 Se você deseja fazer uma contribuição mais significativa não se esqueça de verificar o nosso [rastreador de problemas](https://github.com/emberjs/guides/issues), para ver se seu problema já está sendo abordado. Se você não encontrar um problema ativo, abra um novo.
 
-Se você tiver alguma dúvida de estilo, ou sobre o processo de contribuição você pode conferir nosso [Guia de contribuição](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). Se sua pergunta persiste, fale conosco no canal `#documentation` do nosso [grupo Slack](https://ember-community-slackin.herokuapp.com/).
+Se você tiver alguma dúvida de estilo, ou sobre o processo de contribuição você pode conferir nosso [Guia de contribuição](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md). Se sua pergunta persiste, fale conosco no canal `#-learning` do nosso [grupo Slack](https://ember-community-slackin.herokuapp.com/).
 
 Boa sorte!

--- a/source/localizable/index.zh-CN.md
+++ b/source/localizable/index.zh-CN.md
@@ -32,6 +32,6 @@
 
 如果你想要提供更明确的贡献，请事先检索我们的[问题更踪器](https://github.com/emberjs/guides/issues)以确保不要提交重复的问题。 如果没有正在处理中的问题那就可以开一个新的。
 
-如果你有关于样式的问题，或是关于贡献流程的问题可以参考我们的[贡献指南](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md)。 如果问题得不到解决，请通过 [Slack 群组](https://ember-community-slackin.herokuapp.com/)中的 `#documentation` 频道联络我们。.
+如果你有关于样式的问题，或是关于贡献流程的问题可以参考我们的[贡献指南](https://github.com/emberjs/guides/blob/master/CONTRIBUTING.md)。 如果问题得不到解决，请通过 [Slack 群组](https://ember-community-slackin.herokuapp.com/)中的 `#-learning` 频道联络我们。.
 
 祝你好运！


### PR DESCRIPTION
Received a complaint in Slack #general about not being able to find the `#documentation` room in slack.

(Figured it would be just as easy to open up a PR to fix this as it would be an issue)


