### PR TITLE
Fixes a Mirage file path bug

### DIFF
--- a/source/localizable/tutorial/installing-addons.md
+++ b/source/localizable/tutorial/installing-addons.md
@@ -38,7 +38,7 @@ If you were running `ember serve` in another shell, restart the server to includ
 
 Let's now configure Mirage to send back our rentals that we had defined above by updating `/mirage/config.js`:
 
-```app/mirage/config.js
+```mirage/config.js
 export default function() {
   this.get('/rentals', function() {
     return {


### PR DESCRIPTION
As mentioned here: http://discuss.emberjs.com/t/typo-in-tutorial/10937 the path is wrong for the Mirage files post Mirage 0.2.0 upgrade