### PR TITLE
Fix broken link to qunit api docs

### DIFF
--- a/source/localizable/tutorial/acceptance-test.md
+++ b/source/localizable/tutorial/acceptance-test.md
@@ -63,7 +63,7 @@ test('visiting /', function(assert) {
 A few of things to note in this simple test:
 
 * Acceptance tests are setup by calling the function `moduleForAcceptance`. This function ensures that your Ember application is started and shut down between each test.
-* QUnit passes in an object called an [`assert`](https://api.qunitjs.com/category/assert/) to each test function. An `assert` has functions, such as `equal()`, that allow your test to check for conditions within the test environment. A test must have one passing assert to be successful.
+* QUnit passes in an object called an [`assert`](https://api.qunitjs.com/assert/) to each test function. An `assert` has functions, such as `equal()`, that allow your test to check for conditions within the test environment. A test must have one passing assert to be successful.
 * Ember acceptance tests use a set of test helper functions, such as the `visit`, `andThen`, and `currentURL` functions used above. We'll discuss those functions in more detail later in the tutorial.
 
 Now run your test suite with the CLI command, `ember test --server`.


### PR DESCRIPTION
https://api.qunitjs.com/category/assert/ is returning a 404.  It appears as though the new URL is https://api.qunitjs.com/assert/