### PR TITLE
Improve font rendering in code examples

### DIFF
--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -1,7 +1,7 @@
 // Typography
 $base-font-family: $helvetica;
 $heading-font-family: $base-font-family;
-$monospace-font-family: Menlo, Courier, monospace;
+$monospace-font-family: Menlo, monospace;
 $footer-font-family: proxima-nova, sans-serif;
 
 // Font Sizes

--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -1,7 +1,7 @@
 // Typography
 $base-font-family: $helvetica;
 $heading-font-family: $base-font-family;
-$monospace-font-family: Menlo, monospace;
+$monospace-font-family: Menlo, "DejaVu Sans Mono", "Bitstream Vera Sans Mono", Courier, monospace;
 $footer-font-family: proxima-nova, sans-serif;
 
 // Font Sizes


### PR DESCRIPTION
This mini PR removes Courier from the monospace font-stack used for code examples in the guide. Not because Courier is bad but because Courier renders terribly on Fedora. I suspect other Linux distro as well.

Let's use what the system recommends. I left Menlo in there as I thought it might be defined in a styleguide?

Courier on Fedora

![screenshot from 2016-07-11 21-01-26](https://cloud.githubusercontent.com/assets/184567/16743210/88942e8e-47ab-11e6-81fd-ebe2ff0279bc.png)

`monospace` on Fedora

![screenshot from 2016-07-11 21-01-42](https://cloud.githubusercontent.com/assets/184567/16743211/88b2b0ca-47ab-11e6-92be-475392e7ef21.png)


