### PR TITLE
Fix broken helper links

### DIFF
--- a/source/localizable/templates/built-in-helpers.md
+++ b/source/localizable/templates/built-in-helpers.md
@@ -28,11 +28,11 @@ if the `part` computed property returns "zip", this will display the result of
 
 In the last section it was discussed that helpers can be nested.
 This can be combined with these sorts of dynamic helpers.
-For example, the [`{{concat}}`][1] helper makes it easy to dynamically send
+For example, the [`{{concat}}`][2] helper makes it easy to dynamically send
 a number of parameters to a component or helper as a single parameter in the
 format of a concatenated string.
 
-[1]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_concat
+[2]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_concat
 
 ```handlebars
 {{get "foo" (concat "item" index)}}

--- a/source/localizable/templates/development-helpers.md
+++ b/source/localizable/templates/development-helpers.md
@@ -20,11 +20,11 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``][1] helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``][2] helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 
-[1]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_debugger
+[2]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_debugger
 
 ```handlebars
 {{debugger}}


### PR DESCRIPTION
This fixes duplicate reference-style links.  Previously, `{{get}}` linked to `{{concat}}`.