### PR TITLE
Improve error documentation.

### DIFF
--- a/source/localizable/routing/loading-and-error-substates.md
+++ b/source/localizable/routing/loading-and-error-substates.md
@@ -187,12 +187,15 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model(params) {
-    return this.get('store').findAll('problematic-model');
+    return this.get('store').findAll('privileged-model');
   },
   actions: {
     error(error, transition) {
-      if (error) {
-        return this.transitionTo('error-page');
+      if (error.status === '403') {
+        this.replaceWith('login');
+      } else {
+        // Let the route above this handle the error.
+        return true;
       }
     }
   }


### PR DESCRIPTION
- Updated the example to be more sensible since the previous one is just a bad implementation of https://github.com/emberjs/ember.js/blob/ac957bcf9fc1eccc72a5af9bf81b519db379cda1/packages/ember-routing/lib/system/router.js#L1070-L1126
- We shouldn't return the `transition` from the action as this is unnecessarily confusing and will not do what people expect.
- We may want to document (via  `else { return true; }` that it results in bubbling of the action since it isn't mentioned anywhere else anymore. (https://github.com/emberjs/ember.js/blob/aeeddf7c00b42a340494465252481b5414d87009/packages/ember-runtime/lib/mixins/action_handler.js#L182)

We don't have a way to delegate back to https://github.com/emberjs/ember.js/blob/ac957bcf9fc1eccc72a5af9bf81b519db379cda1/packages/ember-routing/lib/system/router.js#L1076-L1098 which is annoying as well.