### PR TITLE
Localhost link standardization

### DIFF
--- a/source/localizable/configuring-ember/handling-deprecations.md
+++ b/source/localizable/configuring-ember/handling-deprecations.md
@@ -42,7 +42,7 @@ Once installed, the addon works in 3 steps:
 The ember-cli-deprecation-workflow addon provides a command that will collect deprecations from your console and generate JavaScript code listing
 its findings.
 
-To collect deprecations, first run your in-browser test suite by starting your development server and navigating to `http://localhost:4200/tests`.  If your test suite isn't fully covering your app's functionality, you may also
+To collect deprecations, first run your in-browser test suite by starting your development server and navigating to [`http://localhost:4200/tests`](http://localhost:4200/tests).  If your test suite isn't fully covering your app's functionality, you may also
 manually exercise functionality within your app where needed.  Once you've exercised the app to your satisfaction, run the following command within
 your browser console: `deprecationWorkflow.flushDeprecations()`.  This will print to the console JavaScript code, which you should then copy to a
 new file in your project called `/config/deprecation-workflow.js`

--- a/source/localizable/getting-started/quick-start.md
+++ b/source/localizable/getting-started/quick-start.md
@@ -62,7 +62,7 @@ Serving on http://localhost:4200/
 
 (To stop the server at any time, type Ctrl-C in your terminal.)
 
-Open [http://localhost:4200/](http://localhost:4200) in your browser of
+Open [`http://localhost:4200`](http://localhost:4200) in your browser of
 choice. You should see a page that says "Welcome to Ember" and not much
 else. Congratulations! You just created and booted your first Ember app.
 
@@ -116,7 +116,7 @@ the following HTML:
 ```
 
 In your browser, open
-[http://localhost:4200/scientists](http://localhost:4200/scientists). You should
+[`http://localhost:4200/scientists`](http://localhost:4200/scientists). You should
 see the `<h2>` you put in the `scientists.hbs` template, right below the
 `<h2>` from our `application.hbs` template.
 

--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -131,5 +131,5 @@ or, for short:
 ember s
 ```
 
-If we navigate to `localhost:4200`, we'll see our brand new app displaying
+If we navigate to [`http://localhost:4200`](http://localhost:4200), we'll see our brand new app displaying
 the text "Welcome to Ember".

--- a/source/localizable/tutorial/routes-and-templates.md
+++ b/source/localizable/tutorial/routes-and-templates.md
@@ -85,7 +85,7 @@ For our `about` page, we'll add some HTML that has a bit of information about th
 ```
 
 Run `ember serve` (or `ember s` for short) from the shell to start the Ember development server,
-and then go to `localhost:4200/about` to see our new app in action!
+and then go to [`http://localhost:4200/about`](http://localhost:4200/about) to see our new app in action!
 
 ## A Contact Route
 
@@ -121,7 +121,7 @@ In `contact.hbs`, we can add the details for contacting our Super Rentals HQ:
 ```
 
 Now we have completed our second route.
-If we go to the URL `localhost:4200/contact`, we'll arrive on our contact page.
+If we go to the URL [`http://localhost:4200/contact`](http://localhost:4200/contact), we'll arrive on our contact page.
 
 ## Navigating with Links and the {{link-to}} Helper
 
@@ -148,7 +148,7 @@ Here we will use the `{{link-to}}` helper in our code to link between routes:
 ```
 
 The `{{link-to}}` helper takes an argument with the name of the route to link to, in this case: `contact`.
-When we look at our about page at `http://localhost:4200/about`, we now have a working link to our contact page.
+When we look at our about page at [`http://localhost:4200/about`](http://localhost:4200/about), we now have a working link to our contact page.
 
 ![super rentals about page screenshot](../../images/routes-and-templates/ember-super-rentals-about.png)
 


### PR DESCRIPTION
Split off from #1515.

Makes the format of links to localhost throughout the docs consistent. Previously not all places `localhost` was shown were links, not all showed `http://`, and not all were in backticks; now all instances of `localhost` have all three of those attributes.

[Fixes #1514]