### PR TITLE
Correct dependencies in bower.json

### DIFF
--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -49,7 +49,7 @@ It is used in Ember CLI to manage front-end plugins and component dependencies
 (HTML, CSS, JavaScript, etc).  All Bower components are installed in the
 `bower_components` directory.  If we open `bower.json`, we see the list of
 dependencies that are installed automatically including Ember, Ember
-CLI Shims, Ember CLI Test Loader, and QUnit (for testing). If we add additional
+CLI Shims, and QUnit (for testing). If we add additional
 front-end dependencies, such as Bootstrap, we will see them listed here, and
 added to the `bower_components` directory.
 


### PR DESCRIPTION
Remove Ember CLI Test Loader as a dependency found in bower.json. This is a dev dependency in package.json.