### PR TITLE
Google Maps Utility Typo

### DIFF
--- a/source/localizable/tutorial/service.md
+++ b/source/localizable/tutorial/service.md
@@ -272,7 +272,7 @@ ember g util google-maps
 
 The CLI `generate util` command will create a utility file and a unit test.
 We'll delete the unit test since we don't want to test Google code.
-Our app needs a single function, `createMapElement`, which makes use of `google.maps.Map` to create our map element, `google.maps.Geocoder` to lookup the coordinates of our location, and `google.maps.Marker` to pin our map based on the resolved location.
+Our app needs a single function, `createMap`, which makes use of `google.maps.Map` to create our map element, `google.maps.Geocoder` to lookup the coordinates of our location, and `google.maps.Marker` to pin our map based on the resolved location.
 
 ```app/utils/google-maps.js
 import Ember from 'ember';


### PR DESCRIPTION
Line 275 reads "Our app needs a single function, `createMapElement`" however it appears the name of the function on line 288 is actually `createMap`.