### PR TITLE
Install addons using ember-cli instead of npm

### DIFF
--- a/source/localizable/addons-and-dependencies/managing-dependencies.md
+++ b/source/localizable/addons-and-dependencies/managing-dependencies.md
@@ -8,8 +8,10 @@ Ember CLI supports installing these packages through the standard [Bower package
 
 ## Addons
 
-Ember Addons are installed using NPM (e.g. `npm install --save-dev ember-cli-sass`).
-Addons may bring in other dependencies by modifying your project's `bower.json` file automatically.
+Most Ember Addons can be installed using NPM (e.g. `npm install --save-dev ember-cli-sass`).
+However, some addons need to perform additional processing in which case they should be installed using the Ember CLI
+(e.g. `ember install ember-electron`). When in doubt, you should install and update addons using the Ember CLI.
+Note that addons may bring in other dependencies by modifying your project's `bower.json` file automatically.
 
 You can find listings of addons on [Ember Observer](http://emberobserver.com).
 


### PR DESCRIPTION
@alexspeller, is this better or should the `npm` part be removed completely?