### PR TITLE
(Triggering Changes with Actions) Use multiline HBS

### DIFF
--- a/source/localizable/components/triggering-changes-with-actions.md
+++ b/source/localizable/components/triggering-changes-with-actions.md
@@ -31,13 +31,17 @@ ember generate component button-with-confirmation
 We'll plan to use the component in a template something like this:
 
 ```app/templates/components/user-profile.hbs
-{{button-with-confirmation text="Click OK to delete your account."}}
+{{button-with-confirmation
+  text="Click OK to delete your account."
+}}
 ```
 
 We'll also want to use the component elsewhere, perhaps like this:
 
 ```app/templates/components/send-message.hbs
-{{button-with-confirmation text="Click OK to send your message."}}
+{{button-with-confirmation
+  text="Click OK to send your message."
+}}
 ```
 
 ## Designing the Action
@@ -139,7 +143,10 @@ This is possible since actions are simply functions, just like any other method 
 and they can therefore be passed from one component to another like this:
 
 ```app/templates/components/user-profile.hbs
-{{button-with-confirmation text="Click here to delete your account." onConfirm=(action "userDidDeleteAccount")}}
+{{button-with-confirmation
+  text="Click here to delete your account."
+  onConfirm=(action "userDidDeleteAccount")
+}}
 ```
 
 This snippet says "take the `userDidDeleteAccount` action from the parent and make it available on the child component as the property `onConfirm`."
@@ -149,7 +156,10 @@ which serves to return the function named `"userDidDeleteAccount"` that we are p
 We can do a similar thing for our `send-message` component:
 
 ```app/templates/components/send-message.hbs
-{{button-with-confirmation text="Click to send your message." onConfirm=(action "sendMessage")}}
+{{button-with-confirmation
+  text="Click to send your message."
+  onConfirm=(action "sendMessage")
+}}
 ```
 
 Now, we can use `onConfirm` in the child component to invoke the action on the
@@ -425,7 +435,9 @@ Then our `system-preferences-editor` template passes its local `deleteUser` acti
 component's `deleteCurrentUser` property.
 
 ```app/templates/components/system-preferences-editor.hbs
-{{user-profile deleteCurrentUser=(action 'deleteUser' login.currentUser.id)}}
+{{user-profile
+  deleteCurrentUser=(action 'deleteUser' login.currentUser.id)
+}}
 ```
 
 The action `deleteUser` is in quotes, since `system-preferences-editor` is where the action is defined now. Quotes indicate that the action should be looked for in `actions` local to that component, rather than in those that have been passed from a parent.
@@ -433,8 +445,10 @@ The action `deleteUser` is in quotes, since `system-preferences-editor` is where
 In our `user-profile.hbs` template we change our action to call `deleteCurrentUser` as passed above.
 
 ```app/templates/components/user-profile.hbs
-{{button-with-confirmation onConfirm=(action deleteCurrentUser)
-  text="Click OK to delete your account."}}
+{{button-with-confirmation
+  onConfirm=(action deleteCurrentUser)
+  text="Click OK to delete your account."
+}}
 ```
 
 Note that `deleteCurrentUser` is no longer in quotes here as opposed to [previously](#toc_passing-the-action-to-the-component). Quotes are used to initially pass the action down the component tree, but at every subsequent level you are instead passing the actual function reference (without quotes) in the action helper.


### PR DESCRIPTION
When reading current documentation, it's quite annoying that vital pieces of information (component actions) are hidden behind horizontal scroll. This is due to fixed width nature of guides web design.

Before:
![screenshot 2017-02-03 21 04 10](https://cloud.githubusercontent.com/assets/13806/22606697/109551a4-ea55-11e6-9c99-c9d26fbb29f3.png)

After:
![screenshot 2017-02-03 21 04 25](https://cloud.githubusercontent.com/assets/13806/22606700/14f3bbaa-ea55-11e6-953c-175bed021a3c.png)

To keep the coding style consistent inside the same document, I've changed also initial examples that wouldn't directly benefit from this approach. There is a small improvement that since horizontal line already appears with them, you now also don't have to scroll just to make sure there isn't anything cut off.