### PR TITLE
Updated Incorrect Line Highlighting

### DIFF
--- a/source/localizable/tutorial/autocomplete-component.md
+++ b/source/localizable/tutorial/autocomplete-component.md
@@ -22,7 +22,7 @@ which allows a Handlebars template to be rendered _inside_ the component's templ
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
 
-```app/templates/rentals.hbs{+35,+36,+37,+38,+39,+40,+41,+42,+43,+44,+45,-46,-47,-48}
+```app/templates/rentals.hbs{+12,+13,+14,+15,+16,+17,+18,+19,+20,-21,-22,-23}
 <div class="jumbo">
   <div class="right tomster"></div>
   <h2>Welcome!</h2>


### PR DESCRIPTION
The second code example, titled `app/templates/rentals.hbs`, had incorrect line highlighting on it. It did not make clear that you had to remove the last three lines as the highlighting was way off the code.
[Building a Complex Component Guide Page](https://guides.emberjs.com/v2.13.0/tutorial/autocomplete-component/)