### PR TITLE
"instances of that class" instead of "instances of that object"

### DIFF
--- a/source/localizable/object-model/classes-and-instances.md
+++ b/source/localizable/object-model/classes-and-instances.md
@@ -156,7 +156,7 @@ override the `init()` method, make sure you call `this._super(...arguments)`!
 If you don't, a parent class may not have an opportunity to do important
 setup work, and you'll see strange behavior in your application.
 
-Arrays and objects defined directly on any `Ember.Object` are shared across all instances of that object.
+Arrays and objects defined directly on any `Ember.Object` are shared across all instances of that class.
 
 ```js
 const Person = Ember.Object.extend({


### PR DESCRIPTION
I think it's more correct to say "instances of that class" instead of "instances of that object", given that we're defining classes here, and that the Ember object system is designed to mimic a more classical inheritance system.