### PR TITLE
Fix jshint error in `list-filter-test.js` snippet

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -22,7 +22,6 @@ Since we plan to use Ember Data as our model store, we need to make our action c
 Because accessing persisted data is typically done asynchronously, we want to use the wait helper at the end of our test, which will wait for all promises to resolve before completing the test.
 
 ```tests/integration/components/list-filter-test.js
-import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';


### PR DESCRIPTION
Linting error: 'Ember' is defined but never used.
![ember-guide-jshint](https://cloud.githubusercontent.com/assets/7013074/17437788/c167867a-5aed-11e6-8040-9ed17bd6caeb.png)
