### PR TITLE
Update method for removing welcome-page

### DIFF
--- a/source/localizable/tutorial/ember-cli.md
+++ b/source/localizable/tutorial/ember-cli.md
@@ -135,16 +135,5 @@ When we edit the `app/templates/application.hbs` file, we'll replace that conten
 ![default welcome screen](../../images/ember-cli/default-welcome-page.png)
 
 The first thing we want to do in our new project is to remove the welcome screen.
-We do this by simply opening up the application template file located at `app/templates/application.hbs`.
 
-Once open, remove the component labeled `{{welcome-page}}`.
-The application should now be a completely blank canvas to build our application on.
-
-```app/templates/application.hbs{-1,-2,-3}
-{{!-- The following component displays Ember's default welcome message. --}}
-{{welcome-page}}
-{{!-- Feel free to remove this! --}}
-
-{{outlet}}
-
-```
+Open up your `package.json` file and remove the package for the welcome page `"ember-welcome-page": "^1.0.1",`. Once that line is removed you can restart your server and you will have a blank page.


### PR DESCRIPTION
When going through the guide I noticed that the `application.hbs` template simply didn't exist, and the welcome page itself said to remove the add-on from the `package.json` file.