### PR TITLE
Add callout reminder for the 2017 Ember Community Survey

### DIFF
--- a/source/_survey-reminder.html.erb
+++ b/source/_survey-reminder.html.erb
@@ -1,0 +1,7 @@
+<div class="survey-reminder-wrapper">
+  <div class="survey-reminder-container">
+    Take the
+    <% link_to 'http://emberjs.com/ember-community-survey-2017' do %>
+        2017 Ember Community Survey<% end %>!
+  </div>
+</div>

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -30,6 +30,8 @@
 
     <%= partial "header" %>
 
+    <%= partial "survey-reminder" %>
+
     <%= yield_content :outside_wrapper %>
 
     <main class="container">

--- a/source/stylesheets/components/_all.scss
+++ b/source/stylesheets/components/_all.scss
@@ -7,3 +7,4 @@
 @import "highlight";
 @import "toc";
 @import "old-version-warning";
+@import "survey-reminder";

--- a/source/stylesheets/components/_survey-reminder.scss
+++ b/source/stylesheets/components/_survey-reminder.scss
@@ -1,0 +1,25 @@
+$blue-color: #3c64b6;
+
+.survey-reminder-wrapper {
+  background: white;
+  color: $ember-orange;
+  text-align: center;
+  line-height: 2.2;
+  font-size: 1rem;
+  border-bottom: 1px solid #e5dbd6;
+  a {
+    border-bottom: 1px dotted $blue-color;
+    color: $blue-color;
+  }
+}
+
+.survey-reminder-container {
+  width: inherit;
+  line-height: 1.5;
+  padding: 0.8rem 1rem;
+
+  @include media($large-screen) {
+    line-height: 2.2;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
This adds a callout to the top of the page layout, linking to the 2017 community survey page on emberjs.com.

This relies on the [website PR](https://github.com/emberjs/website/pull/2822), which adds the landing page for the 2017 survey.

![Screenshot](https://cloud.githubusercontent.com/assets/174619/23405491/77d99078-fd88-11e6-9f16-b004e06772e6.png)

/cc @mixonic @daniellutz 
