### PR TITLE
[Documentation] Document irregular inflection rules for compound words

### DIFF
--- a/source/localizable/models/customizing-adapters.md
+++ b/source/localizable/models/customizing-adapters.md
@@ -132,6 +132,12 @@ This will tell the JSON API adapter that requests for `formula`
 should go to `/formulae/1` instead of `/formulas/1`, and that
 requests for `advice` should go to `/advice/1` instead of `/advices/1`.
 
+When specifying irregular inflection rules for compound words, only the final word or phrase should be specified. For example, to specify the plural of `redCow` as `redKine` or `red-cow` as `red-kine`, only the final word segments `cow` and `kine` should be specified:
+
+```js
+inflector.irregular('cow', 'kine');
+```
+
 #### Endpoint Path Customization
 
 The `namespace` property can be used to prefix requests with a


### PR DESCRIPTION
This PR adds to the [documentation on pluralization customization](https://guides.emberjs.com/v2.4.0/models/customizing-adapters/#toc_pluralization-customization).

It adds an example of how Ember Inspector handles irregular inflection for compound words (camelCased and dasherized words). The example is drawn from the [Ember Inspector tests](https://github.com/stefanpenner/ember-inflector/blob/master/tests/unit/inflector-test.js#L65-L74).

Fixes #1341.