### PR TITLE
Replace "A 'didUpdateAttrs' is called..." with "As 'didUpdateAttrs is called..."

### DIFF
--- a/source/localizable/components/the-component-lifecycle.md
+++ b/source/localizable/components/the-component-lifecycle.md
@@ -40,7 +40,7 @@ Below are some samples of ways to use lifecycle hooks within your components.
 `didUpdateAttrs` runs when the attributes of a component have changed, but not when the component is re-rendered, via `component.rerender`,
 `component.set`, or changes in models or services used by the template.
 
-As `didUpdateAttrs` is called prior to rerender, you can use this hook to execute code when specific attributes are changed.
+Since `didUpdateAttrs` is called prior to rerender, you can use this hook to execute code when specific attributes are changed.
 This hook can be an effective alternative to an observer, as it will run prior to a re-render, but after an attribute has changed.
 
 An example of this scenario in action is a profile editor component.  As you are editing one user, and the user attribute is changed,

--- a/source/localizable/components/the-component-lifecycle.md
+++ b/source/localizable/components/the-component-lifecycle.md
@@ -40,7 +40,7 @@ Below are some samples of ways to use lifecycle hooks within your components.
 `didUpdateAttrs` runs when the attributes of a component have changed, but not when the component is re-rendered, via `component.rerender`,
 `component.set`, or changes in models or services used by the template.
 
-A `didUpdateAttrs` is called prior to rerender, you can use this hook to execute code when specific attributes are changed.
+As `didUpdateAttrs` is called prior to rerender, you can use this hook to execute code when specific attributes are changed.
 This hook can be an effective alternative to an observer, as it will run prior to a re-render, but after an attribute has changed.
 
 An example of this scenario in action is a profile editor component.  As you are editing one user, and the user attribute is changed,


### PR DESCRIPTION
References issue #1914.

The full sentence is:

- "A `didUpdateAttrs` is called prior to rerender, you can use this hook to execute code when specific attributes are changed."

There seems to be a typo here.  The intended meaning seems to be something like the following: 

- "You can use the `didUpdateAttrs` hook to execute code when specific attributes are changed, since it is called prior to rerender."

I inferred that "As" was the intended first word of the sentence, since one of its meanings is analogous to "since" or "because".  As a suggestion, we could also just use either of those two words as well, to potentially make it less ambiguous (especially to non-native English speakers).
