### PR TITLE
Enable default browser :focus outline

### DIFF
--- a/source/stylesheets/base/_forms.scss
+++ b/source/stylesheets/base/_forms.scss
@@ -48,7 +48,6 @@ textarea {
   &:focus {
     border-color: $action-color;
     box-shadow: $form-box-shadow-focus;
-    outline: none;
   }
 }
 

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -54,8 +54,7 @@ a {
     color: darken($action-color, 15%);
   }
 
-  &:active,
-  &:focus {
+  &:active {
     outline: none;
   }
 }


### PR DESCRIPTION
I found the ember guides to be very frustrating to use without a mouse.