### PR TITLE
Updated the link in the page quick-start.md

### DIFF
--- a/source/localizable/getting-started/quick-start.md
+++ b/source/localizable/getting-started/quick-start.md
@@ -253,8 +253,7 @@ directory.
 
 The Ember community values collaboration and building common tools that
 everyone relies on. If you're interested in deploying your app to
-production in a fast and reliable way, check out the [Ember CLI
-Deploy][ember-deploy] addon.
+production in a fast and reliable way, check out the [Ember CLI Deploy](http://ember-cli-deploy.github.io/ember-cli-deploy/) addon.
 
 [ember-deploy]: http://ember-cli-deploy.github.io/ember-cli-deploy/
 


### PR DESCRIPTION
Previously the link ( Ember CLI Deploy) at the bottom of the page was not working. It was routing to 'http://ember-cli.com/ember-cli-deploy/' link which never existed. Hence i replaced it with this link (http://ember-cli-deploy.github.io/ember-cli-deploy/).
I hope i did right.