### PR TITLE
change superRentals type to propertyType due to JSONAPI

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -57,7 +57,7 @@ We want the component to simply provide an input field and yield the results lis
 ```
 
 The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
-The `value` property of the `input` will be kept in sync with the `value` property in the component. 
+The `value` property of the `input` will be kept in sync with the `value` property in the component.
 
 Another way to say this is that the `value` property of `input` is [**bound**](../../object-model/bindings/) to the `value` property of the component.
 If the property changes, either by the user typing in the input field, or by assigning a new value to it in our program,
@@ -149,7 +149,7 @@ export default function() {
         title: 'Grand Old Mansion',
         owner: 'Veruca Salt',
         city: 'San Francisco',
-        type: 'Estate',
+        propertyType: 'Estate',
         bedrooms: 15,
         image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
         description: "This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests."
@@ -161,7 +161,7 @@ export default function() {
         title: 'Urban Living',
         owner: 'Mike Teavee',
         city: 'Seattle',
-        type: 'Condo',
+        propertyType: 'Condo',
         bedrooms: 1,
         image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
@@ -173,7 +173,7 @@ export default function() {
         title: 'Downtown Charm',
         owner: 'Violet Beauregarde',
         city: 'Portland',
-        type: 'Apartment',
+        propertyType: 'Apartment',
         bedrooms: 3,
         image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg',
         description: "Convenience is at your doorstep with this charming downtown rental. Great restaurants and active night life are within a few feet."
@@ -445,5 +445,3 @@ and the item displayed shows "Seattle" as the location.
 You should be down to only 2 failing tests: One remaining acceptance test failure; and our JSHint test that fails on an unused assert for our unimplemented test.
 
 ![passing acceptance tests](../../images/autocomplete-component/passing-acceptance-tests.png)
-
-

--- a/source/localizable/tutorial/ember-data.md
+++ b/source/localizable/tutorial/ember-data.md
@@ -32,7 +32,7 @@ export default DS.Model.extend({
 ```
 
 Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
