### PR TITLE
Add imports to code samples

### DIFF
--- a/source/localizable/applications/dependency-injection.md
+++ b/source/localizable/applications/dependency-injection.md
@@ -39,6 +39,8 @@ or application instance initializers (with the former being much more common).
 For example, an application initializer could register a `Logger` factory with the key `logger:main`:
 
 ```app/initializers/logger.js
+import Ember from 'ember';
+
 export function initialize(application) {
   var Logger = Ember.Object.extend({
     log(m) {
@@ -93,6 +95,8 @@ register your factories as non-singletons using the `singleton: false` option.
 In the following example, the `Message` class is registered as a non-singleton:
 
 ```app/initializers/notification.js
+import Ember from 'ember';
+
 export function initialize(application) {
   var Message = Ember.Object.extend({
     text: ''
@@ -114,6 +118,8 @@ Once a factory is registered, it can be "injected" where it is needed.
 Factories can be injected into whole "types" of factories with *type injections*. For example:
 
 ```app/initializers/logger.js
+import Ember from 'ember';
+
 export function initialize(application) {
   var Logger = Ember.Object.extend({
     log(m) {
@@ -138,6 +144,8 @@ The value of `logger` will come from the factory named `logger:main`.
 Routes in this example application can now access the injected logger:
 
 ```app/routes/index.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   activate() {
     // The logger property is injected into all routes
@@ -166,6 +174,8 @@ and services (via `Ember.inject.service`).
 The following code injects the `shopping-cart` service on the `cart-contents` component as the property `cart`:
 
 ```app/components/cart-contents.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   cart: Ember.inject.service('shopping-cart')
 });
@@ -175,6 +185,8 @@ If you'd like to inject a service with the same name as the property,
 simply leave off the service name (the dasherized version of the name will be used):
 
 ```app/components/cart-contents.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   shoppingCart: Ember.inject.service()
 });

--- a/source/localizable/applications/services.md
+++ b/source/localizable/applications/services.md
@@ -27,6 +27,8 @@ Services must extend the [`Ember.Service`][1] base class:
 [1]: http://emberjs.com/api/classes/Ember.Service.html
 
 ```app/services/shopping-cart.js
+import Ember from 'ember';
+
 export default Ember.Service.extend({
 });
 ```
@@ -35,6 +37,8 @@ Like any Ember object, a service is initialized and can have properties and meth
 Below the shopping cart service manages an items array that represents the items currently in the shopping cart.
 
 ```app/services/shopping-cart.js
+import Ember from 'ember';
+
 export default Ember.Service.extend({
   items: null,
 
@@ -67,6 +71,8 @@ When no arguments are passed, the service is loaded based on the name of the var
 You can load the shopping cart service with no arguments like below.
 
 ```app/components/cart-contents.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   //will load the service in file /app/services/shopping-cart.js
   shoppingCart: Ember.inject.service()
@@ -76,6 +82,8 @@ export default Ember.Component.extend({
 The other way to inject a service is to provide the name of the service as the argument.
 
 ```app/components/cart-contents.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   //will load the service in file /app/services/shopping-cart.js
   cart: Ember.inject.service('shopping-cart')
@@ -93,6 +101,8 @@ Below we add a remove action to the `cart-contents` component.
 Notice that below we access the `cart` service with a call to`this.get`.
 
 ```app/components/cart-contents.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   cart: Ember.inject.service('shopping-cart'),
 

--- a/source/localizable/components/customizing-a-components-element.md
+++ b/source/localizable/components/customizing-a-components-element.md
@@ -19,6 +19,8 @@ a `tagName` property. This property can be any valid HTML5 tag name as a
 string.
 
 ```app/components/navigation-bar.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   tagName: 'nav'
 });
@@ -44,6 +46,8 @@ You can also specify which class names are applied to the component's
 element by setting its `classNames` property to an array of strings:
 
 ```app/components/navigation-bar.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   classNames: ['primary']
 });
@@ -54,6 +58,8 @@ you can use class name bindings. If you bind to a Boolean property, the
 class name will be added or removed depending on the value:
 
 ```app/components/todo-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   classNameBindings: ['isUrgent'],
   isUrgent: true
@@ -72,6 +78,8 @@ By default, the name of the Boolean property is dasherized. You can customize th
 applied by delimiting it with a colon:
 
 ```app/components/todo-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   classNameBindings: ['isUrgent:urgent'],
   isUrgent: true
@@ -87,6 +95,8 @@ This would render this HTML:
 Besides the custom class name for the value being `true`, you can also specify a class name which is used when the value is `false`:
 
 ```app/components/todo-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   classNameBindings: ['isEnabled:enabled:disabled'],
   isEnabled: false
@@ -103,6 +113,8 @@ You can also specify a class which should only be added when the property is
 `false` by declaring `classNameBindings` like this:
 
 ```app/components/todo-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   classNameBindings: ['isEnabled::disabled'],
   isEnabled: false
@@ -125,6 +137,8 @@ If the bound property's value is a string, that value will be added as a class n
 modification:
 
 ```app/components/todo-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   classNameBindings: ['priority'],
   priority: 'highestPriority'
@@ -143,6 +157,8 @@ You can bind attributes to the DOM element that represents a component
 by using `attributeBindings`:
 
 ```app/components/link-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   tagName: 'a',
   attributeBindings: ['href'],
@@ -153,6 +169,8 @@ export default Ember.Component.extend({
 You can also bind these attributes to differently named properties:
 
 ```app/components/link-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   tagName: 'a',
   attributeBindings: ['customHref:href'],
@@ -163,6 +181,8 @@ export default Ember.Component.extend({
 If the attribute is null, it won't be rendered:
 
 ```app/components/link-item.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   tagName: 'span',
   title: null,

--- a/source/localizable/components/defining-a-component.md
+++ b/source/localizable/components/defining-a-component.md
@@ -33,6 +33,8 @@ Given the above template, you can now use the `{{blog-post}}` component:
 Its model is populated in `model` hook in the route handler:
 
 ```app/routes/index.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return this.get('store').findAll('post');
@@ -98,6 +100,8 @@ means of choosing different components for displaying different kinds of posts:
 ```
 
 ```app/routes/index.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return this.get('store').findAll('post');

--- a/source/localizable/components/handling-events.md
+++ b/source/localizable/components/handling-events.md
@@ -14,6 +14,8 @@ Let's implement `double-clickable` such that when it is
 clicked, an alert is displayed:
 
 ```app/components/double-clickable.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   doubleClick() {
     alert("DoubleClickableComponent was clicked!");
@@ -26,6 +28,8 @@ in succession. To enable bubbling `return true;` from the event handler method
 in your component.
 
 ```app/components/double-clickable.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   doubleClick() {
     Ember.Logger.info("DoubleClickableComponent was clicked!");
@@ -52,6 +56,8 @@ And if you need to, you may also stop events from bubbling, by using
 `return false;`.
 
 ```app/components/drop-target.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   attributeBindings: ['draggable'],
   draggable: 'true',

--- a/source/localizable/components/passing-properties-to-a-component.md
+++ b/source/localizable/components/passing-properties-to-a-component.md
@@ -14,6 +14,8 @@ display a blog post:
 Now imagine we have the following template and route:
 
 ```app/routes/index.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return this.get('store').findAll('post');
@@ -69,6 +71,8 @@ set the [`positionalParams`][1] attribute in your component class.
 [1]: http://emberjs.com/api/classes/Ember.Component.html#property_positionalParams
 
 ```app/components/blog-post.js
+import Ember from 'ember';
+
 const BlogPostComponent = Ember.Component.extend({});
 
 BlogPostComponent.reopenClass({
@@ -90,6 +94,8 @@ setting `positionalParams` to a string, e.g. `positionalParams: 'params'`. This
 will allow you to access those params as an array like so:
 
 ```app/components/blog-post.js
+import Ember from 'ember';
+
 const BlogPostComponent = Ember.Component.extend({
   title: Ember.computed('params.[]', function(){
     return this.get('params')[0];

--- a/source/localizable/components/triggering-changes-with-actions.md
+++ b/source/localizable/components/triggering-changes-with-actions.md
@@ -75,6 +75,8 @@ We'll implement an action on the parent component called
 `deleteUser()` method.
 
 ```app/components/user-profile.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   login: Ember.inject.service(),
 
@@ -95,6 +97,8 @@ Next, let's implement the logic to confirm that the user wants to take
 the action from the component:
 
 ```app/components/button-with-confirmation.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
 
   actions: {
@@ -155,6 +159,8 @@ Now, we can use `onConfirm` in the child component to invoke the action on the
 parent:
 
 ```app/components/button-with-confirmation.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
 
   actions: {
@@ -202,6 +208,8 @@ This is accomplished by expecting a promise to be returned from `onConfirm`.
 Upon resolution of the promise, we set a property used to indicate the visibility of the confirmation modal.
 
 ```app/components/button-with-confirmation.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   actions: {
     launchConfirmDialog() {
@@ -271,6 +279,8 @@ The `send-message` component provides an input as block content to the `button-w
 Now when the `submitConfirm` action is invoked, we call it with the value provided by our yielded input.
 
 ```app/components/button-with-confirmation.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   actions: {
     launchConfirmDialog() {
@@ -296,6 +306,8 @@ and the message value provided in the component JavaScript.
 
 
 ```app/components/send-message.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   actions: {
     sendMessage(messageType, messageText) {
@@ -311,6 +323,8 @@ Actions can be invoked on objects other than the component directly from the tem
 `send-message` component we might include a service that processes the `sendMessage` logic.
 
 ```app/components/send-message.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   messaging: Ember.inject.service(),
 
@@ -333,6 +347,8 @@ By supplying the `target` attribute, the action helper will look to invoke the `
 service, saving us from writing code on the component that just passes the action along to the service.
 
 ```app/services/messaging.js
+import Ember from 'ember';
+
 export default Ember.Service.extend({
   actions: {
     sendMessage(messageType, text) {
@@ -351,6 +367,8 @@ user's account was deleted, and passes along with it the full user profile objec
 
 
 ```app/components/user-profile.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   login: Ember.inject.service(),
 
@@ -374,6 +392,8 @@ object to pull out only what it needs.
 Now when the `system-preferences-editor` handles the delete action, it receives only the user's account `id` string.
 
 ```app/components/system-preferences-editor.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   actions: {
     userDeleted(idStr) {

--- a/source/localizable/configuring-ember/debugging.md
+++ b/source/localizable/configuring-ember/debugging.md
@@ -6,6 +6,8 @@ with your application.
 #### Log router transitions
 
 ```app/app.js
+import Ember from 'ember';
+
 export default Ember.Application.extend({
   // Basic logging, e.g. "Transitioned into 'post'"
   LOG_TRANSITIONS: true,
@@ -62,6 +64,8 @@ It's useful for understanding which objects Ember is finding when it does a look
 and which it is generating automatically for you.
 
 ```app/app.js
+import Ember from 'ember';
+
 export default Ember.Application.extend({
   LOG_RESOLVER: true
 });
@@ -115,6 +119,8 @@ but a common practice is to call `console.assert` to dump the error to the
 console.
 
 ```app/app.js
+import Ember from 'ember';
+
 Ember.RSVP.on('error', function(error) {
   Ember.Logger.assert(false, error);
 });

--- a/source/localizable/configuring-ember/embedding-applications.md
+++ b/source/localizable/configuring-ember/embedding-applications.md
@@ -14,6 +14,8 @@ You can tell the application to append the application template to a
 different element by specifying its `rootElement` property:
 
 ```app/app.js
+import Ember from 'ember';
+
 export default Ember.Application.extend({
   rootElement: '#app'
 });

--- a/source/localizable/controllers/index.md
+++ b/source/localizable/controllers/index.md
@@ -79,6 +79,8 @@ You can then define what the action does within the `actions` hook
 of the controller, as you would with a component:
 
 ```app/controllers/blog-post.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   actions: {
     toggleBody() {

--- a/source/localizable/models/customizing-adapters.md
+++ b/source/localizable/models/customizing-adapters.md
@@ -25,6 +25,8 @@ the default Adapter, however it will still be superseded by model
 specific Adapters.
 
 ```app/adapters/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   // Application specific overrides go here
 });
@@ -37,6 +39,8 @@ For example, running `ember generate adapter post` will create the
 following file:
 
 ```app/adapters/post.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   namespace: 'api/v1'
 });
@@ -140,6 +144,8 @@ The `namespace` property can be used to prefix requests with a
 specific url namespace.
 
 ```app/adapters/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   namespace: 'api/1'
 });
@@ -155,6 +161,8 @@ like to specify a new domain you can do so by setting the `host`
 property on the adapter.
 
 ```app/adapters/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   host: 'https://api.example.com'
 });
@@ -174,6 +182,8 @@ underscore_case instead of camelCase you could override the
 `pathForType` method like this:
 
 ```app/adapters/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   pathForType: function(type) {
     return Ember.String.underscore(type);
@@ -191,6 +201,8 @@ headers can be set as key/value pairs on the `JSONAPIAdapter`'s `headers`
 object and Ember Data will send them along with each ajax request.
 
 ```app/adapters/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   headers: {
     'API_KEY': 'secret key',
@@ -204,6 +216,8 @@ headers. In the example below, the headers are generated with a computed
 property dependent on the `session` service.
 
 ```app/adapters/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   session: Ember.inject.service('session'),
   headers: Ember.computed('session.authToken', function() {
@@ -223,6 +237,8 @@ function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 
 ```app/adapters/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   headers: Ember.computed(function() {
     return {
@@ -246,6 +262,8 @@ ensure Ember does the right thing in the case a user of your adapter
 does not specify an `serializer:application`.
 
 ```app/adapters/my-custom-adapter.js
+import DS from 'ember-data';
+
 export default DS.JSONAPIAdapter.extend({
   defaultSerializer: '-default'
 });

--- a/source/localizable/models/customizing-serializers.md
+++ b/source/localizable/models/customizing-serializers.md
@@ -268,6 +268,8 @@ serializer's `primaryKey` property to correctly transform the id
 property to `id` when serializing and deserializing data.
 
 ```app/serializers/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPISerializer.extend({
   primaryKey: '_id'
 });
@@ -279,6 +281,8 @@ In Ember Data the convention is to camelize attribute names on a
 model. For example:
 
 ```app/models/person.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   firstName: DS.attr('string'),
   lastName:  DS.attr('string'),
@@ -313,6 +317,8 @@ method like this.
 
 ```app/serializers/application.js
 import Ember from 'ember';
+import DS from 'ember-data';
+
 export default DS.JSONAPISerializer.extend({
   keyForAttribute: function(attr) {
     return Ember.String.underscore(attr);
@@ -332,12 +338,16 @@ desired attribute name is simply `lastName`, then create a custom
 Serializer for the model and override the `attrs` property.
 
 ```app/models/person.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   lastName: DS.attr('string')
 });
 ```
 
 ```app/serializers/person.js
+import DS from 'ember-data';
+
 export default DS.JSONAPISerializer.extend({
   attrs: {
     lastName: 'lastNameOfPerson'
@@ -351,6 +361,8 @@ References to other records should be done by ID. For example, if you
 have a model with a `hasMany` relationship:
 
 ```app/models/post.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   comments: DS.hasMany('comment', { async: true })
 });
@@ -385,6 +397,8 @@ dasherized version of the property's name. For example, if you have
 a model:
 
 ```app/models/comment.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   originalPost: DS.belongsTo('post')
 });
@@ -411,6 +425,8 @@ the
 method.
 
 ```app/serializers/application.js
+import DS from 'ember-data';
+
 export default DS.JSONAPISerializer.extend({
   keyForRelationship: function(key, relationship) {
     return key + 'Ids';
@@ -429,6 +445,8 @@ Ember Data can have new JSON transforms
 registered for use as attributes:
 
 ```app/transforms/coordinate-point.js
+import DS from 'ember-data';
+
 export default DS.Transform.extend({
   serialize: function(value) {
     return [value.get('x'), value.get('y')];
@@ -440,6 +458,8 @@ export default DS.Transform.extend({
 ```
 
 ```app/models/cursor.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   position: DS.attr('coordinate-point')
 });
@@ -481,6 +501,8 @@ To use it in your application you will need to define an
 `serializer:application` that extends the `JSONSerializer`.
 
 ```app/serializers/application.js
+import DS from 'ember-data';
+
 export default DS.JSONSerializer.extend({
   // ...
 });
@@ -556,6 +578,8 @@ that looks similar to this:
 You would define your relationship like this:
 
 ```app/serializers/post.js
+import DS from 'ember-data';
+
 export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     authors: {
@@ -571,6 +595,8 @@ embedded relationship you can use the shorthand option of `{ embedded:
 'always' }`. The following example and the one above are equivalent.
 
 ```app/serializers/post.js
+import DS from 'ember-data';
+
 export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     authors: { embedded: 'always' }
@@ -591,6 +617,8 @@ serializing the record. This is possible by using the `serialize:
 setting `serialize: false`.
 
 ```app/serializers/post.js
+import DS from 'ember-data';
+
 export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     author: {
@@ -645,6 +673,8 @@ relationship properties on the Model.
 For Example: given this `post` model.
 
 ```app/models/post.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   title: DS.attr('string'),
   tag: DS.attr('string'),

--- a/source/localizable/models/defining-models.md
+++ b/source/localizable/models/defining-models.md
@@ -15,6 +15,8 @@ ember generate model person
 This will generate the following file:
 
 ```app/models/person.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
 });
 ```
@@ -29,6 +31,8 @@ The `person` model we generated earlier didn't have any attributes. Let's
 add first and last name, as well as the birthday, using [`DS.attr`](http://emberjs.com/api/data/classes/DS.html#method_attr):
 
 ```app/models/person.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   firstName: DS.attr(),
   lastName: DS.attr(),
@@ -45,6 +49,8 @@ computed property. Frequently, you will want to define computed
 properties that combine or transform primitive attributes.
 
 ```app/models/person.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   firstName: DS.attr(),
   lastName: DS.attr(),
@@ -70,6 +76,8 @@ supports attribute types of `string`, `number`, `boolean`, and `date`,
 which coerce the value to the JavaScript type that matches its name.
 
 ```app/models/person.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   name: DS.attr('string'),
   age: DS.attr('number'),
@@ -100,6 +108,8 @@ ember generate transform dollars
 Here is a simple transform that converts values between cents and US dollars.
 
 ```app/transforms/dollars.js
+import DS from 'ember-data';
+
 export default DS.Transform.extend({
   deserialize: function(serialized) {
     return serialized / 100; // returns dollars
@@ -118,6 +128,8 @@ reverse and converts a value to the format expected by the persistence layer.
 You would use the custom `dollars` transform like this:
 
 ```app/models/product.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   spent: DS.attr('dollars')
 });
@@ -134,6 +146,8 @@ In the following example we define that `verified` has a default value of
 creation:
 
 ```app/models/user.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   username: DS.attr('string'),
   email: DS.attr('string'),

--- a/source/localizable/models/index.md
+++ b/source/localizable/models/index.md
@@ -74,6 +74,8 @@ You might be tempted to make the component responsible for fetching that
 data and storing it:
 
 ```app/components/list-of-drafts.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   willRender() {
     $.getJSON('/drafts').then(data => {
@@ -101,6 +103,8 @@ tempted to copy and paste your existing `willRender` code into the new
 component.
 
 ```app/components/drafts-button.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   willRender() {
     $.getJSON('/drafts').then(data => {
@@ -189,6 +193,8 @@ example, a `Person` model might have a `firstName` attribute that is a
 string, and a `birthday` attribute that is a date:
 
 ```app/models/person.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   firstName: DS.attr('string'),
   birthday:  DS.attr('date')
@@ -200,12 +206,15 @@ example, an `order` may have many `line-items`, and a
 `line-item` may belong to a particular `order`.
 
 ```app/models/order.js
+import DS from 'ember-data';
 export default DS.Model.extend({
   lineItems: DS.hasMany('line-item')
 });
 ```
 
 ```app/models/line-item.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   order: DS.belongsTo('order')
 });

--- a/source/localizable/models/pushing-records-into-the-store.md
+++ b/source/localizable/models/pushing-records-into-the-store.md
@@ -29,6 +29,8 @@ the top-most route in the route hierarchy, and its `model` hook gets
 called once when the app starts up.
 
 ```app/models/album.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   title: DS.attr(),
   artist: DS.attr(),
@@ -37,6 +39,8 @@ export default DS.Model.extend({
 ```
 
 ```app/routes/application.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     this.get('store').push({
@@ -77,6 +81,8 @@ serializer before pushing it into the store, you can use the
 [`store.pushPayload()`](http://emberjs.com/api/data/classes/DS.Store.html#method_pushPayload) method.
 
 ```app/serializers/album.js
+import DS from 'ember-data';
+
 export default DS.RestSerializer.extend({
   normalize(typeHash, hash) {
     hash['songCount'] = hash['song_count']
@@ -88,6 +94,8 @@ export default DS.RestSerializer.extend({
 ```
 
 ```app/routes/application.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     this.get('store').pushPayload({
@@ -120,6 +128,8 @@ so it can be accessed by other parts of your application.
 
 
 ```app/routes/confirm-payment.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   actions: {
     confirm: function(data) {

--- a/source/localizable/models/relationships.md
+++ b/source/localizable/models/relationships.md
@@ -7,12 +7,16 @@ To declare a one-to-one relationship between two models, use
 `DS.belongsTo`:
 
 ```app/models/user.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   profile: DS.belongsTo('profile')
 });
 ```
 
 ```app/models/profile.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   user: DS.belongsTo('user')
 });
@@ -24,12 +28,16 @@ To declare a one-to-many relationship between two models, use
 `DS.belongsTo` in combination with `DS.hasMany`, like this:
 
 ```app/models/blog-post.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   comments: DS.hasMany('comment')
 });
 ```
 
 ```app/models/comment.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   blogPost: DS.belongsTo('blog-post')
 });
@@ -41,12 +49,16 @@ To declare a many-to-many relationship between two models, use
 `DS.hasMany`:
 
 ```app/models/blog-post.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   tags: DS.hasMany('tag')
 });
 ```
 
 ```app/models/tag.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   blogPosts: DS.hasMany('blog-post')
 });
@@ -68,6 +80,8 @@ including `{ inverse: null }`.
 
 
 ```app/models/comment.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   onePost: DS.belongsTo('blog-post', { inverse: null }),
   twoPost: DS.belongsTo('blog-post'),
@@ -77,6 +91,8 @@ export default DS.Model.extend({
 ```
 
 ```app/models/blog-post.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   comments: DS.hasMany('comment', {
     inverse: 'redPost'
@@ -93,6 +109,8 @@ is no inverse relationship then you can set the inverse to `null`.
 Here's an example of a one-to-many reflexive relationship:
 
 ```app/models/folder.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   children: DS.hasMany('folder', { inverse: 'parent' }),
   parent: DS.belongsTo('folder', { inverse: 'children' })
@@ -102,6 +120,8 @@ export default DS.Model.extend({
 Here's an example of a one-to-one reflexive relationship:
 
 ```app/models/user.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   name: DS.attr('string'),
   bestFriend: DS.belongsTo('user', { inverse: 'bestFriend' }),
@@ -111,6 +131,8 @@ export default DS.Model.extend({
 You can also define a reflexive relationship that doesn't have an inverse:
 
 ```app/models/folder.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   parent: DS.belongsTo('folder', { inverse: null })
 });
@@ -134,12 +156,16 @@ extraneous models.
 Let's assume that we have a `blog-post` and a `comment` model, which are related to each other as follows:
 
 ```app/models/blog-post.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   comments: DS.hasMany('comment')
 });
 ```
 
 ```app/models/comment.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   blogPost: DS.belongsTo('blog-post')
 });

--- a/source/localizable/routing/asynchronous-routing.md
+++ b/source/localizable/routing/asynchronous-routing.md
@@ -81,6 +81,8 @@ will be the fulfilled values from the promises.
 A basic example:
 
 ```app/routes/tardy.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return new Ember.RSVP.Promise(function(resolve) {
@@ -121,6 +123,8 @@ default error handler unless it is handled by a custom error handler
 along the way, e.g.:
 
 ```app/routes/good-for-nothing.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return Ember.RSVP.reject("FAIL");
@@ -152,6 +156,8 @@ you can catch promise rejects within the `model` hook itself and convert
 them into fulfills that won't halt the transition.
 
 ```app/routes/funky.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return iHopeThisWorks().catch(function() {

--- a/source/localizable/routing/loading-and-error-substates.md
+++ b/source/localizable/routing/loading-and-error-substates.md
@@ -16,6 +16,8 @@ Router.map(function() {
 ```
 
 ```app/routes/slow-model.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return this.get('store').findAll('slow-model');
@@ -87,6 +89,8 @@ don't immediately resolve, a [`loading`][1] event will be fired on that route.
 [1]: http://emberjs.com/api/classes/Ember.Route.html#event_loading
 
 ```app/routes/foo-slow-model.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return this.get('store').findAll('slow-model');
@@ -107,6 +111,8 @@ route, providing the `application` route the opportunity to manage it.
 When using the `loading` handler, we can make use of the transition promise to know when the loading event is over:
 
 ```app/routes/foo-slow-model.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   ...
   actions: {
@@ -177,6 +183,8 @@ redirect to a login page, etc.
 [1]: http://emberjs.com/api/classes/Ember.Route.html#event_error
 
 ```app/routes/articles-overview.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model(params) {
     return this.get('store').findAll('problematic-model');

--- a/source/localizable/routing/preventing-and-retrying-transitions.md
+++ b/source/localizable/routing/preventing-and-retrying-transitions.md
@@ -20,6 +20,8 @@ made on the form, which can make for a pretty frustrating user experience.
 Here's one way this situation could be handled:
 
 ```app/routes/form.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   actions: {
     willTransition(transition) {
@@ -52,6 +54,8 @@ each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 
 ```app/routes/disco.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   beforeModel(transition) {
     if (new Date() > new Date('January 1, 1980')) {
@@ -70,6 +74,8 @@ page, and then redirecting them back to the authenticated route once
 they've logged in.
 
 ```app/routes/some-authenticated.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   beforeModel(transition) {
     if (!this.controllerFor('auth').get('userIsLoggedIn')) {
@@ -82,6 +88,8 @@ export default Ember.Route.extend({
 ```
 
 ```app/controllers/login.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   actions: {
     login() {

--- a/source/localizable/routing/query-params.md
+++ b/source/localizable/routing/query-params.md
@@ -23,6 +23,8 @@ been categorized as popular we'd specify `'category'`
 as one of `controller:article`'s `queryParams`:
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: ['category'],
   category: null
@@ -39,6 +41,8 @@ Now we need to define a computed property of our category-filtered
 array that the `articles` template will render:
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: ['category'],
   category: null,
@@ -130,6 +134,8 @@ associated with that controller, and set that query param's
 
 
 ```app/routes/articles.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   queryParams: {
     category: {
@@ -149,6 +155,8 @@ export default Ember.Route.extend({
 ```
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: ['category'],
   category: null
@@ -165,6 +173,8 @@ specify this on the `Route`'s `queryParams` config hash, e.g. (continued
 from the example above):
 
 ```app/routes/articles.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   queryParams: {
     category: {
@@ -186,6 +196,8 @@ a controller property to a different query param key using the
 following configuration syntax:
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: {
     category: 'articles_category'
@@ -201,6 +213,8 @@ Note that query params that require additional customization can
 be provided along with strings in the `queryParams` array.
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: ['page', 'filter', {
     category: 'articles_category'
@@ -217,6 +231,8 @@ In the following example, the controller query param property `page` is
 considered to have a default value of `1`.
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: 'page',
   page: 1
@@ -281,6 +297,8 @@ will use the newly reset value `1` as the value for the `page` query
 param.
 
 ```app/routes/articles.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   resetController(controller, isExiting, transition) {
     if (isExiting) {
@@ -298,6 +316,8 @@ even as a route's model changes. This can be accomplished by setting the
 config hash:
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: [{
     showMagnifyingGlass: {
@@ -311,6 +331,8 @@ The following demonstrates how you can override both the scope and the
 query param URL key of a single controller query param property:
 
 ```app/controllers/articles.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   queryParams: ['page', 'filter',
     {

--- a/source/localizable/routing/redirection.md
+++ b/source/localizable/routing/redirection.md
@@ -24,6 +24,8 @@ Router.map(function() {
 ```
 
 ```app/routes/index.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   beforeModel() {
     this.transitionTo('posts');
@@ -51,6 +53,8 @@ Router.map(function() {
 ```
 
 ```app/routes/posts.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   afterModel(model, transition) {
     if (model.get('length') === 1) {
@@ -88,6 +92,8 @@ transition validated, and not cause the parent route's hooks to fire again:
 [5]: http://emberjs.com/api/classes/Ember.Route.html#method_redirect
 
 ```app/routes/posts.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   redirect(model, transition) {
     if (model.get('length') === 1) {

--- a/source/localizable/routing/rendering-a-template.md
+++ b/source/localizable/routing/rendering-a-template.md
@@ -26,6 +26,8 @@ If you want to render a template other than the default one, implement the
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate
 
 ```app/routes/posts.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   renderTemplate() {
     this.render('favoritePosts');

--- a/source/localizable/routing/specifying-a-routes-model.md
+++ b/source/localizable/routing/specifying-a-routes-model.md
@@ -15,6 +15,8 @@ hook in the `favorite-posts` route handler:
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_model
 
 ```app/routes/favorite-posts.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return this.get('store').query('post', { favorite: true });
@@ -70,6 +72,8 @@ Router.map(function() {
 ```
 
 ```app/routes/photo.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model(params) {
     return this.get('store').findRecord('photo', params.photo_id);
@@ -98,6 +102,8 @@ parameters that return promises, and when all parameter promises resolve, then
 the `Ember.RSVP.hash` promise resolves. For example:
 
 ```app/routes/songs.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   model() {
     return Ember.RSVP.hash({

--- a/source/localizable/templates/actions.md
+++ b/source/localizable/templates/actions.md
@@ -18,6 +18,8 @@ In the component or controller, you can then define what the action does within
 the `actions` hook:
 
 ```app/components/single-post.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   actions: {
     toggleBody() {
@@ -46,6 +48,8 @@ The `select` action handler would be called with a single argument
 containing the post model:
 
 ```app/components/single-post.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   actions: {
     select(post) {

--- a/source/localizable/templates/displaying-the-keys-in-an-object.md
+++ b/source/localizable/templates/displaying-the-keys-in-an-object.md
@@ -4,6 +4,8 @@ JavaScript object in your template, you can use the
 helper:
 
 ```/app/components/store-categories.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   willRender() {
     // Set the "categories" property to a JavaScript object
@@ -65,6 +67,8 @@ helper **does not observe property changes** to the object passed into it. In
  automatically update.
 
 ```/app/components/store-categories.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   willRender() {
     this.set('categories', {
@@ -90,6 +94,8 @@ property on the component again, or manually trigger a re-render of the
 component via [`rerender()`](http://emberjs.com/api/classes/Ember.Component.html#method_rerender):
 
 ```/app/components/store-categories.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   willRender() {
     this.set('categories', {

--- a/source/localizable/templates/handlebars-basics.md
+++ b/source/localizable/templates/handlebars-basics.md
@@ -51,6 +51,8 @@ Ember gives you the ability to [write your own helpers](../writing-helpers/), to
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 
 ```app/helpers/sum.js
+import Ember from 'ember';
+
 export function sum(params) {
   return params.reduce((a, b) => {
     return a + b;

--- a/source/localizable/templates/writing-helpers.md
+++ b/source/localizable/templates/writing-helpers.md
@@ -42,6 +42,8 @@ That file should export a function wrapped with [`Ember.Helper.helper()`][1]:
 [1]: http://emberjs.com/api/classes/Ember.Helper.html#method_helper
 
 ```app/helpers/format-currency.js
+import Ember from 'ember';
+
 export function formatCurrency([value, ...rest]) {
   let dollars = Math.floor(value / 100);
   let cents = value % 100;
@@ -97,6 +99,8 @@ list after the helper name:
 An array of these arguments is passed to the helper function:
 
 ```app/helpers/my-helper.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function(params) {
   let [arg1, arg2] = params;
 
@@ -109,6 +113,8 @@ You can use JavaScript's destructuring assignment shorthand to clean up
 the code. This example is equivalent to the above example (note the function signature):
 
 ```app/helpers/my-helper.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function([arg1, arg2]) {
   console.log(arg1); // => "hello"
   console.log(arg2); // => "world"
@@ -151,6 +157,8 @@ to the helper function.  Here is our example from above, updated to
 support the optional `sign` option:
 
 ```app/helpers/format-currency.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function([value, ...rest], namedArgs) {
   let dollars = Math.floor(value / 100);
   let cents = value % 100;
@@ -169,6 +177,8 @@ You can pass as many named arguments as you'd like. They get added to the
 ```
 
 ```app/helpers/my-helper.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function(params, namedArgs) {
   console.log(namedArgs.option1); // => "hello"
   console.log(namedArgs.option2); // => "world"
@@ -180,6 +190,8 @@ You can use JavaScript's destructuring assignment shorthand in this case
 as well to clean up the above code:
 
 ```app/helpers/my-helper.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function(params, { option1, option2, option3 }) {
   console.log(option1); // => "hello"
   console.log(option2); // => "world"
@@ -239,6 +251,8 @@ As an exercise, here is the above `format-currency` helper re-factored
 into a class-based helper:
 
 ```app/helpers/format-currency.js
+import Ember from 'ember';
+
 export default Ember.Helper.extend({
   compute([value, ...rest], hash) {
     let dollars = Math.floor(value / 100);
@@ -259,6 +273,8 @@ As another example, let's make a helper utilizing an authentication
 service that welcomes users by their name if they're logged in:
 
 ```app/helpers/is-authenticated.js
+import Ember from 'ember';
+
 export default Ember.Helper.extend({
   authentication: Ember.inject.service(),
   compute() {
@@ -282,6 +298,8 @@ the browser will not interpret it as HTML.
 For example, here's a `make-bold` helper that returns a string containing HTML:
 
 ```app/helpers/make-bold.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function([param, ...rest]) {
   return `<b>${param}</b>`;
 });
@@ -305,6 +323,8 @@ escape the return value (that is, that it is _safe_) by using the
 [`htmlSafe`][4] string utility:
 
 ```app/helpers/make-bold.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function([param, ...rest]) {
   return Ember.String.htmlSafe(`<b>${param}</b>`);
 });
@@ -338,6 +358,8 @@ escape anything that may have come from an untrusted user with the
 `escapeExpression` utility:
 
 ```app/helpers/make-bold.js
+import Ember from 'ember';
+
 export default Ember.Helper.helper(function([param, ...rest]) {
   let value = Ember.Handlebars.Utils.escapeExpression(param);
   return Ember.String.htmlSafe(`<b>${value}</b>`);

--- a/source/localizable/testing/acceptance.md
+++ b/source/localizable/testing/acceptance.md
@@ -154,6 +154,8 @@ For creating your own test helper, run `ember generate test-helper
 shouldHaveElementWithCount`:
 
 ```tests/helpers/should-have-element-with-count.js
+import Ember from 'ember';
+
 export default Ember.Test.registerAsyncHelper(
     'shouldHaveElementWithCount', function(app) {
 });
@@ -176,6 +178,8 @@ first parameter. Other parameters, such as assert, need to be provided when call
 Here is an example of a non-async helper:
 
 ```tests/helpers/should-have-element-with-count.js
+import Ember from 'ember';
+
 export default Ember.Test.registerHelper('shouldHaveElementWithCount',
   function(app, assert, selector, n, context) {
     const el = findWithAssert(selector, context);
@@ -190,6 +194,8 @@ export default Ember.Test.registerHelper('shouldHaveElementWithCount',
 Here is an example of an async helper:
 
 ```tests/helpers/dblclick.js
+import Ember from 'ember';
+
 export default Ember.Test.registerAsyncHelper('dblclick',
   function(app, assert, selector, context) {
     let $el = findWithAssert(selector, context);
@@ -204,6 +210,8 @@ Async helpers also come in handy when you want to group interaction
 into one helper. For example:
 
 ```tests/helpers/add-contact.js
+import Ember from 'ember';
+
 export default Ember.Test.registerAsyncHelper('addContact',
   function(app, name) {
     fillIn('#name', name);

--- a/source/localizable/testing/testing-components.md
+++ b/source/localizable/testing/testing-components.md
@@ -8,6 +8,8 @@ component is bound to its `style` property.
 > component pretty-color`.
 
 ```app/components/pretty-color.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   attributeBindings: ['style'],
 
@@ -89,6 +91,8 @@ clicked on:
 > component magic-title`.
 
 ```app/components/magic-title.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   title: 'Hello World',
 
@@ -138,6 +142,8 @@ For example, imagine you have a comment form component that invokes a
 > component comment-form`.
 
 ```app/components/comment-form.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   comment: '',
 
@@ -194,6 +200,8 @@ and country of your current location:
 > component location-indicator`.
 
 ```app/components/location-indicator.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   locationService: Ember.inject.service('location-service'),
 
@@ -286,6 +294,8 @@ to limit requests to the server, and you want to verify that results are display
 > component delayed-typeahead`.
 
 ```app/components/delayed-typeahead.js
+import Ember from 'ember';
+
 export default Ember.Component.extend({
   actions: {
     handleTyping() {

--- a/source/localizable/testing/testing-controllers.md
+++ b/source/localizable/testing/testing-controllers.md
@@ -13,6 +13,8 @@ sets one of those properties, and an action named `setProps`.
 > controller posts`.
 
 ```app/controllers/posts.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   propA: 'You need to write tests',
   propB: 'And write one for me too',
@@ -76,12 +78,16 @@ accomplished by injecting one controller into another. For example, here are two
 > controller post`, and `ember generate controller comments`.
 
 ```app/controllers/post.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   title: Ember.computed.alias('model.title')
 });
 ```
 
 ```app/controllers/comments.js
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   post: Ember.inject.controller(),
   title: Ember.computed.alias('post.title')

--- a/source/localizable/testing/testing-models.md
+++ b/source/localizable/testing/testing-models.md
@@ -11,6 +11,8 @@ new `levelName` when the player reaches level 5.
 > model player`.
 
 ```app/models/player.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   level:     DS.attr('number', { defaultValue: 0 }),
   levelName: DS.attr('string', { defaultValue: 'Noob' }),
@@ -59,11 +61,15 @@ Assume that a `User` can own a `Profile`.
 > generate model user` and `ember generate model profile`.
 
 ```app/models/profile.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
 });
 ```
 
 ```app/models/user.js
+import DS from 'ember-data';
+
 export default DS.Model.extend({
   profile: DS.belongsTo('profile')
 });

--- a/source/localizable/testing/testing-routes.md
+++ b/source/localizable/testing/testing-routes.md
@@ -19,6 +19,8 @@ sub-routes and controllers.
 > we will answer 'n'.
 
 ```app/routes/application.js
+import Ember from 'ember';
+
 export default Ember.Route.extend({
   actions: {
     displayAlert(text) {

--- a/source/localizable/testing/unit-testing-basics.md
+++ b/source/localizable/testing/unit-testing-basics.md
@@ -17,6 +17,8 @@ Let's start by creating an object that has a `computedFoo` computed property
 based on a `foo` property.
 
 ```app/models/some-thing.js
+import Ember from 'ember';
+
 export default Ember.Object.extend({
   foo: 'bar',
 
@@ -58,6 +60,8 @@ the `testMethod` method alters some internal state of the object (by updating
 the `foo` property).
 
 ```app/models/some-thing.js
+import Ember from 'ember';
+
 export default Ember.Object.extend({
   foo: 'bar',
   testMethod() {
@@ -83,6 +87,8 @@ return value is calculated correctly. Suppose our object has a `calc` method
 that returns a value based on some internal state.
 
 ```app/models/some-thing.js
+import Ember from 'ember';
+
 export default Ember.Object.extend({
   count: 0,
   calc() {
@@ -108,6 +114,8 @@ test('should return incremented count on calc', function(assert) {
 Suppose we have an object that has a property and a method observing that property.
 
 ```app/models/some-thing.js
+import Ember from 'ember';
+
 export default Ember.Object.extend({
   foo: 'bar',
   other: 'no',


### PR DESCRIPTION
As mentioned by @locks on Slack, the Guides need imports all over. This takes care of that!

I've intentionally not squashed these commits, both for my own sanity, and ease of review. Let me know if you prefer that I squash these. 