### PR TITLE
Add explicit hbs dependency in Component tests

### DIFF
--- a/source/localizable/testing/testing-components.md
+++ b/source/localizable/testing/testing-components.md
@@ -42,6 +42,8 @@ We can test that changing the component's `name` property updates the
 component's `style` attribute and is reflected in the  rendered HTML:
 
 ```tests/integration/components/pretty-color-test.js
+import hbs from 'htmlbars-inline-precompile';
+
 test('should change colors', function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
Include **hbs** import in Component tests example. Otherwise the test will fail sin it will undefined and I think is not that easy to figure out that the dependency come form **htmlbars-inline-precompile** package.

Thanks!