### PR TITLE
add /api namespace to ajax requests

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -1,15 +1,15 @@
-As they search for a rental, users might also want to narrow their search to a specific city. 
+As they search for a rental, users might also want to narrow their search to a specific city.
 Let's build a component that will let them filter rentals by city.
 
-To begin, let's generate our new component. 
+To begin, let's generate our new component.
 We'll call this component `list-filter`, since all we want our component to do is filter the list of rentals based on input.
 
 ```shell
 ember g component list-filter
 ```
 
-As before, this creates a Handlebars template (`app/templates/components/list-filter.hbs`), 
-a JavaScript file (`app/components/list-filter.js`), 
+As before, this creates a Handlebars template (`app/templates/components/list-filter.hbs`),
+a JavaScript file (`app/components/list-filter.js`),
 and a component integration test (`tests/integration/components/list-filter-test.js`).
 
 Let's start with writing some tests to help us think through what we are doing.
@@ -43,8 +43,8 @@ test('should initially load all listings', function (assert) {
       return RSVP.resolve(FILTERED_ITEMS);
     }
   });
-  
-  // with an integration test, you can set up and use your component in the same way your application 
+
+  // with an integration test, you can set up and use your component in the same way your application
   // will use it.
   this.render(hbs`
     {{#list-filter filter=(action 'filterByCity') as |results|}}
@@ -58,7 +58,7 @@ test('should initially load all listings', function (assert) {
     {{/list-filter}}
   `);
 
-  // the wait function will return a promise that will wait for all promises 
+  // the wait function will return a promise that will wait for all promises
   // and xhr requests to resolve before running the contents of the then block.
   return wait().then(() => {
     assert.equal(this.$('.city').length, 3);
@@ -91,7 +91,7 @@ test('should update with matching listings', function (assert) {
       </ul>
     {{/list-filter}}
   `);
-  
+
   // The keyup event here should invoke an action that will cause the list to be filtered
   this.$('.list-filter input').val('San').keyup();
 
@@ -136,7 +136,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -196,14 +196,16 @@ export default Ember.Controller.extend({
 });
 ```
 
-When the user types in the text field in our component, the `filterByCity` action in the controller is called. 
-This action takes in the `value` property, and filters the `rental` data for records in data store that match what the user has typed thus far. 
+When the user types in the text field in our component, the `filterByCity` action in the controller is called.
+This action takes in the `value` property, and filters the `rental` data for records in data store that match what the user has typed thus far.
 The result of the query is returned to the caller.
 
 For this action to work, we need to replace our Mirage `config.js` file with the following, so that it can respond to our queries.
 
 ```mirage/config.js
 export default function() {
+  this.namespace = '/api';
+
   let rentals = [{
       type: 'rentals',
       id: 1,

--- a/source/localizable/tutorial/installing-addons.md
+++ b/source/localizable/tutorial/installing-addons.md
@@ -42,6 +42,8 @@ Let's now configure Mirage to send back our rentals that we had defined above by
 
 ```mirage/config.js
 export default function() {
+  this.namespace = '/api';
+
   this.get('/rentals', function() {
     return {
       data: [{
@@ -83,5 +85,25 @@ export default function() {
 }
 ```
 
-This configures Mirage so that whenever Ember Data makes a GET request to `/rentals`, Mirage will return this JavaScript object as JSON.
+This configures Mirage so that whenever Ember Data makes a GET request to `/api/rentals`, Mirage will return this JavaScript object as JSON.
+In order for this to work, we need our application to default to making requests to the namespace of `/api`.
+Otherwise, we wouldn't be able later make a `rentals` route in our application, as Mirage would be using it.
 
+To do this, we want to generate an application adapter.
+
+```shell
+ember generate adapter application
+```
+
+This adapter will extend the [`JSONAPIAdapter`][1] base class from Ember Data:
+
+[1]: http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html
+
+```app/adapters/application.js
+import DS from 'ember-data';
+
+export default DS.JSONAPIAdapter.extend({
+  namespace: 'api'
+});
+
+```

--- a/source/localizable/tutorial/subroutes.md
+++ b/source/localizable/tutorial/subroutes.md
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown. (fo
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route. 
+Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -75,7 +75,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals. 
+In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.hbs{-2,-3,-4}
@@ -155,8 +155,10 @@ In order to do this, we need to modify the Mirage `config.js` file.
 If you need a refresher on how Mirage works, go back to the [Installing Addons section](../installing-addons)
 We will add a new route handler to mirage to handle when the http request comes in to fetch a rental.
 
-```mirage/config.js{+55,+56,+57,+58}
+```mirage/config.js{+57,+58,+59,+60}
 export default function() {
+  this.namespace = '/api';
+
   let rentals = [
     {
       type: 'rentals',
@@ -289,14 +291,14 @@ export default Ember.Route.extend({
 
 Since we added `:rental_id` to the `show` path in our router, we can now access `rental_id` through the `params` in our `model` hook.
 When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data makes an HTTP GET request to `/rentals/our-id`.
-You can read more about Ember Data in the [Models section](../../models/) of the guides, 
+You can read more about Ember Data in the [Models section](../../models/) of the guides,
 and read about the `findRecord` method of the Ember Data store service in the [API Documentation](http://emberjs.com/api/data/classes/DS.Store.html#method_findRecord).
 
 To ensure that we are properly interfacing with Ember Data, we'll write a unit test that confirms `findRecord` is called with the correct parameters.
 Since we are already leveraging ember-cli-mirage for our app persistence in this tutorial, we'll leverage it for our route test to act as a stub for the HTTP request that gets generated when we fetch our rental.
 
 Mirage will automatically start when the app starts for an acceptance test, but since we are writing a unit test, the same application start logic is not executed.
-Therefore we need to [start Mirage manually within our test](http://www.ember-cli-mirage.com/docs/v0.2.x/manually-starting-mirage/). 
+Therefore we need to [start Mirage manually within our test](http://www.ember-cli-mirage.com/docs/v0.2.x/manually-starting-mirage/).
 
 Create an ember test helper by running the following command:
 
@@ -414,10 +416,10 @@ Note that passing the `rental` model object to the `link-to` helper will by defa
 
 ## Final Check
 
-At this point all our tests should pass, including our [battery of acceptance tests](../acceptance-test) we created as our beginning requirements. 
+At this point all our tests should pass, including our [battery of acceptance tests](../acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)
 
-At this point you can go to [deployment](../deploying) and share your Super Rentals application to the world, 
+At this point you can go to [deployment](../deploying) and share your Super Rentals application to the world,
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hoped this has helped you get started with creating your own ambitious applications with Ember!


### PR DESCRIPTION
Per conversation here: https://github.com/emberjs/guides/pull/1603#issuecomment-238420863, this addresses adding the `/api` namespace to mirage, freeing up the `rentals` routes.

Corresponding super-rentals PR here: https://github.com/emberjs/super-rentals/pull/40