### PR TITLE
Fix hyphen’s code

### DIFF
--- a/source/localizable/index.md
+++ b/source/localizable/index.md
@@ -10,9 +10,9 @@ as well as an integrated development toolkit that enables rapid iteration.
 Some of these features that you'll learn about in the guides are:
 
 * [Ember CLI](./configuring-ember/configuring-ember-cli/) - A robust development toolkit to create, develop, and build Ember applications. When you see an `$ ember <command>` instruction throughout the guides, that's Ember CLI!
-* [Routing](./routing) — The central part of an Ember application. Enables developers to drive the application state from the URL.
-* [Templating engine](./templates/handlebars-basics/) — Use Handlebars syntax to write your application's templates
-* [Data layer](./models/) — Ember Data provides a consistent way to communicate with external APIs and manage application state
+* [Routing](./routing) - The central part of an Ember application. Enables developers to drive the application state from the URL.
+* [Templating engine](./templates/handlebars-basics/) - Use Handlebars syntax to write your application's templates
+* [Data layer](./models/) - Ember Data provides a consistent way to communicate with external APIs and manage application state
 * [Ember Inspector](./ember-inspector/) - A browser extension, or bookmarklet, to inspect your application live. It's also useful for spotting Ember applications in the wild, try to install it and open up the [NASA website](https://www.nasa.gov/)!
 
 ## Organization


### PR DESCRIPTION
I found that the type of hyphens are different in the guide.

<img width="701" alt="2017-03-25 7 03 28" src="https://cloud.githubusercontent.com/assets/3954/24315384/12344960-112a-11e7-9268-504f7d880213.png">