### PR TITLE
Tutorial: clarify build before deploy

### DIFF
--- a/source/localizable/tutorial/deploying.md
+++ b/source/localizable/tutorial/deploying.md
@@ -1,4 +1,4 @@
-To deploy an Ember application simply transfer the output from `ember build` to a web server.
+To deploy an Ember application simply transfer the output from `ember build` to a web server (make sure to not build with `--enviroment=production`, as the data mocked with Mirage will only work with a development build).
 This can be done with standard Unix file transfer tools such as `rsync` or `scp`.
 There are also services that will let you deploy easily.
 


### PR DESCRIPTION
I think the instructions are good as they are, I don’t know why I built with `--env=production`, I didn’t think about it. But I tested it with just `ember build` and it works. But if you want to be 100% clear, we can add an extra explanation to it

@toddjordan 