### PR TITLE
Fix broken relative link on Template Actions page

### DIFF
--- a/source/localizable/templates/actions.md
+++ b/source/localizable/templates/actions.md
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](/components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters


### PR DESCRIPTION
On the live Ember guides site, if you navigate to the
`/template/actions/` page and click the link 'Triggering Changes With
Actions', you get the 404 page. Looking at the URL you can see that the
link is missing the Ember version number:

- Bad URL:  https://guides.emberjs.com/components/triggering-changes-with-actions/
- Expected: https://guides.emberjs.com/v2.6.0/components/triggering-changes-with-actions/

Looking at the source files, it seems this link was absolute instead of
relative like the other links in the guides. Adding `../../` seemed like
the correct thing to do. *However* when running middleman locally the
bad URL worked, as does the fixed URL, so it was not possible to test
that this will work on the live site. I am assuming it will based on
similar relative links in the file
`source/localizable/tutorial/autocomplete-component.md` (line 172).

I also looked for any other broken links with the following command, but
found none:

```
find source/localizable -type f -regex '[^A-Z]*\.md' -exec grep -H "](" {} \; |
  grep -v "(http" |
  grep -v "(#" |
  grep -v "(../"
```

After fixing the bad link, this command returned no matches, indicating
that this was the only link in that state.