### PR TITLE
Remove extra space between dependent keys for brace expansion example

### DIFF
--- a/source/localizable/object-model/computed-properties.md
+++ b/source/localizable/object-model/computed-properties.md
@@ -37,7 +37,7 @@ When you want to depend on a property which belongs to an object, you can setup 
 var obj = Ember.Object.extend({
   baz: {foo: 'BLAMMO', bar: 'BLAZORZ'},
 
-  something: Ember.computed('baz.{foo, bar}', function() {
+  something: Ember.computed('baz.{foo,bar}', function() {
     return this.get('baz.foo') + ' ' + this.get('baz.bar');
   })
 ```


### PR DESCRIPTION
* To avoid confusion; If there's a space between dependent keys we get the following error `Brace expanded properties cannot contain spaces, e.g. "user.{firstName, lastName}" should be "user.{firstName,lastName}"`.