### PR TITLE
Fix call to `this.store()` in relationship test example

### DIFF
--- a/source/localizable/testing/testing-models.md
+++ b/source/localizable/testing/testing-models.md
@@ -90,7 +90,7 @@ moduleForModel('user', 'Unit | Model | user', {
 });
 
 test('should own a profile', function(assert) {
-  const User = this.get('store')().modelFor('user');
+  const User = this.store().modelFor('user');
   const relationship = Ember.get(User, 'relationshipsByName').get('profile');
 
   assert.equal(relationship.key, 'profile', 'has relationship with profile');


### PR DESCRIPTION
Using `this.get('store')` generates the error:

    undefined is not a constructor (evaluating 'this.get('store')') 