### PR TITLE
Update algolia version

### DIFF
--- a/source/javascripts/app/docsearch.js.erb
+++ b/source/javascripts/app/docsearch.js.erb
@@ -2,7 +2,7 @@
   var script = document.createElement('script');
   script.type = 'text/javascript';
   script.async = true;
-  script.src = '//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js';
+  script.src = '//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js';
   var entry = document.getElementsByTagName('script')[0];
   entry.parentNode.insertBefore(script, entry);
 }());

--- a/source/stylesheets/_vendor-overwrites.scss
+++ b/source/stylesheets/_vendor-overwrites.scss
@@ -1,14 +1,14 @@
 /* Algolia Docsearch CSS overrides - https://github.com/algolia/docsearch#customization
    =========================================================================================== */
 
-.aa-dropdown-menu {
+.ds-dropdown-menu {
   right: 0 !important;
   font-size: .8rem;
   border-color: #aaa;
 }
 
 @media (min-width: $breakpoint-large) {
-  .aa-dropdown-menu {
+  .ds-dropdown-menu {
     // The guides search input is on the right-hand
     // side of the header, so it should extend to
     // the left of the input, not to the right.

--- a/source/stylesheets/vendor/_docsearch.scss
+++ b/source/stylesheets/vendor/_docsearch.scss
@@ -8,7 +8,7 @@
 // - Adding a second colum to let the content breath if enough room available
 
 // Main autocomplete wrapper
-.aa-dropdown-menu {
+.ds-dropdown-menu {
   background-color: #FFF;
   border-radius: 4px;
   margin: 6px 0 0;
@@ -67,6 +67,12 @@
 // The text snippet is hidden on small screens
 .algolia-docsearch-suggestion--text {
   display: none;
+
+  // If text parent node has --no-results
+  // we should display the content
+  .algolia-docsearch-suggestion--no-results & {
+    display: block;
+  }
 }
 
 .algolia-docsearch-suggestion--content {
@@ -110,7 +116,7 @@
 // BREAKPOINT 1:
 // Screen is big enough to display the text snippets
 @media (min-width: $breakpoint-medium) {
-  .aa-dropdown-menu {
+  .ds-dropdown-menu {
     min-width: $dropdown-min-width-medium;
   }
   .algolia-docsearch-suggestion--text {
@@ -123,7 +129,7 @@
 // BREAKPOINT 2:
 // Screen is big enough to display results in two columns
 @media (min-width: $breakpoint-large) {
-  .aa-dropdown-menu {
+  .ds-dropdown-menu {
     min-width: $dropdown-min-width-large;
   }
   .algolia-docsearch-suggestion {


### PR DESCRIPTION
Related to https://github.com/emberjs/website/pull/2799

- Updated algolia by modifiying CDN namespace version in order to display an error message when no results found.
- Updated _docsearch.scss vendors accordingly to algolia CDN update due to some markup update from Algolia.
- Remove display none of .algolia-docsearch-suggestion--text when parent node has a class of --no-results otherwise "no results" message was not visible.

Now when there is no result we have a UI feedback

![result](https://s28.postimg.org/48c6w0j7h/Capture_d_e_cran_2017_02_01_a_21_34_50.png)