### PR TITLE
Update guides and tutorial to use the import DS from 'ember-data'

### DIFF
--- a/source/localizable/models/creating-updating-and-deleting-records.md
+++ b/source/localizable/models/creating-updating-and-deleting-records.md
@@ -37,7 +37,7 @@ person.incrementProperty('age'); // Happy birthday!
 
 Records in Ember Data are persisted on a per-instance basis.
 Call [`save()`](http://emberjs.com/api/data/classes/DS.Model.html#method_save)
-on any instance of `Model` and it will make a network request.
+on any instance of `DS.Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
 you. This allows Ember Data to treat newly created records differently
@@ -146,7 +146,7 @@ post.save().then(transitionToPost).catch(failure);
 ## Deleting Records
 
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](http://emberjs.com/api/data/classes/DS.Model.html#method_deleteRecord)
-on any instance of `Model`. This flags the record as `isDeleted`. The 
+on any instance of `DS.Model`. This flags the record as `isDeleted`. The 
 deletion can then be persisted using `save()`.  Alternatively, you can use 
 the `destroyRecord` method to delete and persist at the same time.
 

--- a/source/localizable/models/customizing-adapters.md
+++ b/source/localizable/models/customizing-adapters.md
@@ -25,9 +25,7 @@ the default Adapter, however it will still be superseded by model
 specific Adapters.
 
 ```app/adapters/application.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   // Application specific overrides go here
 });
 ```
@@ -39,9 +37,7 @@ For example, running `ember generate adapter post` will create the
 following file:
 
 ```app/adapters/post.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   namespace: 'api/v1'
 });
 ```
@@ -50,17 +46,17 @@ By default Ember Data comes with several built-in adapters. Feel free
 to use these adapters as a starting point for creating your own custom
 adapter.
 
-- [Adapter](http://emberjs.com/api/data/classes/DS.Adapter.html) is the basic adapter
+- [DS.Adapter](http://emberjs.com/api/data/classes/DS.Adapter.html) is the basic adapter
 with no functionality. It is generally a good starting point if you
 want to create an adapter that is radically different from the other
 Ember adapters.
 
-- [JSONAPIAdapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
+- [DS.JSONAPIAdapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
 The `JSONAPIAdapter` is the default adapter and follows JSON API
 conventions to communicate with an HTTP server by transmitting JSON
 via XHR.
 
-- [RESTAdapter](http://emberjs.com/api/data/classes/DS.RESTAdapter.html)
+- [DS.RESTAdapter](http://emberjs.com/api/data/classes/DS.RESTAdapter.html)
 The `RESTAdapter` allows your store to communicate with an HTTP server
 by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default.
 
@@ -68,7 +64,7 @@ by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default
 ## Customizing the JSONAPIAdapter
 
 The
-[JSONAPIAdapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
+[DS.JSONAPIAdapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
 has a handful of hooks that are commonly used to extend it to work
 with non-standard backends.
 
@@ -138,9 +134,7 @@ The `namespace` property can be used to prefix requests with a
 specific url namespace.
 
 ```app/adapters/application.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   namespace: 'api/1'
 });
 ```
@@ -155,9 +149,7 @@ like to specify a new domain you can do so by setting the `host`
 property on the adapter.
 
 ```app/adapters/application.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   host: 'https://api.example.com'
 });
 ```
@@ -176,9 +168,7 @@ underscore_case instead of camelCase you could override the
 `pathForType` method like this:
 
 ```app/adapters/application.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   pathForType: function(type) {
     return Ember.String.underscore(type);
   }
