### PR TITLE
Clarify context of action implementation

### DIFF
--- a/source/localizable/components/triggering-changes-with-actions.md
+++ b/source/localizable/components/triggering-changes-with-actions.md
@@ -57,7 +57,7 @@ Let's take it step by step.
 ## Implementing the Action
 
 In the parent component, let's first define what we want to happen when the
-user clicks the button and then confirms. In this case, we'll find the user's
+user clicks the button and then confirms. In the first case, we'll find the user's
 account and delete it.
 
 In Ember, each component can


### PR DESCRIPTION
This is a minor change to help the reader parse the discussion that follows. The fact that two different usages of the component are planned has already been introduced in the section "Creating the Component." Just saying "in this case" is potentially confusing given that two different cases have been foreshadowed and the second case of message sending is discussed later in the presentation.