### PR TITLE
Setup continuous delivery to staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     packages:
     - aspell-en
+cache: bundler
 script: bundle exec rspec spec && bundle exec middleman build --verbose
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ deploy:
   provider: script
   script: ".travis/continuous-delivery.sh"
   on:
-    branch: continuous-delivery-step-1
+    branch: master
 env:
   global:
   - secure: jv3v+FUShKuRAHcs6RM5Bc+BFMPDPBdJY39dtW/K3p7UILu1R6ZyXCRBn33YTanYfJ+ujT3ktIGmOmsRX24f6ZjUOd2NT8rM+7anRW7qRrPlP25bN5Y/YMqAcuhZr7Ktd2NRZeYQw7xtYgwYAlh1GkzRAl/FjCUFj8v1hNpqRBM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: ruby
 sudo: false
 rvm:
-  - "1.9.3"
+- 1.9.3
 addons:
   apt:
     packages:
     - aspell-en
 script: bundle exec rspec spec && bundle exec middleman build --verbose
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: ".travis/continuous-delivery.sh"
+  on:
+    branch: continuous-delivery-step-1
+env:
+  global:
+  - secure: jv3v+FUShKuRAHcs6RM5Bc+BFMPDPBdJY39dtW/K3p7UILu1R6ZyXCRBn33YTanYfJ+ujT3ktIGmOmsRX24f6ZjUOd2NT8rM+7anRW7qRrPlP25bN5Y/YMqAcuhZr7Ktd2NRZeYQw7xtYgwYAlh1GkzRAl/FjCUFj8v1hNpqRBM=

--- a/.travis/continuous-delivery.sh
+++ b/.travis/continuous-delivery.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+REPO="https://github.com/emberjs/guides.emberjs.com.git"
+BUILT_FILES=$HOME/build/emberjs/guides/build
+DEPLOY=$HOME/deploy
+WEBSITE_FILES=$DEPLOY/guides.emberjs.com
+
+# setup a temp folder to run things out of
+mkdir $DEPLOY
+cd $DEPLOY
+
+echo "Installing Firebase tools for deploys"
+npm install firebase-tools@^2.1 -g
+
+git clone $REPO
+
+# get latest version so we can copy our files to the right snapshot dir
+cd guides.emberjs.com/snapshots
+a=(*/)
+tmp=${a[@]: -1} # has a trailing slash we remove below
+latestVersion=${tmp%/}
+
+LATEST_VERSION=$WEBSITE_FILES/snapshots/$latestVersion
+
+cd $DEPLOY
+
+rm -rf $LATEST_VERSION
+cp -r $BUILT_FILES $LATEST_VERSION
+
+# start the deploy
+cd $WEBSITE_FILES
+firebase deploy -f ember-guides-staging

--- a/.travis/continuous-delivery.sh
+++ b/.travis/continuous-delivery.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 REPO="https://github.com/emberjs/guides.emberjs.com.git"
-BUILT_FILES=$HOME/build/emberjs/guides/build
-DEPLOY=$HOME/deploy
+ROOT=$HOME/build/emberjs/guides
+BUILT_FILES=$ROOT/build
+DEPLOY=$ROOT/deploy
 WEBSITE_FILES=$DEPLOY/guides.emberjs.com
 
 # setup a temp folder to run things out of
@@ -26,6 +27,10 @@ cd $DEPLOY
 rm -rf $LATEST_VERSION
 cp -r $BUILT_FILES $LATEST_VERSION
 
-# start the deploy
 cd $WEBSITE_FILES
+
+# clean up versions in our built files
+node tasks/update-versions.js
+
+# do the deploy
 firebase deploy -f ember-guides-staging


### PR DESCRIPTION
With these changes, the latest changes to `master` will always be visible at https://ember-guides-staging.firebaseapp.com/v2.6.0/

I'm not updating https://github.com/emberjs/guides.emberjs.com on every commit (that seems excessive), but we'll end up with functionally the same setup when we do more major deploys.

When we do any changes on older versions (by manually working with the repo above) we'll need to make sure to update the latest version with the latest build from `master` here as well ...

/cc @locks @toddjordan 