### PR TITLE
correct a reference to .jshintrc's predef

### DIFF
--- a/source/localizable/addons-and-dependencies/managing-dependencies.md
+++ b/source/localizable/addons-and-dependencies/managing-dependencies.md
@@ -48,7 +48,7 @@ Provide the asset path as the first and only argument.
 app.import('bower_components/moment/moment.js');
 ```
 
-You will need to add `"moment": true` to the `predef` section in `.jshintrc` to prevent JSHint errors
+You will need to add `"moment"` to the `predef` section in `.jshintrc` to prevent JSHint errors
 about using an undefined variable.
 
 ### AMD Javascript modules


### PR DESCRIPTION
The predef section of .jshintrc is an array of strings, not an object.  One does need to add "option":true elsewhere in the file to turn on features, but to tell jshintrc to ignore predefined variable names you just add the name to this array, not 'name:true'.  

Note here: http://jshint.com/docs/options/#predef it says "This option allows you to control which variables JSHint considers to be implicitly defined in the environment. Configure it with an array of string values."