### PR TITLE
Long code samples font shouldn't be auto-adjusted

### DIFF
--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -1,4 +1,5 @@
 @import "mixins/hidpi";
+@import "mixins/text-adjust";
 
 body {
   @include font-feature-settings("kern", "liga", "pnum");

--- a/source/stylesheets/components/_highlight.scss
+++ b/source/stylesheets/components/_highlight.scss
@@ -37,6 +37,7 @@
     font-size: 1.2em;
     font-family: inherit;
     @include font-feature-settings("kern", "tnum");
+    @include text-adjust();
   }
 
   table {

--- a/source/stylesheets/mixins/_text-adjust.scss
+++ b/source/stylesheets/mixins/_text-adjust.scss
@@ -1,0 +1,5 @@
+@mixin text-adjust($size: 100%) {
+	-webkit-text-size-adjust: $size;
+	-moz-text-size-adjust: $size;
+	-ms-text-size-adjust: $size;
+}


### PR DESCRIPTION
This fixes #1445 by setting the `text-size-adjust` property on `.highlight pre`-elements. Mobile Safari would auto-adjust the font-size of wide elements to make sure they weren't too small to read, which resulted in code samples with long lines being larger than the line numbers.  

I added a mixin with browser-prefixes for Mozilla and IE/Edge too, but I'm lacking devices to test that on, but it should be consistently fixed (if there were any issues there in the first place).