### PR TITLE
[FIX] ES6 shorthand for example in `components/handling-events`

### DIFF
--- a/source/localizable/components/handling-events.md
+++ b/source/localizable/components/handling-events.md
@@ -92,7 +92,7 @@ function definition can define the event object as its first parameter.
 
 ```js
 actions: {
-  signUp: function(event){ 
+  signUp(event){ 
   	// Only when assigning the action to an inline handler, the event object
     // is passed to the action as the first parameter.
   }
@@ -110,7 +110,7 @@ default behavior using an action.
 
 ```js
 actions: {
-  signUp: function(){
+  signUp(){
     // No event object is passed to the action.
   }
 }


### PR DESCRIPTION
We use the function shorthand pretty much everywhere else.