-_title_, _owner_, _city_, _type_, _image_, _bedrooms_ and _description_.
+_title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](http://emberjs.com/api/data/classes/DS.html#method_attr).
 For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
 
@@ -43,7 +43,7 @@ export default DS.Model.extend({
   title: DS.attr(),
   owner: DS.attr(),
   city: DS.attr(),
-  type: DS.attr(),
+  propertyType: DS.attr(),
   image: DS.attr(),
   bedrooms: DS.attr(),
   description: DS.attr()
@@ -71,7 +71,7 @@ export default Ember.Route.extend({
       title: 'Grand Old Mansion',
       owner: 'Veruca Salt',
       city: 'San Francisco',
-      type: 'Estate',
+      propertyType: 'Estate',
       bedrooms: 15,
       image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
       description: "This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests."
@@ -80,7 +80,7 @@ export default Ember.Route.extend({
       title: 'Urban Living',
       owner: 'Mike TV',
       city: 'Seattle',
-      type: 'Condo',
+      propertyType: 'Condo',
       bedrooms: 1,
       image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
@@ -89,7 +89,7 @@ export default Ember.Route.extend({
       title: 'Downtown Charm',
       owner: 'Violet Beauregarde',
       city: 'Portland',
-      type: 'Apartment',
+      propertyType: 'Apartment',
       bedrooms: 3,
       image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg',
       description: "Convenience is at your doorstep with this charming downtown rental. Great restaurants and active night life are within a few feet."
@@ -98,7 +98,7 @@ export default Ember.Route.extend({
 });
 ```
 
-When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`. 
+When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`.
 If you recall, in the section titled [Installing Addons](../installing-addons/) we set up an adapter to route data requests through `/api`.
 
 You can read more about Ember Data in the [Models section](../../models/).

--- a/source/localizable/tutorial/hbs-helper.md
+++ b/source/localizable/tutorial/hbs-helper.md
@@ -30,9 +30,9 @@ export function rentalPropertyType(params/*, hash*/) {
 export default Ember.Helper.helper(rentalPropertyType);
 ```
 
-Let's update our `rental-listing` component template to use our new helper and pass in `rental.type`:
+Let's update our `rental-listing` component template to use our new helper and pass in `rental.propertyType`:
 
-```app/templates/components/rental-listing.hbs{-11,+12}
+```app/templates/components/rental-listing.hbs{-11,+12,+13}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
     <img src="{{rental.image}}" alt="">
@@ -43,8 +43,9 @@ Let's update our `rental-listing` component template to use our new helper and p
     <span>Owner:</span> {{rental.owner}}
   </div>
   <div class="detail type">
-    <span>Type:</span> {{rental.type}}
-    <span>Type:</span> {{rental-property-type rental.type}} - {{rental.type}}
+    <span>Type:</span> {{rental.propertyType}}
+    <span>Type:</span> {{rental-property-type rental.propertyType}}
+      - {{rental.propertyType}}
   </div>
   <div class="detail location">
     <span>Location:</span> {{rental.city}}
@@ -56,7 +57,7 @@ Let's update our `rental-listing` component template to use our new helper and p
 ```
 
 Ideally we'll see "Type: Standalone - Estate" for our first rental property.
-Instead, our default template helper is returning back our `rental.type` values.
+Instead, our default template helper is returning back our `rental.propertyType` values.
 Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
@@ -69,8 +70,8 @@ const communityPropertyTypes = [
   'Apartment'
 ];
 
-export function rentalPropertyType([type]) {
-  if (communityPropertyTypes.includes(type)) {
+export function rentalPropertyType([propertyType]) {
+  if (communityPropertyTypes.includes(propertyType)) {
     return 'Community';
   }
 
@@ -80,7 +81,7 @@ export function rentalPropertyType([type]) {
 export default Ember.Helper.helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `type`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/source/localizable/tutorial/installing-addons.md
+++ b/source/localizable/tutorial/installing-addons.md
@@ -57,7 +57,7 @@ export default function() {
           title: 'Grand Old Mansion',
           owner: 'Veruca Salt',
           city: 'San Francisco',
-          type: 'Estate',
+          propertyType: 'Estate',
           bedrooms: 15,
           image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg'
         }
@@ -68,7 +68,7 @@ export default function() {
           title: 'Urban Living',
           owner: 'Mike Teavee',
           city: 'Seattle',
-          type: 'Condo',
+          propertyType: 'Condo',
           bedrooms: 1,
           image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
         }
@@ -79,7 +79,7 @@ export default function() {
           title: 'Downtown Charm',
           owner: 'Violet Beauregarde',
           city: 'Portland',
-          type: 'Apartment',
+          propertyType: 'Apartment',
           bedrooms: 3,
           image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg'
         }

--- a/source/localizable/tutorial/model-hook.md
+++ b/source/localizable/tutorial/model-hook.md
@@ -27,7 +27,7 @@ export default Ember.Route.extend({
       title: 'Grand Old Mansion',
       owner: 'Veruca Salt',
       city: 'San Francisco',
-      type: 'Estate',
+      propertyType: 'Estate',
       bedrooms: 15,
       image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
       description: 'This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests.'
@@ -36,7 +36,7 @@ export default Ember.Route.extend({
       title: 'Urban Living',
       owner: 'Mike TV',
       city: 'Seattle',
-      type: 'Condo',
+      propertyType: 'Condo',
       bedrooms: 1,
       image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
@@ -46,7 +46,7 @@ export default Ember.Route.extend({
       title: 'Downtown Charm',
       owner: 'Violet Beauregarde',
       city: 'Portland',
-      type: 'Apartment',
+      propertyType: 'Apartment',
       bedrooms: 3,
       image: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg',
       description: 'Convenience is at your doorstep with this charming downtown rental. Great restaurants and active night life are within a few feet.'
@@ -85,7 +85,7 @@ This helper will let us loop through each of the rental objects in our model:
       <span>Owner:</span> {{rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental.type}}
+      <span>Type:</span> {{rental.propertyType}}
     </div>
     <div class="detail location">
       <span>Location:</span> {{rental.city}}

--- a/source/localizable/tutorial/service.md
+++ b/source/localizable/tutorial/service.md
@@ -215,7 +215,7 @@ This property will be passed in to the component by its parent template below.
 
 Finally open the template file for our `rental-listing` component and add the new `location-map` component.
 
-```app/templates/components/rental-listing.hbs{+19}
+```app/templates/components/rental-listing.hbs{+20}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
     <img src="{{rental.image}}" alt="">
@@ -226,7 +226,8 @@ Finally open the template file for our `rental-listing` component and add the ne
     <span>Owner:</span> {{rental.owner}}
   </div>
   <div class="detail type">
-    <span>Type:</span> {{rental-property-type rental.type}} - {{rental.type}}
+    <span>Type:</span> {{rental-property-type rental.propertyType}}
+      - {{rental.propertyType}}
   </div>
   <div class="detail location">
     <span>Location:</span> {{rental.city}}

--- a/source/localizable/tutorial/simple-component.md
+++ b/source/localizable/tutorial/simple-component.md
@@ -37,7 +37,7 @@ To start, let's move the rental display details for a single rental from the `re
     <span>Owner:</span> {{rental.owner}}
   </div>
   <div class="detail type">
-    <span>Type:</span> {{rental.type}}
+    <span>Type:</span> {{rental.propertyType}}
   </div>
   <div class="detail location">
     <span>Location:</span> {{rental.city}}
@@ -72,7 +72,7 @@ with our new `rental-listing` component:
       <span>Owner:</span> {{rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental.type}}
+      <span>Type:</span> {{rental.propertyType}}
     </div>
     <div class="detail location">
       <span>Location:</span> {{rental.city}}
@@ -109,7 +109,7 @@ giving it the `image` class name so that our test can find it.
     <span>Owner:</span> {{rental.owner}}
   </div>
   <div class="detail type">
-    <span>Type:</span> {{rental.type}}
+    <span>Type:</span> {{rental.propertyType}}
   </div>
   <div class="detail location">
     <span>Location:</span> {{rental.city}}
@@ -145,7 +145,7 @@ Let's call this action `toggleImageSize`
     <span>Owner:</span> {{rental.owner}}
   </div>
   <div class="detail type">
-    <span>Type:</span> {{rental.type}}
+    <span>Type:</span> {{rental.propertyType}}
   </div>
   <div class="detail location">
     <span>Location:</span> {{rental.city}}
@@ -230,7 +230,7 @@ let rental = Ember.Object.create({
   image: 'fake.png',
   title: 'test-title',
   owner: 'test-owner',
-  type: 'test-type',
+  propertyType: 'test-type',
   city: 'test-city',
   bedrooms: 3
 });
@@ -261,7 +261,7 @@ let rental = Ember.Object.create({
   image: 'fake.png',
   title: 'test-title',
   owner: 'test-owner',
-  type: 'test-type',
+  propertyType: 'test-type',
   city: 'test-city',
   bedrooms: 3
 });
@@ -320,7 +320,7 @@ let rental = Ember.Object.create({
   image: 'fake.png',
   title: 'test-title',
   owner: 'test-owner',
-  type: 'test-type',
+  propertyType: 'test-type',
   city: 'test-city',
   bedrooms: 3
 });

--- a/source/localizable/tutorial/subroutes.md
+++ b/source/localizable/tutorial/subroutes.md
@@ -168,7 +168,7 @@ export default function() {
         title: "Grand Old Mansion",
         owner: "Veruca Salt",
         city: "San Francisco",
-        type: "Estate",
+        propertyType: "Estate",
         bedrooms: 15,
         image: "https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg",
         description: "This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests."
@@ -181,7 +181,7 @@ export default function() {
         title: "Urban Living",
         owner: "Mike Teavee",
         city: "Seattle",
-        type: "Condo",
+        propertyType: "Condo",
         bedrooms: 1,
         image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
@@ -194,7 +194,7 @@ export default function() {
         title: "Downtown Charm",
         owner: "Violet Beauregarde",
         city: "Portland",
-        type: "Apartment",
+        propertyType: "Apartment",
         bedrooms: 3,
         image: "https://upload.wikimedia.org/wikipedia/commons/f/f7/Wheeldon_Apartment_Building_-_Portland_Oregon.jpg",
         description: "Convenience is at your doorstep with this charming downtown rental. Great restaurants and active night life are within a few feet."
@@ -302,7 +302,7 @@ Next, we can update the template for our show route (`app/templates/rentals/show
       <strong>Owner:</strong> {{model.owner}}
     </div>
     <div class="detail">
-      <strong>Type:</strong> {{rental-property-type model.type}} - {{model.type}}
+      <strong>Type:</strong> {{rental-property-type model.propertyType}} - {{model.propertyType}}
     </div>
     <div class="detail">
       <strong>Location:</strong> {{model.city}}
@@ -340,7 +340,8 @@ Clicking on the title will load the detail page for that rental.
     <span>Owner:</span> {{rental.owner}}
   </div>
   <div class="detail type">
-    <span>Type:</span> {{rental-property-type rental.type}} - {{rental.type}}
+    <span>Type:</span> {{rental-property-type rental.propertyType}}
+      - {{rental.propertyType}}
   </div>
   <div class="detail location">
     <span>Location:</span> {{rental.city}}


### PR DESCRIPTION
This PR would close https://github.com/emberjs/guides/issues/1894

Changes need to be propagated to any files that are translated. I only edited the basic English markdown files.

I changed only the code block text and mentions of `type`. I don't think it's necessary to change the images so they say "Property Type: Estate" instead of "Type: Estate" but if others feel that it's important, I can add that too.

I also did not change any class names due to the styling addon.