### PR TITLE
[BUGFIX] Remove references to Ember.Logger.assert

### DIFF
--- a/source/localizable/configuring-ember/debugging.de-DE.md
+++ b/source/localizable/configuring-ember/debugging.de-DE.md
@@ -103,7 +103,7 @@ You can provide an `onerror` function that will be called with the error details
 
 ```app/app.js import Ember from 'ember'; import RSVP from 'rsvp';
 
-RSVP.on('error', function(error) { Ember.Logger.assert(false, error); });
+RSVP.on('error', function(error) { Ember.assert(false, error); });
 
     <br />#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
     

--- a/source/localizable/configuring-ember/debugging.es-ES.md
+++ b/source/localizable/configuring-ember/debugging.es-ES.md
@@ -103,7 +103,7 @@ You can provide an `onerror` function that will be called with the error details
 
 ```app/app.js import Ember from 'ember'; import RSVP from 'rsvp';
 
-RSVP.on('error', function(error) { Ember.Logger.assert(false, error); });
+RSVP.on('error', function(error) { Ember.assert(false, error); });
 
     <br />#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
     

--- a/source/localizable/configuring-ember/debugging.fr-FR.md
+++ b/source/localizable/configuring-ember/debugging.fr-FR.md
@@ -103,7 +103,7 @@ You can provide an `onerror` function that will be called with the error details
 
 ```app/app.js import Ember from 'ember'; import RSVP from 'rsvp';
 
-RSVP.on('error', function(error) { Ember.Logger.assert(false, error); });
+RSVP.on('error', function(error) { Ember.assert(false, error); });
 
     <br />#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
     

--- a/source/localizable/configuring-ember/debugging.ja-JP.md
+++ b/source/localizable/configuring-ember/debugging.ja-JP.md
@@ -103,7 +103,7 @@ You can provide an `onerror` function that will be called with the error details
 
 ```app/app.js import Ember from 'ember'; import RSVP from 'rsvp';
 
-RSVP.on('error', function(error) { Ember.Logger.assert(false, error); });
+RSVP.on('error', function(error) { Ember.assert(false, error); });
 
     <br />#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
     

--- a/source/localizable/configuring-ember/debugging.md
+++ b/source/localizable/configuring-ember/debugging.md
@@ -123,7 +123,7 @@ import Ember from 'ember';
 import RSVP from 'rsvp';
 
 RSVP.on('error', function(error) {
-  Ember.Logger.assert(false, error);
+  Ember.assert(false, error);
 });
 ```
 

--- a/source/localizable/configuring-ember/debugging.pt-BR.md
+++ b/source/localizable/configuring-ember/debugging.pt-BR.md
@@ -103,7 +103,7 @@ You can provide an `onerror` function that will be called with the error details
 
 ```app/app.js import Ember from 'ember'; import RSVP from 'rsvp';
 
-RSVP.on('error', function(error) { Ember.Logger.assert(false, error); });
+RSVP.on('error', function(error) { Ember.assert(false, error); });
 
     <br />#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
     

--- a/source/localizable/configuring-ember/debugging.ru-RU.md
+++ b/source/localizable/configuring-ember/debugging.ru-RU.md
@@ -103,7 +103,7 @@ You can provide an `onerror` function that will be called with the error details
 
 ```app/app.js import Ember from 'ember'; import RSVP from 'rsvp';
 
-RSVP.on('error', function(error) { Ember.Logger.assert(false, error); });
+RSVP.on('error', function(error) { Ember.assert(false, error); });
 
     <br />#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
     

--- a/source/localizable/configuring-ember/debugging.zh-CN.md
+++ b/source/localizable/configuring-ember/debugging.zh-CN.md
@@ -103,7 +103,7 @@ You can provide an `onerror` function that will be called with the error details
 
 ```app/app.js import Ember from 'ember'; import RSVP from 'rsvp';
 
-RSVP.on('error', function(error) { Ember.Logger.assert(false, error); });
+RSVP.on('error', function(error) { Ember.assert(false, error); });
 
     <br />#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
     


### PR DESCRIPTION
As explained in [this comment](https://github.com/emberjs/ember.js/issues/13597#issuecomment-223951392):

> Ember.Logger is largely a polyfill from the dark ages when we couldn't rely
on console methods to exist or function properly.

This PR removes references to `Ember.Logger`

Related to emberjs/ember.js#13597

_Note:_ The extra line at the end of file is just my editor complying with the [editorconfig](https://github.com/emberjs/guides/blob/master/.editorconfig#L10)