### PR TITLE
Typo: component generation

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -8,7 +8,7 @@ We'll call this component `list-filter`, since all we want our component to do i
 ember g component list-filter
 ```
 
-As before, this creates a Handlebars template (`app/templates/components/list-filter.hbs`),
+As before, this creates a Component template (`app/templates/components/list-filter.hbs`),
 a JavaScript file (`app/components/list-filter.js`),
 and a component integration test (`tests/integration/components/list-filter-test.js`).
 


### PR DESCRIPTION
Ember tutorial: Building a Complex Component

Corrected line 11 typo: we are generating a new Component template, not "Handlebar" template.