### PR TITLE
Update Ember.assert parameters order

### DIFF
--- a/source/localizable/configuring-ember/debugging.md
+++ b/source/localizable/configuring-ember/debugging.md
@@ -123,7 +123,7 @@ import Ember from 'ember';
 import RSVP from 'rsvp';
 
 RSVP.on('error', function(error) {
-  Ember.assert(false, error);
+  Ember.assert(error, false);
 });
 ```
 


### PR DESCRIPTION
The example on the debbuging page is outdated with [the API](https://emberjs.com/api/#method_assert)