### PR TITLE
Remove class "image" from <img>

### DIFF
--- a/source/localizable/tutorial/simple-component.md
+++ b/source/localizable/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `in
 
 ```app/templates/components/rental-listing.hbs{+2}
 <article class="listing">
-  <img src="{{rental.image}}" class="image" alt="">
+  <img src="{{rental.image}}" alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}


### PR DESCRIPTION
Just because it's only there to be error prone. And I say this because, obviously, I suffered it ^_^U.

1. It doesn't have anything to do with the styles of the application.

   If you check the styles provided by `ember-cli-tutorial-style` addon, the class `image` is only used to style the `a` tag (~~I didn't find a repo for it~~ [CSS here](https://github.com/emberjs/super-rentals/blob/master/vendor/ember-tutorial.css)):

  `vendor/ember-tutorial.css`

   ```css
   ...
   .listing a.image.wide {
     max-width: 100%;
     position: relative;
     z-index: 999;
   }
  ...
  .listing a.image {
    max-width: 150px;
    display: block;
  }
  ...
   ```

   Just that.It only styles the `a` tag.
2. Later, in this same tutorial page, in the section [Hiding and Showing an Image](https://guides.emberjs.com/v2.7.0/tutorial/simple-component/#toc_hiding-and-showing-an-image), the template `app/templates/components/rental-listing.hbs` is edited:

   ```hbs
   <a class="image {{if isWide "wide"}}">
     <img src="{{rental.image}}" alt="">
     <small>View Larger</small>
   </a>
   ```

   The other lines edited are highlighted with a very visual green background and marked with a `+`, because are new lines. There is no warning at all that the `<img>` tag here is also being edited (the *not used in any moment* `class="image"` is removed here). You can miss that change, because your attention is lured to that lines with a green background (yes, I totally miss this «silent» change).
3. *Very much later*, when you hit component `rental-listing-test.js` integration test (and you hit that at the very end of the **Super Rentals** Tutorial), you realise that not all your tests are passing. And guess what, yes: the error is caused because you didn't removed that `class="image" in the `<img>` that never has any mean. The error is caused because this:

   ```js
     this.render(hbs`{{rental-listing rental=rentalObj}}`);
    assert.equal(this.$('.image.wide').length, 0, 'initially rendered small');
    this.$('.image').click();
    assert.equal(this.$('.image.wide').length, 1, 'rendered wide after click');
    this.$('.image').click();
    assert.equal(this.$('.image.wide').length, 0, 'rendered small after second click');
   ```

   You see the problem? The `click` event is triggered over the `.image`. But you have both, `img` and `a` elements with the `image` class, so both are clicked, click event propagates and well, the thing is that this assertion:

  ```js
    assert.equal(this.$('.image.wide').length, 1, 'rendered wide after click');
  ```

  always fail, because `a` is always clicked twice, first directly and second when `<img>` inside it is clicked and the event bubbles, I guess. The fact is that the `length` is always zero (because you didn't delete the `class="image"` from the `<img>`).

So, like I don't see here any reason for the initial existence of `class="image"` in the `<img>` tag, and considering the fact that it's error prone, I strongly suggest this change ;). Unless I'm missing something, I think that's better off. All tests pass, everything continues working the same, everyone is happy :).