### PR TITLE
Changed double quotes to single quotes around description property value

### DIFF
--- a/source/localizable/tutorial/model-hook.md
+++ b/source/localizable/tutorial/model-hook.md
@@ -30,7 +30,7 @@ export default Ember.Route.extend({
       type: 'Estate',
       bedrooms: 15,
       image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
-      description: "This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests."
+      description: 'This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests.'
     }, {
       id: 'urban-living',
       title: 'Urban Living',
@@ -39,7 +39,7 @@ export default Ember.Route.extend({
       type: 'Condo',
       bedrooms: 1,
       image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
-      description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
+      description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
 
     }, {
       id: 'downtown-charm',
@@ -49,7 +49,7 @@ export default Ember.Route.extend({
       type: 'Apartment',
       bedrooms: 3,
       image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg',
-      description: "Convenience is at your doorstep with this charming downtown rental. Great restaurants and active night life are within a few feet."
+      description: 'Convenience is at your doorstep with this charming downtown rental. Great restaurants and active night life are within a few feet.'
 
     }];
   }


### PR DESCRIPTION
Changed the double quotes surrounding the description property's text to single quotes for consistency with the rest of the string data.