### PR TITLE
Link to super rentals repo at the beginning of the tutorial

### DIFF
--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -1,3 +1,7 @@
+Welcome to the Ember Tutorial!
+This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
+If you get stuck at any point during the tutorial feel free to visit [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
+
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.
 This allows Ember developers to focus on building apps rather


### PR DESCRIPTION
I frequently get people on slack or github issues that are stuck at various points in the tutorial.  The first thing I typically do is direct them to the super rentals repo to compare their work against.  Its worth adding a reference to the tutorial.