### PR TITLE
Point a link to the correct version of the doc

### DIFF
--- a/source/localizable/getting-started/quick-start.md
+++ b/source/localizable/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](https://guides.emberjs.com/v2.7.0/getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 


### PR DESCRIPTION
A link in the Quick Start page (v2.8.0) incorrectly points to an older version of the doc (v2.7.0).