### PR TITLE
Fix link typo and reopen() clarification

### DIFF
--- a/source/localizable/object-model/reopening-classes-and-instances.md
+++ b/source/localizable/object-model/reopening-classes-and-instances.md
@@ -1,7 +1,7 @@
 You don't need to define a class all at once. You can reopen a class and
-define new properties using the [`reopen()`][1] method.
-
-[1]: http://emberjs.com/api/classes/Ember.Object.html#method_reopen
+define new properties using the
+[`reopen()`](http://emberjs.com/api/classes/Ember.Object.html#method_reopen)
+method.
 
 ```javascript
 Person.reopen({
@@ -29,16 +29,14 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`][1].
-
-[1]: http://emberjs.com/api/classes/Ember.Object.html#method_reopenClass
+you can use [`reopenClass()`](http://emberjs.com/api/classes/Ember.Object.html#method_reopenClass).
 
 ```javascript
 // add static property to class
 Person.reopenClass({
   isPerson: false
 });
-// override property of Person instance
+// override property of existing and future Person instances
 Person.reopen({
   isPerson: true
 });


### PR DESCRIPTION
Change two [1] links to [1] and [2].  Clarify that reopen affects both past and future instances.