### PR TITLE
Match code with the latest version

### DIFF
--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -88,7 +88,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {


### PR DESCRIPTION
The code listing of `app/router.js` in the tutorial does not match the one generated with latest `ember-cli` (v2.7.0).