### PR TITLE
Fix typo: "Web Sockets" -> "WebSockets"

### DIFF
--- a/source/localizable/applications/services.md
+++ b/source/localizable/applications/services.md
@@ -7,7 +7,7 @@ include:
 
 * User/session authentication.
 * Geolocation.
-* Web Sockets.
+* WebSockets.
 * Server-sent events or notifications.
 * Server-backed API calls that may not fit Ember Data.
 * Third-party APIs.


### PR DESCRIPTION
WebSocket is how the protocol is spelled in https://tools.ietf.org/html/rfc6455 and is also used [elsewhere in the guides](https://guides.emberjs.com/v2.5.0/models/).