### PR TITLE
Change parameter name to match description

### DIFF
--- a/source/localizable/controllers/index.md
+++ b/source/localizable/controllers/index.md
@@ -9,10 +9,10 @@ the return value of the Route's `model()` method.
 To define a Controller, run:
 
 ```shell
-ember generate controller my-component-name
+ember generate controller my-controller-name
 ```
 
-The value of `my-component-name` must match the name of the Route that renders
+The value of `my-controller-name` must match the name of the Route that renders
 it. So a Route named `blog-post` would have a matching Controller named
 `blog-post`.
 


### PR DESCRIPTION
Wouldn't it make more sense to call this controller `my-controller-name` instead of `my-component-name` since it is not a component?