### PR TITLE
Remove unnecessary _super call

### DIFF
--- a/source/localizable/tutorial/routes-and-templates.md
+++ b/source/localizable/tutorial/routes-and-templates.md
@@ -243,7 +243,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   beforeModel() {
-    this._super(...arguments);
     this.replaceWith('rentals');
   }
 });


### PR DESCRIPTION
This call is not needed, the route extends Ember.Route, this PR is in response to someone who it confused on slack.

Either way, it's definitely wrong. You can't just call `this._super()` in beforeModel and expect it to work. If you actually have a superclass hook to call, you need to take promises into account.

I.e., if you want to be paranoid about making sure it always works correctly with superclasses, this code is required:

```javascript
export default Ember.Route.extend({
  beforeModel() {
    Ember.RSVP.resolve(this._super(...arguments)).then( () =>
      this.replaceWith('rentals')
    );
   }
 });
```