### PR TITLE
clarify preventDefault=false

### DIFF
--- a/source/localizable/templates/actions.md
+++ b/source/localizable/templates/actions.md
@@ -100,10 +100,10 @@ use `preventDefault=false`:
 <a href="newPage.htm" {{action "logClick" preventDefault=false}}>Go</a>
 ```
 
-Without `preventDefault=false`, if the user clicked on the link, Ember.js
+With `preventDefault=false` omitted, if the user clicked on the link, Ember.js
 will trigger the action, but the user will remain on the current page.
 
-With `preventDefault=false`, if the user clicked on the link, Ember.js
+With `preventDefault=false` present, if the user clicked on the link, Ember.js
 will trigger the action *and* the user will be directed to the new page.
 
 ## Modifying the action's first parameter


### PR DESCRIPTION
(minor text change)

Previously, `with` vs `without` was unclear. Even after a few glances I almost didn't notice this difference between the sentences. Using `omitted` vs `present` makes the difference here clearer.