### PR TITLE
Removed uls surronding rental-listing render

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -122,11 +122,9 @@ Next, in our `app/templates/rentals.hbs` file, we'll add our new `list-filter` c
 {{#list-filter
    filter=(action 'filterByCity')
    as |rentals|}}
-  <ul class="results">
-    {{#each rentals as |rentalUnit|}}
-      <li>{{rental-listing rental=rentalUnit}}</li>
-    {{/each}}
-  </ul>
+  {{#each rentals as |rentalUnit|}}
+    {{rental-listing rental=rentalUnit}}
+  {{/each}}
 {{/list-filter}}
 ```
 


### PR DESCRIPTION
This `ul` and `li` is breaking the design. I also don't see any need for them to be there!