### PR TITLE
discourage the use of jquery in tests

### DIFF
--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -109,13 +109,13 @@ export default Ember.Component.extend({
 ```app/templates/components/magic-title.hbs
 <h2>{{title}}</h2>
 
-<button {{action "updateTitle"}}>
+<button class="title-button" {{action "updateTitle"}}>
   Update Title
 </button>
 ```
 
-jQuery triggers can be used to simulate user interaction and test that the title
-is updated when the button is clicked on:
+We recommend using native DOM events wrapped inside the run loop or the [`ember-native-dom-helpers`](https://github.com/cibernox/ember-native-dom-helpers) addon to simulate user interaction and test that the title is updated when the button is clicked.<br>
+Using jQuery to simulate user click events might lead to unexpected test results as the action can potentially be called twice.
 
 ```tests/integration/components/magic-title-test.js
 test('should update title on button click', function(assert) {
@@ -126,7 +126,7 @@ test('should update title on button click', function(assert) {
   assert.equal(this.$('h2').text(), 'Hello World', 'initial text is hello world');
 
   //Click on the button
-  this.$('button').click();
+  Ember.run(() => document.querySelector('.title-button').click());
 
   assert.equal(this.$('h2').text(), 'This is Magic', 'title changes after click');
 });
@@ -162,7 +162,7 @@ export default Ember.Component.extend({
   <label>Comment:</label>
   {{textarea value=comment}}
 
-  <input type="submit" value="Submit"/>
+  <input class="comment-input" type="submit" value="Submit"/>
 </form>
 ```
 
@@ -186,7 +186,7 @@ test('should trigger external action on form submit', function(assert) {
   this.$('textarea').change();
 
   // click the button to submit the form
-  this.$('input').click();
+   Ember.run(() => document.querySelector('.comment-input').click());
 });
 ```
 ### Stubbing Services

--- a/source/tutorial/simple-component.md
+++ b/source/tutorial/simple-component.md
@@ -324,9 +324,9 @@ test('should toggle wide class on click', function(assert) {
   this.set('rentalObj', rental);
   this.render(hbs`{{rental-listing rental=rentalObj}}`);
   assert.equal(this.$('.image.wide').length, 0, 'initially rendered small');
-  this.$('.image').click();
+  Ember.run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 1, 'rendered wide after click');
-  this.$('.image').click();
+  Ember.run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 0, 'rendered small after second click');
 });
 ```
@@ -361,9 +361,9 @@ test('should toggle wide class on click', function(assert) {
   this.set('rentalObj', rental);
   this.render(hbs`{{rental-listing rental=rentalObj}}`);
   assert.equal(this.$('.image.wide').length, 0, 'initially rendered small');
-  this.$('.image').click();
+  Ember.run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 1, 'rendered wide after click');
-  this.$('.image').click();
+  Ember.run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 0, 'rendered small after second click');
 });
 ```


### PR DESCRIPTION
Part of https://github.com/emberjs/guides/issues/1815: 
- Replacing jQuery click events with native Dom events
- Mentioning ember-native-dom-helpers

The only usage of onclick={{action…}} I could find, is here: https://guides.emberjs.com/v2.13.0/components/handling-events/. However, it feels like it is still needed to explain how to obtain references to the event object. I found the PR that introduced it [here](https://github.com/emberjs/guides/pull/1624).

cc @toddjordan Happy for any comment to make this better :)