### PR TITLE
Fix JSON-API serializer extending example

### DIFF
--- a/source/localizable/models/customizing-serializers.md
+++ b/source/localizable/models/customizing-serializers.md
@@ -318,9 +318,10 @@ payload. For example, if your backend returned attributes that are
 method like this.
 
 ```app/serializers/application.js
-import JSONSerializer from 'ember-data/serializers/json';
+import Ember from 'ember';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
-export default JSONSerializer.extend({
+export default JSONAPISerializer.extend({
   keyForAttribute: function(attr) {
     return Ember.String.underscore(attr);
   }

--- a/source/localizable/models/customizing-serializers.md
+++ b/source/localizable/models/customizing-serializers.md
@@ -124,18 +124,18 @@ serializer for your entire application by defining an "application"
 serializer.
 
 ```app/serializers/application.js
-import JSONSerializer from 'ember-data/serializers/json';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
-export default JSONSerializer.extend({});
+export default JSONAPISerializer.extend({});
 ```
 
 You can also define a serializer for a specific model. For example, if
 you had a `post` model you could also define a `post` serializer:
 
 ```app/serializers/post.js
-import JSONSerializer from 'ember-data/serializers/json';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
-export default JSONSerializer.extend({});
+export default JSONAPISerializer.extend({});
 ```
 
 To change the format of the data that is sent to the backend store, you can use
@@ -177,9 +177,9 @@ But our server expects data in this format:
 Here's how you can change the data:
 
 ```app/serializers/application.js
-import JSONSerializer from 'ember-data/serializers/json';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
-export default JSONSerializer.extend({
+export default JSONAPISerializer.extend({
   serialize(snapshot, options) {
     var json = this._super(...arguments);
 
@@ -237,9 +237,9 @@ And so we need to change it to look like:
 Here's how we could do it:
 
 ```app/serializers/application.js
-import JSONSerializer from 'ember-data/serializers/json';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
-export default JSONSerializer.extend({
+export default JSONAPISerializer.extend({
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     payload.data.attributes.amount = payload.data.attributes.cost.amount;
     payload.data.attributes.currency = payload.data.attributes.cost.currency;
@@ -268,9 +268,9 @@ serializer's `primaryKey` property to correctly transform the id
 property to `id` when serializing and deserializing data.
 
 ```app/serializers/application.js
-import JSONSerializer from 'ember-data/serializers/json';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
-export default JSONSerializer.extend({
+export default JSONAPISerializer.extend({
   primaryKey: '_id'
 });
 ```
@@ -349,7 +349,7 @@ export default Model.extend({
 ```
 
 ```app/serializers/person.js
-import JSONSerializer from 'ember-data/serializers/json';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
 export default JSONSerializer.extend({
   attrs: {


### PR DESCRIPTION
Took me quite a while to find out all the problems in this snippet that was causing my Ember app to crash. :(

I believe there are other examples on this page where using the `json-api` serializer instead of `json` would be more appropriate, given the surrounding text. But I'd prefer if one of the maintainers would just go through these, as I don't want to make all these decisions...

Thanks.