### PR TITLE
Add basic component class example

### DIFF
--- a/source/localizable/components/customizing-a-components-element.md
+++ b/source/localizable/components/customizing-a-components-element.md
@@ -31,7 +31,14 @@ export default Ember.Component.extend({
 </ul>
 ```
 
-### Customizing Class Names
+### Customizing the Element's Class
+
+You can specify the class of a component's element at invocation time the same
+way you would for a regular HTML element:
+
+```hbs
+{{navigation-bar class="primary"}}
+```
 
 You can also specify which class names are applied to the component's
 element by setting its `classNames` property to an array of strings:


### PR DESCRIPTION
Fixes https://github.com/emberjs/guides/issues/1372

This adds an example of setting the class for a component's element
like:

```hbs
{{navigation-bar class="primary"}}
```