### PR TITLE
remove new code line marker

### DIFF
--- a/source/localizable/tutorial/subroutes.md
+++ b/source/localizable/tutorial/subroutes.md
@@ -294,7 +294,7 @@ When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data que
 
 Next, we can update the template for our show route (`app/templates/rentals/show.hbs`) and list the information for our rental.
 
-```app/templates/rentals/show.hbs{+16}
+```app/templates/rentals/show.hbs
 <div class="jumbo show-listing">
   <h2 class="title">{{model.title}}</h2>
   <div class="right detail-section">


### PR DESCRIPTION
we're editing a newly created file, so the marker is not needed and confusing