### PR TITLE
Correct `filterBy` example

### DIFF
--- a/source/localizable/object-model/computed-properties-and-aggregate-data.md
+++ b/source/localizable/object-model/computed-properties-and-aggregate-data.md
@@ -1,6 +1,6 @@
-Sometimes you have a computed property whose value depends on the properties of 
+Sometimes you have a computed property whose value depends on the properties of
 items in an array. For example, you may have an array of todo items, and want
-to calculate how many remain incomplete based on their `isDone` property.
+to calculate the incomplete todo's based on their `isDone` property.
 
 To facilitate this, Ember provides the `@each` key illustrated below:
 
@@ -12,15 +12,15 @@ export default Ember.Component.extend({
     Ember.Object.create({ isDone: true })
   ],
 
-  remaining: Ember.computed('todos.@each.isDone', function() {
+  incomplete: Ember.computed('todos.@each.isDone', function() {
     var todos = this.get('todos');
-    return todos.filterBy('isDone', false).get('length');
+    return todos.filterBy('isDone', false);
   })
 });
 ```
 
-Here, the dependent key `todos.@each.isDone` instructs Ember.js to update bindings 
-and fire observers when any of the following events occurs: 
+Here, the dependent key `todos.@each.isDone` instructs Ember.js to update bindings
+and fire observers when any of the following events occurs:
 
 1. The `isDone` property of any of the objects in the `todos` array changes.
 2. An item is added to the `todos` array.
@@ -39,21 +39,21 @@ export default Ember.Component.extend({
     Ember.Object.create({ isDone: true })
   ],
 
-  remaining: Ember.computed.filterBy('todos', 'isDone', false)
+  incomplete: Ember.computed.filterBy('todos', 'isDone', false)
 });
 ```
 
-In both of the examples above, the `remaining` count is `1`:
+In both of the examples above, `incomplete` is an array containing the single incomplete todo:
 
 ```javascript
 import TodosComponent from 'app/components/todos';
 
 let todosComponent = TodosComponent.create();
-todosComponent.get('remaining');
+todosComponent.get('incomplete.length');
 // 1
 ```
 
-If we change the todo's `isDone` property, the `remaining` property is updated
+If we change the todo's `isDone` property, the `incomplete` property is updated
 automatically:
 
 ```javascript
@@ -61,13 +61,13 @@ let todos = todosComponent.get('todos');
 let todo = todos.objectAt(1);
 todo.set('isDone', true);
 
-todosComponent.get('remaining');
+todosComponent.get('incomplete.length');
 // 0
 
 todo = Ember.Object.create({ isDone: false });
 todos.pushObject(todo);
 
-todosComponent.get('remaining');
+todosComponent.get('incomplete.length');
 // 1
 ```
 
@@ -97,9 +97,9 @@ export default Ember.Component.extend({
 Here, `indexOfSelectedTodo` depends on `todos.[]`, so it will update if we add an item
 to `todos`, but won't update if the value of `isDone` on a `todo` changes.
 
-Several of the [Ember.computed](http://emberjs.com/api/classes/Ember.computed.html) macros 
+Several of the [Ember.computed](http://emberjs.com/api/classes/Ember.computed.html) macros
 utilize the `[]` key to implement common use-cases. For instance, to
-create a computed property that mapped properties from an array, you could use 
+create a computed property that mapped properties from an array, you could use
 [Ember.computed.map](http://emberjs.com/api/classes/Ember.computed.html#method_map)
 or build the computed property yourself:
 


### PR DESCRIPTION
```js
remaining: Ember.computed('todos.@each.isDone', function() {
  var todos = this.get('todos');
  return todos.filterBy('isDone', false).get('length');
})
```

isn't the same as:

```js
remaining: Ember.computed.filterBy('todos', 'isDone', false)
```

as one returns a count and the other returns an array.

I've modified them both to return an `incomplete` array and have updated the examples to use `incomplete.length`