### PR TITLE
Adds a bit of JavaScript to show the correct version on ember-cli install

### DIFF
--- a/source/javascripts/app/version-select.js.erb
+++ b/source/javascripts/app/version-select.js.erb
@@ -12,4 +12,12 @@ window.GUIDE_VERSIONS.onReady(function (versions) {
 
     window.location = versions.urlFor(version);
   });
+
+  var npmInstallVersion = $('pre:contains("install -g ember-cli")');
+
+  if (currentRevision.slice(0,1) !== "C") {
+    var installVersion = versions.current.slice(1).split(".").slice(0,2).join(".");
+
+    npmInstallVersion.text("npm install -g ember-cli@" + installVersion);
+  }
 });

--- a/source/localizable/getting-started/index.md
+++ b/source/localizable/getting-started/index.md
@@ -55,7 +55,7 @@ need for a browser to be open. Consult the [PhantomJS download instructions](htt
 Install Ember using npm:
 
 ```bash
-npm install -g ember-cli@2.4
+npm install -g ember-cli
 ```
 
 To verify that your installation was successful, run:

--- a/source/localizable/getting-started/quick-start.md
+++ b/source/localizable/getting-started/quick-start.md
@@ -15,7 +15,7 @@ You can install Ember with a single command using npm, the Node.js package
 manager. Type this into your terminal:
 
 ```sh
-npm install -g ember-cli@2.4
+npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].


### PR DESCRIPTION
Defaults to installing latest (npm install -g ember-cli) if JavaScript
does not run.
Fixes #1396.