### PR TITLE
Fix an issue with the Google Maps service tutorial

### DIFF
--- a/source/localizable/tutorial/service.md
+++ b/source/localizable/tutorial/service.md
@@ -294,8 +294,8 @@ export default Ember.Object.extend({
   pinLocation(location, map) {
     this.get('geocoder').geocode({address: location}, (result, status) => {
       if (status === google.maps.GeocoderStatus.OK) {
-        let location = result[0].geometry.location;
-        let position = { lat: location.lat(), lng: location.lng() };
+        let geometry = result[0].geometry.location;
+        let position = { lat: geometry.lat(), lng: geometry.lng() };
         map.setCenter(position);
         new google.maps.Marker({ position, map, title: location });
       }


### PR DESCRIPTION
Name collision between 2 variables in `pinLocation()` produced `gmaps.js:32 InvalidValueError: setTitle: not a string`.