### PR TITLE
Emphasize change of context to child component

### DIFF
--- a/source/localizable/components/triggering-changes-with-actions.md
+++ b/source/localizable/components/triggering-changes-with-actions.md
@@ -93,8 +93,8 @@ want this action to be triggered, which is the next step.
 
 ## Designing the Child Component
 
-Next, let's implement the logic to confirm that the user wants to take
-the action from the component:
+Next,
+in the child component we will implement the logic to confirm that the user wants to take the action they indicated by clicking the button:
 
 ```app/components/button-with-confirmation.js
 import Ember from 'ember';


### PR DESCRIPTION
This is a minor change to help the reader parse the explanation of how component actions are implemented. In the preceding section we have already said "Let's look at the parent component's JavaScript file". This proposed change just emphasizes to the reader that we are now shifting focus to the internal implementation of the component.