### PR TITLE
Update app/routes.js at tutorial of routes and templates

### DIFF
--- a/source/localizable/tutorial/routes-and-templates.md
+++ b/source/localizable/tutorial/routes-and-templates.md
@@ -51,7 +51,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {


### PR DESCRIPTION
The docs show the ```app/routes.js``` without the config of ```rootURL``` defined by the environment.

