### PR TITLE
Recommend `templateName` as way to set template

### DIFF
--- a/source/localizable/routing/rendering-a-template.md
+++ b/source/localizable/routing/rendering-a-template.md
@@ -1,5 +1,4 @@
-One job of a route handler is rendering the
-appropriate template to the screen.
+One job of a route handler is rendering the appropriate template to the screen.
 
 By default, a route handler will render the template with the same name as the
 route. Take this router:
@@ -20,17 +19,19 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, implement the
-[`renderTemplate()`][1] hook:
-
-[1]: http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate
+If you want to render a template other than the default one, set the route's [`templateName`][1] property to the name of
+the template you want to render instead.
 
 ```app/routes/posts.js
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  renderTemplate() {
-    this.render('favoritePosts');
-  }
+  templateName: 'posts/favorite-posts'
 });
 ```
+
+You can override the [`renderTemplate()`][2] hook if you want finer control over template rendering.
+Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.
+
+[1]: http://emberjs.com/api/classes/Ember.Route.html#property_templateName
+[2]: http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate


### PR DESCRIPTION
Since `renderTemplate()` is one of those methods you can't call
`this._super()`, `templateName` is a cleaner way to change a route's
default template. Also, we will automatically benefit from improvements
to `renderTemplate()` if we don't override it for the simple reason of
choosing a different template.