### PR TITLE
[docs] Document metadata reuse

### DIFF
--- a/source/localizable/models/handling-metadata.md
+++ b/source/localizable/models/handling-metadata.md
@@ -63,4 +63,26 @@ post.get('comments').then((comments) => {
 
 After reading it, `meta.total` can be used to calculate how many pages of posts you'll have.
 
+To use the `meta` data outside of the `model` hook, you need to return it:
+
+```app/routes/users.js
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+    return this.store.findAll('user').then((results) => {
+      return {
+        users: results,
+        meta: results.meta
+      };
+    });
+  },
+  
+  setupController(controller, { users, meta }) {
+    this._super(controller, users);
+    controller.set('meta', meta);
+  }
+});
+```
+
 To customize metadata extraction, check out the documentation for your serializer.


### PR DESCRIPTION
It's not so obvious that the above is needed, since the model in `setupController` is different then the "model" returned from the promise via `then`.