### PR TITLE
Remove Bower mention from "Manage Dependencies"

### DIFF
--- a/source/localizable/addons-and-dependencies/managing-dependencies.md
+++ b/source/localizable/addons-and-dependencies/managing-dependencies.md
@@ -4,7 +4,6 @@ Ember CLI provides a common format called [Ember Addons](#toc_addons) for distri
 to solve these problems.
 Additionally, you may want to make use of front-end dependencies like a CSS framework
 or a JavaScript datepicker that aren't specific to Ember apps.
-Ember CLI supports installing these packages through the standard [Bower package manager](#toc_bower).
 
 ## Addons
 

--- a/source/localizable/addons-and-dependencies/managing-dependencies.md
+++ b/source/localizable/addons-and-dependencies/managing-dependencies.md
@@ -14,17 +14,6 @@ Addons may bring in other dependencies by modifying your project's `bower.json` 
 
 You can find listings of addons on [Ember Observer](http://emberobserver.com).
 
-## Bower
-
-Ember CLI uses the [Bower](http://bower.io) package manager,
-making it easy to keep your front-end dependencies up to date.
-The Bower configuration file, `bower.json`, is located at the root of your Ember CLI project,
-and lists the dependencies for your project.
-Executing `bower install` will install all of the dependencies listed in `bower.json` in one step.
-
-Ember CLI watches `bower.json` for changes.
-Thus it reloads your app if you install new dependencies via `bower install <dependencies> --save`.
-
 ## Other assets
 
 Third-party JavaScript not available as an addon or Bower package should be placed in the `vendor/` folder in your project.


### PR DESCRIPTION
While we still support Bower, Bower itself is on maintenance mode.
On top of that, you have to do some manual importing, which is
kinda out of scope, maybe?
Fixes https://github.com/emberjs/guides/issues/1948.