### PR TITLE
Change ember version for npm install

### DIFF
--- a/source/localizable/getting-started/index.md
+++ b/source/localizable/getting-started/index.md
@@ -55,7 +55,7 @@ need for a browser to be open. Consult the [PhantomJS download instructions](htt
 Install Ember using npm:
 
 ```bash
-npm install -g ember-cli@2.4
+npm install -g ember-cli@2.5
 ```
 
 To verify that your installation was successful, run:


### PR DESCRIPTION
I could be crazy, but I don't think the command-line instructions were updated for Ember 2.5.0.