### PR TITLE
Improve doc find records

### DIFF
--- a/source/localizable/models/finding-records.md
+++ b/source/localizable/models/finding-records.md
@@ -4,7 +4,7 @@ type.
 ### Retrieving a Single Record
 
 Use [`store.findRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_findRecord)
-to retrieve a record by its type and ID. Ember Data will check if the record has already been loaded into store. If it is not loaded it will make a request to the Adapter. This will return a promise that fulfills with the requested record:
+findRecord always returns a promise. If the record is already in the store then how long it takes the promise to resolve depends on the reload behavior. If the record is not already loaded, the store calls the appropriate adapter's find method:
 
 ```javascript
 var post = this.get('store').findRecord('post', 1); // => GET /posts/1


### PR DESCRIPTION
Guides page does not explain that findAll/findRecord searches the cache (store) first