@@ -195,9 +185,7 @@ headers can be set as key/value pairs on the `JSONAPIAdapter`'s `headers`
 object and Ember Data will send them along with each ajax request.
 
 ```app/adapters/application.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   headers: {
     'API_KEY': 'secret key',
     'ANOTHER_HEADER': 'Some header value'
@@ -210,9 +198,7 @@ headers. In the example below, the headers are generated with a computed
 property dependent on the `session` service.
 
 ```app/adapters/application.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   session: Ember.inject.service('session'),
   headers: Ember.computed('session.authToken', function() {
     return {
@@ -231,9 +217,7 @@ function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 
 ```app/adapters/application.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   headers: Ember.computed(function() {
     return {
       'API_KEY': Ember.get(document.cookie.match(/apiKey\=([^;]*)/), '1'),
@@ -256,9 +240,7 @@ ensure Ember does the right thing in the case a user of your adapter
 does not specify an `serializer:application`.
 
 ```app/adapters/my-custom-adapter.js
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-
-export default JSONAPIAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
   defaultSerializer: '-default'
 });
 ```

--- a/source/localizable/models/customizing-serializers.md
+++ b/source/localizable/models/customizing-serializers.md
@@ -124,18 +124,18 @@ serializer for your entire application by defining an "application"
 serializer.
 
 ```app/serializers/application.js
-import JSONAPISerializer from 'ember-data/serializers/json-api';
+import DS from 'ember-data';
 
-export default JSONAPISerializer.extend({});
+export default DS.JSONAPISerializer.extend({});
 ```
 
 You can also define a serializer for a specific model. For example, if
 you had a `post` model you could also define a `post` serializer:
 
 ```app/serializers/post.js
-import JSONAPISerializer from 'ember-data/serializers/json-api';
+import DS from 'ember-data';
 
-export default JSONAPISerializer.extend({});
+export default DS.JSONAPISerializer.extend({});
 ```
 
 To change the format of the data that is sent to the backend store, you can use
@@ -177,9 +177,9 @@ But our server expects data in this format:
 Here's how you can change the data:
 
 ```app/serializers/application.js
-import JSONAPISerializer from 'ember-data/serializers/json-api';
+import DS from 'ember-data';
 
-export default JSONAPISerializer.extend({
+export default DS.JSONAPISerializer.extend({
   serialize(snapshot, options) {
     var json = this._super(...arguments);
 
@@ -237,9 +237,9 @@ And so we need to change it to look like:
 Here's how we could do it:
 
 ```app/serializers/application.js
-import JSONAPISerializer from 'ember-data/serializers/json-api';
+import DS from 'ember-data';
 
-export default JSONAPISerializer.extend({
+export default DS.JSONAPISerializer.extend({
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     payload.data.attributes.amount = payload.data.attributes.cost.amount;
     payload.data.attributes.currency = payload.data.attributes.cost.currency;
@@ -268,9 +268,7 @@ serializer's `primaryKey` property to correctly transform the id
 property to `id` when serializing and deserializing data.
 
 ```app/serializers/application.js
-import JSONAPISerializer from 'ember-data/serializers/json-api';
-
-export default JSONAPISerializer.extend({
+export default DS.JSONAPISerializer.extend({
   primaryKey: '_id'
 });
 ```
@@ -281,13 +279,10 @@ In Ember Data the convention is to camelize attribute names on a
 model. For example:
 
 ```app/models/person.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  firstName: attr('string'),
-  lastName:  attr('string'),
-  isPersonOfTheYear: attr('boolean')
+export default DS.Model.extend({
+  firstName: DS.attr('string'),
+  lastName:  DS.attr('string'),
+  isPersonOfTheYear: DS.attr('boolean')
 });
 ```
 
@@ -318,9 +313,7 @@ method like this.
 
 ```app/serializers/application.js
 import Ember from 'ember';
-import JSONAPISerializer from 'ember-data/serializers/json-api';
-
-export default JSONAPISerializer.extend({
+export default DS.JSONAPISerializer.extend({
   keyForAttribute: function(attr) {
     return Ember.String.underscore(attr);
   }
@@ -329,7 +322,7 @@ export default JSONAPISerializer.extend({
 
 Irregular keys can be mapped with a custom serializer. The `attrs`
 object can be used to declare a simple mapping between property names
-on `Model` records and payload keys in the serialized JSON object
+on DS.Model records and payload keys in the serialized JSON object
 representing the record. An object with the property key can also be
 used to designate the attribute's key on the response payload.
 
@@ -339,18 +332,13 @@ desired attribute name is simply `lastName`, then create a custom
 Serializer for the model and override the `attrs` property.
 
 ```app/models/person.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  lastName: attr('string')
+export default DS.Model.extend({
+  lastName: DS.attr('string')
 });
 ```
 
 ```app/serializers/person.js
-import JSONAPISerializer from 'ember-data/serializers/json-api';
-
-export default JSONSerializer.extend({
+export default DS.JSONAPISerializer.extend({
   attrs: {
     lastName: 'lastNameOfPerson'
   }
@@ -363,11 +351,8 @@ References to other records should be done by ID. For example, if you
 have a model with a `hasMany` relationship:
 
 ```app/models/post.js
-import Model from 'ember-data/model';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  comments: hasMany('comment', { async: true })
+export default DS.Model.extend({
+  comments: DS.hasMany('comment', { async: true })
 });
 ```
 
@@ -400,11 +385,8 @@ dasherized version of the property's name. For example, if you have
 a model:
 
 ```app/models/comment.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships'
-
-export default Model.extend({
-  originalPost: belongsTo('post')
+export default DS.Model.extend({
+  originalPost: DS.belongsTo('post')
 });
 ```
 
@@ -429,9 +411,7 @@ the
 method.
 
 ```app/serializers/application.js
-import JSONAPISerializer from 'ember-data/serializers/json-api';
-
-export default JSONAPISerializer.extend({
+export default DS.JSONAPISerializer.extend({
   keyForRelationship: function(key, relationship) {
     return key + 'Ids';
   }
@@ -449,9 +429,7 @@ Ember Data can have new JSON transforms
 registered for use as attributes:
 
 ```app/transforms/coordinate-point.js
-import Transform from 'ember-data/transform';
-
-export default Transform.extend({
+export default DS.Transform.extend({
   serialize: function(value) {
     return [value.get('x'), value.get('y')];
   },
@@ -462,11 +440,8 @@ export default Transform.extend({
 ```
 
 ```app/models/cursor.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  position: attr('coordinate-point')
+export default DS.Model.extend({
+  position: DS.attr('coordinate-point')
 });
 ```
 
@@ -506,9 +481,7 @@ To use it in your application you will need to define an
 `serializer:application` that extends the `JSONSerializer`.
 
 ```app/serializers/application.js
-import JSONSerializer from 'ember-data/serializers/json';
-
-export default JSONSerializer.extend({
+export default DS.JSONSerializer.extend({
   // ...
 });
 ```
@@ -583,10 +556,7 @@ that looks similar to this:
 You would define your relationship like this:
 
 ```app/serializers/post.js
-import JSONSerializer from 'ember-data/serializers/json';
-import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
-
-export default JSONSerializer.extend(EmbeddedRecordsMixin, {
+export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     authors: {
       serialize: 'records',
@@ -601,10 +571,7 @@ embedded relationship you can use the shorthand option of `{ embedded:
 'always' }`. The following example and the one above are equivalent.
 
 ```app/serializers/post.js
-import JSONSerializer from 'ember-data/serializers/json';
-import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
-
-export default JSONSerializer.extend(EmbeddedRecordsMixin, {
+export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     authors: { embedded: 'always' }
   }
@@ -624,10 +591,7 @@ serializing the record. This is possible by using the `serialize:
 setting `serialize: false`.
 
 ```app/serializers/post.js
-import JSONSerializer from 'ember-data/serializers/json';
-import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
-
-export default JSONSerializer.extend(EmbeddedRecordsMixin, {
+export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     author: {
       serialize: false,
@@ -660,7 +624,7 @@ If you would like to create a custom serializer its recommend that you
 start with the `JSONAPISerializer` or `JSONSerializer` and extend one of
 those to match your needs. However, if your payload is extremely
 different from one of these serializers you can create your own by
-extending the `Serializer` base class. There are 3 methods that
+extending the `DS.Serializer` base class. There are 3 methods that
 must be implemented on a serializer.
 
 - [normalizeResponse](http://emberjs.com/api/data/classes/DS.Serializer.html#method_normalizeResponse)
@@ -681,13 +645,9 @@ relationship properties on the Model.
 For Example: given this `post` model.
 
 ```app/models/post.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  title: attr('string'),
-  tag: attr('string'),
+export default DS.Model.extend({
+  title: DS.attr('string'),
+  tag: DS.attr('string'),
   comments: hasMany('comment', { async: false }),
   relatedPosts: hasMany('post')
 });

--- a/source/localizable/models/defining-models.md
+++ b/source/localizable/models/defining-models.md
@@ -4,7 +4,7 @@ if they leave your app and come back later (or if they refresh the page)
 should be represented by a model.
 
 When you want a new model for your application you need to create a new file
-under the models folder and extend from `Model`. This is more conveniently
+under the models folder and extend from `DS.Model`. This is more conveniently
 done by using one of Ember CLI's generator commands. For instance, let's create
 a `person` model:
 
@@ -15,9 +15,7 @@ ember generate model person
 This will generate the following file:
 
 ```app/models/person.js
-import Model from 'ember-data/model';
-
-export default Model.extend({
+export default DS.Model.extend({
 });
 ```
 
@@ -28,16 +26,13 @@ and [working with records](../creating-updating-and-deleting-records) of that ty
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](http://emberjs.com/api/data/classes/DS.html#method_attr):
+add first and last name, as well as the birthday, using [`DS.attr`](http://emberjs.com/api/data/classes/DS.html#method_attr):
 
 ```app/models/person.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  firstName: attr(),
-  lastName: attr(),
-  birthday: attr()
+export default DS.Model.extend({
+  firstName: DS.attr(),
+  lastName: DS.attr(),
+  birthday: DS.attr()
 });
 ```
 
@@ -50,12 +45,9 @@ computed property. Frequently, you will want to define computed
 properties that combine or transform primitive attributes.
 
 ```app/models/person.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  firstName: attr(),
-  lastName: attr(),
+export default DS.Model.extend({
+  firstName: DS.attr(),
+  lastName: DS.attr(),
 
   fullName: Ember.computed('firstName', 'lastName', function() {
     return `${this.get('firstName')} ${this.get('lastName')}`;
@@ -73,19 +65,16 @@ match the type you would like to use in your JavaScript code. Ember
 Data allows you to define simple serialization and deserialization
 methods for attribute types called transforms. You can specify that
 you would like a transform to run for an attribute by providing the
-transform name as the first argument to the `attr` method. Ember Data
+transform name as the first argument to the `DS.attr` method. Ember Data
 supports attribute types of `string`, `number`, `boolean`, and `date`,
 which coerce the value to the JavaScript type that matches its name.
 
 ```app/models/person.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  name: attr('string'),
-  age: attr('number'),
-  admin: attr('boolean'),
-  birthday: attr('date')
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  age: DS.attr('number'),
+  admin: DS.attr('boolean'),
+  birthday: DS.attr('date')
 });
 ```
 
@@ -111,9 +100,7 @@ ember generate transform dollars
 Here is a simple transform that converts values between cents and US dollars.
 
 ```app/transforms/dollars.js
-import Transform from 'ember-data/transform';
-
-export default Transform.extend({
+export default DS.Transform.extend({
   deserialize: function(serialized) {
     return serialized / 100; // returns dollars
   },
@@ -131,17 +118,14 @@ reverse and converts a value to the format expected by the persistence layer.
 You would use the custom `dollars` transform like this:
 
 ```app/models/product.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  spent: attr('dollars')
+export default DS.Model.extend({
+  spent: DS.attr('dollars')
 });
 ```
 
 ### Options
 
-`attr` can also take a hash of options as a second parameter. At the moment
+`DS.attr` can also take a hash of options as a second parameter. At the moment
 the only option available is `defaultValue`, which can use a value or a function
 to set the default value of the attribute if one is not supplied.
 
@@ -150,14 +134,11 @@ In the following example we define that `verified` has a default value of
 creation:
 
 ```app/models/user.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  username: attr('string'),
-  email: attr('string'),
-  verified: attr('boolean', { defaultValue: false }),
-  createdAt: attr('date', {
+export default DS.Model.extend({
+  username: DS.attr('string'),
+  email: DS.attr('string'),
+  verified: DS.attr('boolean', { defaultValue: false }),
+  createdAt: DS.attr('date', {
     defaultValue() { return new Date(); }
   })
 });

--- a/source/localizable/models/finding-records.md
+++ b/source/localizable/models/finding-records.md
@@ -36,10 +36,10 @@ the store, without making a network request:
 var posts = this.get('store').peekAll('post'); // => no network request
 ```
 
-`store.findAll()` returns a `PromiseArray` that fulfills to a
-`RecordArray` and `store.peekAll` directly returns a `RecordArray`.
+`store.findAll()` returns a `DS.PromiseArray` that fulfills to a
+`DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `RecordArray` is not a JavaScript array.  It is
+It's important to note that `DS.RecordArray` is not a JavaScript array.  It is
 an object that implements [`Ember.Enumerable`][1]. This is important because,
 for example, if you want to retrieve records by index, the `[]` notation will
 not work--you'll have to use `objectAt(index)` instead.
@@ -51,7 +51,7 @@ not work--you'll have to use `objectAt(index)` instead.
 Ember Data provides the ability to query for records that meet certain criteria. Calling
 [`store.query()`](http://emberjs.com/api/data/classes/DS.Store.html#method_query)
 will make a `GET` request with the passed object serialized as query params. This method returns
-a `PromiseArray` in the same way as `findAll`.
+a `DS.PromiseArray` in the same way as `findAll`.
 
 For example, we could search for all `person` models who have the name of
 `Peter`:

--- a/source/localizable/models/index.md
+++ b/source/localizable/models/index.md
@@ -189,12 +189,9 @@ example, a `Person` model might have a `firstName` attribute that is a
 string, and a `birthday` attribute that is a date:
 
 ```app/models/person.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  firstName: attr('string'),
-  birthday:  attr('date')
+export default DS.Model.extend({
+  firstName: DS.attr('string'),
+  birthday:  DS.attr('date')
 });
 ```
 
@@ -203,20 +200,14 @@ example, an `order` may have many `line-items`, and a
 `line-item` may belong to a particular `order`.
 
 ```app/models/order.js
-import Model from 'ember-data/model';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  lineItems: hasMany('line-item')
+export default DS.Model.extend({
+  lineItems: DS.hasMany('line-item')
 });
 ```
 
 ```app/models/line-item.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  order: belongsTo('order')
+export default DS.Model.extend({
+  order: DS.belongsTo('order')
 });
 ```
 

--- a/source/localizable/models/pushing-records-into-the-store.md
+++ b/source/localizable/models/pushing-records-into-the-store.md
@@ -29,13 +29,10 @@ the top-most route in the route hierarchy, and its `model` hook gets
 called once when the app starts up.
 
 ```app/models/album.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  title: attr(),
-  artist: attr(),
-  songCount: attr()
+export default DS.Model.extend({
+  title: DS.attr(),
+  artist: DS.attr(),
+  songCount: DS.attr()
 });
 ```
 
@@ -80,9 +77,7 @@ serializer before pushing it into the store, you can use the
 [`store.pushPayload()`](http://emberjs.com/api/data/classes/DS.Store.html#method_pushPayload) method.
 
 ```app/serializers/album.js
-import RestSerializer from 'ember-data/serializers/rest';
-
-export default RestSerializer.extend({
+export default DS.RestSerializer.extend({
   normalize(typeHash, hash) {
     hash['songCount'] = hash['song_count']
     delete hash['song_count']

--- a/source/localizable/models/relationships.md
+++ b/source/localizable/models/relationships.md
@@ -4,69 +4,51 @@ define how your models relate to each other.
 ### One-to-One
 
 To declare a one-to-one relationship between two models, use
-`belongsTo`:
+`DS.belongsTo`:
 
 ```app/models/user.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  profile: belongsTo('profile')
+export default DS.Model.extend({
+  profile: DS.belongsTo('profile')
 });
 ```
 
 ```app/models/profile.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  user: belongsTo('user')
+export default DS.Model.extend({
+  user: DS.belongsTo('user')
 });
 ```
 
 ### One-to-Many
 
 To declare a one-to-many relationship between two models, use
-`belongsTo` in combination with `hasMany`, like this:
+`DS.belongsTo` in combination with `DS.hasMany`, like this:
 
 ```app/models/post.js
-import Model from 'ember-data/model';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  comments: hasMany('comment')
+export default DS.Model.extend({
+  comments: DS.hasMany('comment')
 });
 ```
 
 ```app/models/comment.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  post: belongsTo('post')
+export default DS.Model.extend({
+  post: DS.belongsTo('post')
 });
 ```
 
 ### Many-to-Many
 
 To declare a many-to-many relationship between two models, use
-`hasMany`:
+`DS.hasMany`:
 
 ```app/models/post.js
-import Model from 'ember-data/model';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  tags: hasMany('tag')
+export default DS.Model.extend({
+  tags: DS.hasMany('tag')
 });
 ```
 
 ```app/models/tag.js
-import Model from 'ember-data/model';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  posts: hasMany('post')
+export default DS.Model.extend({
+  posts: DS.hasMany('post')
 });
 ```
 
@@ -80,29 +62,23 @@ that model.
 
 However, sometimes you may have multiple `belongsTo`/`hasMany`s for
 the same type. You can specify which property on the related model is
-the inverse using `belongsTo` or `hasMany`'s `inverse`
+the inverse using `DS.belongsTo` or `DS.hasMany`'s `inverse`
 option. Relationships without an inverse can be indicated as such by
 including `{ inverse: null }`.
 
 
 ```app/models/comment.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  onePost: belongsTo('post', { inverse: null }),
-  twoPost: belongsTo('post'),
-  redPost: belongsTo('post'),
-  bluePost: belongsTo('post')
+export default DS.Model.extend({
+  onePost: DS.belongsTo('post', { inverse: null }),
+  twoPost: DS.belongsTo('post'),
+  redPost: DS.belongsTo('post'),
+  bluePost: DS.belongsTo('post')
 });
 ```
 
 ```app/models/post.js
-import Model from 'ember-data/model';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  comments: hasMany('comment', {
+export default DS.Model.extend({
+  comments: DS.hasMany('comment', {
     inverse: 'redPost'
   })
 });
@@ -117,36 +93,26 @@ is no inverse relationship then you can set the inverse to `null`.
 Here's an example of a one-to-many reflexive relationship:
 
 ```app/models/folder.js
-import Model from 'ember-data/model';
-import { belongsTo, hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  children: hasMany('folder', { inverse: 'parent' }),
-  parent: belongsTo('folder', { inverse: 'children' })
+export default DS.Model.extend({
+  children: DS.hasMany('folder', { inverse: 'parent' }),
+  parent: DS.belongsTo('folder', { inverse: 'children' })
 });
 ```
 
 Here's an example of a one-to-one reflexive relationship:
 
 ```app/models/user.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  name: attr('string'),
-  bestFriend: belongsTo('user', { inverse: 'bestFriend' })
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  bestFriend: DS.belongsTo('user', { inverse: 'bestFriend' }),
 });
 ```
 
 You can also define a reflexive relationship that doesn't have an inverse:
 
 ```app/models/folder.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  parent: belongsTo('folder', { inverse: null })
+export default DS.Model.extend({
+  parent: DS.belongsTo('folder', { inverse: null })
 });
 ```
 
@@ -159,7 +125,7 @@ relationship. However, since readonly data will never need to be
 updated and saved this often results in the creation of a great deal
 of code for very little benefit. An alternate approach is to define
 these relationships using an attribute with no transform
-(`attr()`). This makes it easy to access readonly values in
+(`DS.attr()`). This makes it easy to access readonly values in
 computed properties and templates without the overhead of defining
 extraneous models.
 
@@ -168,20 +134,14 @@ extraneous models.
 Let's assume that we have a `post` and a `comment` model, which are related to each other as follows:
 
 ```app/models/post.js
-import Model from 'ember-data/model';
-import { hasMany } from 'ember-data/relationships';
-
-export default Model.extend({
-  comments: hasMany('comment')
+export default DS.Model.extend({
+  comments: DS.hasMany('comment')
 });
 ```
 
 ```app/models/comment.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  post: belongsTo('post')
+export default DS.Model.extend({
+  post: DS.belongsTo('post')
 });
 ```
 

--- a/source/localizable/object-model/classes-and-instances.md
+++ b/source/localizable/object-model/classes-and-instances.md
@@ -1,5 +1,5 @@
 As you learn about Ember, you'll see code like `Ember.Component.extend()` and
-`Model.extend()`. Here, you'll learn about this `extend()` method, as well
+`DS.Model.extend()`. Here, you'll learn about this `extend()` method, as well
 as other major features of the Ember object model.
 
 ### Defining Classes

--- a/source/localizable/testing/testing-models.md
+++ b/source/localizable/testing/testing-models.md
@@ -1,5 +1,5 @@
 _Unit testing methods and computed properties follows previous patterns shown
-in [Unit Testing Basics] because Model extends Ember.Object._
+in [Unit Testing Basics] because DS.Model extends Ember.Object._
 
 [Ember Data] Models can be tested using the `moduleForModel` helper.
 
@@ -11,12 +11,9 @@ new `levelName` when the player reaches level 5.
 > model player`.
 
 ```app/models/player.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-
-export default Model.extend({
-  level:     attr('number', { defaultValue: 0 }),
-  levelName: attr('string', { defaultValue: 'Noob' }),
+export default DS.Model.extend({
+  level:     DS.attr('number', { defaultValue: 0 }),
+  levelName: DS.attr('string', { defaultValue: 'Noob' }),
 
   levelUp() {
     var newLevel = this.incrementProperty('level');
@@ -62,18 +59,13 @@ Assume that a `User` can own a `Profile`.
 > generate model user` and `ember generate model profile`.
 
 ```app/models/profile.js
-import Model from 'ember-data/model';
-
-export default Model.extend({
+export default DS.Model.extend({
 });
 ```
 
 ```app/models/user.js
-import Model from 'ember-data/model';
-import { belongsTo } from 'ember-data/relationships';
-
-export default Model.extend({
-  profile: belongsTo('profile')
+export default DS.Model.extend({
+  profile: DS.belongsTo('profile')
 });
 ```
 

--- a/source/localizable/tutorial/ember-data.md
+++ b/source/localizable/tutorial/ember-data.md
@@ -21,9 +21,9 @@ installing model-test
 When we open the model file, we see:
 
 ```app/models/rental.js
-import Model from 'ember-data/model';
+import DS from 'ember-data';
 
-export default Model.extend({
+export default DS.Model.extend({
 
 });
 ```
@@ -32,16 +32,15 @@ Let's add the same attributes for our rental that we used in our hard-coded arra
 _title_, _owner_, _city_, _type_, _image_, and _bedrooms_:
 
 ```app/models/rental.js
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
+import DS from 'ember-data';
 
-export default Model.extend({
-  title: attr(),
-  owner: attr(),
-  city: attr(),
-  type: attr(),
-  image: attr(),
-  bedrooms: attr()
+export default DS.Model.extend({
+  title: DS.attr(),
+  owner: DS.attr(),
+  city: DS.attr(),
+  type: DS.attr(),
+  image: DS.attr(),
+  bedrooms: DS.attr()
 });
 ```
 


### PR DESCRIPTION
I have an open https://github.com/emberjs/data/pull/4481 on the ember data repo to change the generators back to use the `import DS from 'ember-data'` style. This pr updates the guides to match those generators.