### PR TITLE
Working on fixing build issues for v1.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     eventmachine (1.0.7)
-    execjs (2.3.0)
+    execjs (2.7.0)
     ffi (1.9.6)
     ffi (1.9.6-x86-mingw32)
     haml (4.0.6)
@@ -58,7 +58,7 @@ GEM
     hooks (0.4.0)
       uber (~> 0.0.4)
     i18n (0.6.11)
-    json (1.8.2)
+    json (1.8.6)
     kramdown (1.5.0)
     listen (2.8.5)
       celluloid (>= 0.15.2)
@@ -172,7 +172,7 @@ GEM
     tzinfo-data (1.2015.1)
       tzinfo (>= 1.0.0)
     uber (0.0.13)
-    uglifier (2.7.0)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     underscore-rails (1.7.0)
@@ -209,6 +209,3 @@ DEPENDENCIES
   tzinfo-data
   underscore-rails
   wdm (>= 0.1.0)
-
-BUNDLED WITH
-   1.12.4


### PR DESCRIPTION
This is to help with building v1.10 for https://github.com/emberjs/guides/issues/1561

Currently (after upgrading `eventmachine` to `1.0.9` to work around openssl issues mentioned here (https://github.com/eventmachine/eventmachine/issues/602), I'm seeing an error about `select2.js` when trying to run `bundle exec middleman build` to produce our static files:

```sh
machine-name:~/ember/guides$ bundle exec middleman build
   identical  build/stylesheets/colors.css
   identical  build/stylesheets/fonts/animation.css

   ... snippage ...

   identical  build/fonts/maven_pro_black-webfont.eot
   identical  build/fonts/maven_pro_medium-webfont.eot
   identical  build/fonts/maven_pro_bold-webfont.eot
       error  build/javascripts/vendor/select2.js
   identical  build/javascripts/common-old-ie.js
   identical  build/javascripts/app/back-to-top.js
   identical  build/javascripts/guides.js

```

when I run in verbose mode I get more detail, but am having a hard time debugging what is going on:

```sh
machine-name:~/ember/guides$ bundle exec middleman build --verbose

  .. much snippage ....

   identical  build/fonts/fontello.eot
   identical  build/fonts/maven_pro_black-webfont.eot
   identical  build/fonts/maven_pro_medium-webfont.eot
   identical  build/fonts/maven_pro_bold-webfont.eot

       error  build/javascripts/vendor/select2.js

/machine/path/ember/guides/vendor/bundle/gems/execjs-2.3.0/lib/execjs/external_runtime.rb:196:in `exec_runtime'
/machine/path/ember/guides/vendor/bundle/gems/execjs-2.3.0/lib/execjs/external_runtime.rb:32:in `exec'
/machine/path/ember/guides/vendor/bundle/gems/uglifier-2.7.0/lib/uglifier.rb:200:in `run_uglifyjs'
/machine/path/ember/guides/vendor/bundle/gems/uglifier-2.7.0/lib/uglifier.rb:178:in `compile'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-more/extensions/minify_javascript.rb:55:in `call'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-more/extensions/minify_css.rb:48:in `call'
/machine/path/ember/guides/vendor/bundle/gems/rack-1.6.0/lib/rack/head.rb:13:in `call'
/machine/path/ember/guides/vendor/bundle/gems/rack-1.6.0/lib/rack/lint.rb:49:in `_call'
/machine/path/ember/guides/vendor/bundle/gems/rack-1.6.0/lib/rack/lint.rb:37:in `call'
/machine/path/ember/guides/vendor/bundle/gems/rack-1.6.0/lib/rack/builder.rb:153:in `call'
/machine/path/ember/guides/vendor/bundle/gems/rack-test-0.6.3/lib/rack/mock_session.rb:30:in `request'
/machine/path/ember/guides/vendor/bundle/gems/rack-test-0.6.3/lib/rack/test.rb:244:in `process_request'
/machine/path/ember/guides/vendor/bundle/gems/rack-test-0.6.3/lib/rack/test.rb:58:in `get'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli/build.rb:255:in `render_to_file'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli/build.rb:221:in `build_resource'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli/build.rb:213:in `each'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli/build.rb:213:in `execute!'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli/build.rb:128:in `invoke!'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/actions.rb:94:in `action'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli/build.rb:70:in `build'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli.rb:72:in `method_missing'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/command.rb:29:in `run'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/command.rb:126:in `run'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
/machine/path/ember/guides/vendor/bundle/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/lib/middleman-core/cli.rb:20:in `start'
/machine/path/ember/guides/vendor/bundle/gems/middleman-core-3.3.7/bin/middleman:18:in `<top (required)>'
/machine/path/ember/guides/vendor/bundle/bin/middleman:23:in `load'
/machine/path/ember/guides/vendor/bundle/bin/middleman:23:in `<main>'
   identical  build/javascripts/common-old-ie.js
   identical  build/javascripts/app/back-to-top.js
   identical  build/javascripts/guides.js
   identical  build/javascripts/app/docsearch.js

  ... much snippage ...
```

As far as I can tell, this seems to be something in the uglifier gem dying on our `select2.js` file, but as far as I can tell neither uglifier nor the `select2.js` file have changed.

The closest I've come to finding an answer is https://github.com/lord/slate/issues/510 and https://github.com/lord/slate/commit/62fb143490ccde66fa312068bc99aa66a2fd99e5 but those are upgrades to a much newer version of Middleman than we're using

I'm seeing this issue on 10.11 with Ruby 2.0, 2.2 and 2.3