### PR TITLE
consistent use of this.get('store')

### DIFF
--- a/source/localizable/tutorial/subroutes.de-DE.md
+++ b/source/localizable/tutorial/subroutes.de-DE.md
@@ -67,7 +67,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 
 <pre><code class="app/routes/rentals.js{-2,-3,-4}">export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 </code></pre>
@@ -75,7 +75,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -258,12 +258,12 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
-Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 

--- a/source/localizable/tutorial/subroutes.es-ES.md
+++ b/source/localizable/tutorial/subroutes.es-ES.md
@@ -67,7 +67,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 
 <pre><code class="app/routes/rentals.js{-2,-3,-4}">export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 </code></pre>
@@ -75,7 +75,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -258,12 +258,12 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
-Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 

--- a/source/localizable/tutorial/subroutes.fr-FR.md
+++ b/source/localizable/tutorial/subroutes.fr-FR.md
@@ -67,7 +67,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 
 <pre><code class="app/routes/rentals.js{-2,-3,-4}">export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 </code></pre>
@@ -75,7 +75,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -258,12 +258,12 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
-Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 

--- a/source/localizable/tutorial/subroutes.ja-JP.md
+++ b/source/localizable/tutorial/subroutes.ja-JP.md
@@ -67,7 +67,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 
 <pre><code class="app/routes/rentals.js{-2,-3,-4}">export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 </code></pre>
@@ -75,7 +75,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -258,12 +258,12 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
-Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 

--- a/source/localizable/tutorial/subroutes.md
+++ b/source/localizable/tutorial/subroutes.md
@@ -81,7 +81,7 @@ Let's implement our newly generated `rentals/index` route by moving this `findAl
 ```app/routes/rentals.js{-2,-3,-4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -89,7 +89,7 @@ export default Ember.Route.extend({
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -282,13 +282,13 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 

--- a/source/localizable/tutorial/subroutes.pt-BR.md
+++ b/source/localizable/tutorial/subroutes.pt-BR.md
@@ -67,7 +67,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 
 <pre><code class="app/routes/rentals.js{-2,-3,-4}">export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 </code></pre>
@@ -75,7 +75,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -258,12 +258,12 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
-Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 

--- a/source/localizable/tutorial/subroutes.ru-RU.md
+++ b/source/localizable/tutorial/subroutes.ru-RU.md
@@ -67,7 +67,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 
 <pre><code class="app/routes/rentals.js{-2,-3,-4}">export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 </code></pre>
@@ -75,7 +75,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -258,12 +258,12 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
-Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 

--- a/source/localizable/tutorial/subroutes.zh-CN.md
+++ b/source/localizable/tutorial/subroutes.zh-CN.md
@@ -67,7 +67,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 
 <pre><code class="app/routes/rentals.js{-2,-3,-4}">export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 </code></pre>
@@ -75,7 +75,7 @@ In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook),
 ```app/routes/rentals/index.js{+2,+3,+4}
 export default Ember.Route.extend({
   model() {
-    return this.store.findAll('rental');
+    return this.get('store').findAll('rental');
   }
 });
 ```
@@ -258,12 +258,12 @@ Next, we want to edit our `show` route to retrieve the requested rental:
 ```app/routes/rentals/show.js{+2,+3,+4}
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('rental', params.rental_id);
+    return this.get('store').findRecord('rental', params.rental_id);
   }
 });
 ```
 
-Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook. When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
 
 ## Adding the Rental To Our Template
 


### PR DESCRIPTION
the `subroute` step in the tutorial uses `this.store.find...` where all others use `this.get('store')`