### PR TITLE
Update deploying.md to help Apache users

### DIFF
--- a/data/spelling-exceptions.txt
+++ b/data/spelling-exceptions.txt
@@ -8,6 +8,7 @@ ajax
 allget
 amd
 americentric
+apache
 api
 apis
 app's
@@ -109,9 +110,11 @@ hashchange
 hasmany
 hoc
 homebrew
+htaccess
 html
 htmlbars
 http
+httpd
 https
 iframe
 iframes
@@ -204,6 +207,7 @@ rerender
 rerendering
 restadapter
 reversereverseobjects
+rewriteguide
 routinglog
 rsvp
 runloop
@@ -216,6 +220,7 @@ semver
 serializer
 serializer's
 serializers
+ServersApache
 shiftshiftobject
 sideload
 sideloaded

--- a/source/localizable/tutorial/deploying.md
+++ b/source/localizable/tutorial/deploying.md
@@ -48,8 +48,9 @@ surge funny-name.surge.sh
 
 We use `--enviroment=development` here so that Mirage will continue to mock fake data.  However, normally we would use `ember build --environment=production` which does more to make your code ready for production.
 
-## Apache Users
+## Servers
 
+### Apache
 On an Apache server, the rewrite engine (mod-rewrite) must be enabled in order for Ember routing to work properly. If you upload your dist folder, going to your main URL works, but when you try to go to a route such as '{main URL}/example' and it returns 404, your server has not been configured for "friendly" URLs. To fix this, if it doesn't exist, add a file called '.htaccess' (just a period at the beginning, nothing before it) to the root folder of your website. Add these lines:
 
 ```

--- a/source/localizable/tutorial/deploying.md
+++ b/source/localizable/tutorial/deploying.md
@@ -46,14 +46,19 @@ cp index.html 200.html
 surge funny-name.surge.sh
 ```
 
-We use `--enviroment=development` here so that Mirage will continue to mock fake data.  However, normally we would use `ember build --environment=production` which does more to make your code ready for production.
+We use `--enviroment=development` here so that Mirage will continue to mock fake data.
+However, normally we would use `ember build --environment=production` which does more to make your code ready for production.
 
 ## Servers
 
 ### Apache
-On an Apache server, the rewrite engine (mod-rewrite) must be enabled in order for Ember routing to work properly. If you upload your dist folder, going to your main URL works, but when you try to go to a route such as '{main URL}/example' and it returns 404, your server has not been configured for "friendly" URLs. To fix this, if it doesn't exist, add a file called '.htaccess' (just a period at the beginning, nothing before it) to the root folder of your website. Add these lines:
 
-```
+On an Apache server, the rewrite engine (mod-rewrite) must be enabled in order for Ember routing to work properly.
+If you upload your dist folder, going to your main URL works, but when you try to go to a route such as '{main URL}/example' and it returns 404, your server has not been configured for "friendly" URLs.
+To fix this, if it doesn't exist, add a file called '.htaccess' (just a period at the beginning, nothing before it) to the root folder of your website.
+Add these lines:
+
+```text
 <IfModule mod_rewrite.c>
 RewriteEngine On
 RewriteRule ^index\.html$ - [L]

--- a/source/localizable/tutorial/deploying.md
+++ b/source/localizable/tutorial/deploying.md
@@ -47,3 +47,19 @@ surge funny-name.surge.sh
 ```
 
 We use `--enviroment=development` here so that Mirage will continue to mock fake data.  However, normally we would use `ember build --environment=production` which does more to make your code ready for production.
+
+## Apache Users
+
+On an Apache server, the rewrite engine (mod-rewrite) must be enabled in order for Ember routing to work properly. If you upload your dist folder, going to your main URL works, but when you try to go to a route such as '{main URL}/example' and it returns 404, your server has not been configured for "friendly" URLs. To fix this, if it doesn't exist, add a file called '.htaccess' (just a period at the beginning, nothing before it) to the root folder of your website. Add these lines:
+
+```
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule ^index\.html$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule (.*) index.html [L]
+</IfModule>
+```
+
+Your server's configuration may be different so you may need different options. Please see http://httpd.apache.org/docs/2.0/misc/rewriteguide.html for more information.


### PR DESCRIPTION
Most websites are hosted on Apache servers so many users will need to enable and configure mod-rewrite in order for Ember routing (or most MVC routing) to work properly. This gives the most common example.