### PR TITLE
Explain conditions that trigger the `model` hook

### DIFF
--- a/source/localizable/routing/specifying-a-routes-model.md
+++ b/source/localizable/routing/specifying-a-routes-model.md
@@ -25,10 +25,9 @@ export default Ember.Route.extend({
 ```
 
 Typically, the `model` hook should return an [Ember Data](../../models/) record,
-but it can also return any [Promise](https://www.promisejs.org/) object (Ember
-Data records are promises), or a plain JavaScript object or array. Ember will
-wait until the data finishes loading (until the promise is resolved) before
-rendering the template.
+but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
+or a plain JavaScript object or array.
+Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
 
 The route will then set the return value from the `model` hook as the `model` property of the controller.
 You will then be able to access the controller's `model` property in your template:

--- a/source/localizable/routing/specifying-a-routes-model.md
+++ b/source/localizable/routing/specifying-a-routes-model.md
@@ -90,10 +90,10 @@ method.
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
 If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
-If anything other than a model is provided as the context, the model hook will be executed.
+If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 
 For example, transitioning to the `photo` route this way won't cause the `model` hook to be executed (because `link-to`
-was passed a model)
+was passed a model):
 
 ```app/templates/photos.hbs
 <h1>Photos</h1>
@@ -106,8 +106,8 @@ was passed a model)
 {{/each}}
 ```
 
-while transitioning this way will cause the `model` hook to be executed (because `link-to` was passed `photo.id`
-instead)
+while transitioning this way will cause the `model` hook to be executed (because `link-to` was passed `photo.id`, an
+identifier, instead):
 
 ```app/templates/photos.hbs
 <h1>Photos</h1>

--- a/source/localizable/routing/specifying-a-routes-model.md
+++ b/source/localizable/routing/specifying-a-routes-model.md
@@ -25,7 +25,7 @@ export default Ember.Route.extend({
 ```
 
 Typically, the `model` hook should return an [Ember Data](../../models/) record,
-but it can also return any [promise](https://www.promisejs.org/) object (Ember
+but it can also return any [Promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
 rendering the template.
@@ -87,11 +87,40 @@ be rendered by the route's template. In the above example, we use the
 photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
-Note: A route with a dynamic segment will only have its `model` hook called
-when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
-already provided and the hook is not executed. Routes without dynamic segments
-will always execute the model hook.
+Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
+If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+and a model context is provided (second argument to `link-to`), then the hook is not executed.
+If anything other than a model is provided as the context, the model hook will be executed.
+
+For example, transitioning to the `photo` route this way won't cause the `model` hook to be executed (because `link-to`
+was passed a model)
+
+```app/templates/photos.hbs
+<h1>Photos</h1>
+{{#each model as |photo|}}
+  <p>
+    {{#link-to 'photo' photo}}
+      <img src="{{photo.thumbnailUrl}}" alt="{{photo.title}}" />
+    {{/link-to}}
+  </p>
+{{/each}}
+```
+
+while transitioning this way will cause the `model` hook to be executed (because `link-to` was passed `photo.id`
+instead)
+
+```app/templates/photos.hbs
+<h1>Photos</h1>
+{{#each model as |photo|}}
+  <p>
+    {{#link-to 'photo' photo.id}}
+      <img src="{{photo.thumbnailUrl}}" alt="{{photo.title}}" />
+    {{/link-to}}
+  </p>
+{{/each}}
+```
+
+Routes without dynamic segments will always execute the model hook.
 
 ## Multiple Models
 


### PR DESCRIPTION
For routes with dynamic segments, the `model` hook is not executed at all times. This change explains what conditions will or will not cause an execution.