### PR TITLE
QUEST | Convert code samples to RFC #176 imports

### DIFF
--- a/data/spelling-exceptions.txt
+++ b/data/spelling-exceptions.txt
@@ -12,6 +12,7 @@ apache
 api
 apis
 app's
+ApplicationInstance
 assistive
 async
 asynchronicity

--- a/source/applications/applications-and-instances.md
+++ b/source/applications/applications-and-instances.md
@@ -1,15 +1,12 @@
-Every Ember application is represented by a class that extends [`Ember.Application`][1].
+Every Ember application is represented by a class that extends [`Application`][http://emberjs.com/api/classes/Application.html].
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`Ember.ApplicationInstance`][2] that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`][http://emberjs.com/api/classes/ApplicationInstance.html] that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*
 while the `ApplicationInstance` *manages its state*.
-
-[1]: http://emberjs.com/api/classes/Ember.Application.html
-[2]: http://emberjs.com/api/classes/Ember.ApplicationInstance.html
 
 This separation of concerns not only clarifies the architecture of your app,
 it can also improve its efficiency.

--- a/source/applications/applications-and-instances.md
+++ b/source/applications/applications-and-instances.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`][http://emberjs.com/api/classes/Application.html].
+Every Ember application is represented by a class that extends [`Application`](http://emberjs.com/api/classes/Application.html).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`][http://emberjs.com/api/classes/ApplicationInstance.html] that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](http://emberjs.com/api/classes/ApplicationInstance.html) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/source/applications/dependency-injection.md
+++ b/source/applications/dependency-injection.md
@@ -2,11 +2,11 @@ Ember applications utilize the [dependency injection](https://en.wikipedia.org/w
 ("DI") design pattern to declare and instantiate classes of objects and dependencies between them.
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`][http://emberjs.com/api/classes/Ember.Application.html] serves as a "registry" for dependency declarations.
+An [`Application`](http://emberjs.com/api/classes/Ember.Application.html) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`][http://emberjs.com/api/classes/Ember.ApplicationInstance.html] serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](http://emberjs.com/api/classes/Ember.ApplicationInstance.html) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,

--- a/source/applications/dependency-injection.md
+++ b/source/applications/dependency-injection.md
@@ -2,20 +2,17 @@ Ember applications utilize the [dependency injection](https://en.wikipedia.org/w
 ("DI") design pattern to declare and instantiate classes of objects and dependencies between them.
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Ember.Application`][1] serves as a "registry" for dependency declarations.
+An [`Application`][http://emberjs.com/api/classes/Ember.Application.html] serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`Ember.ApplicationInstance`][2] serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`][http://emberjs.com/api/classes/Ember.ApplicationInstance.html] serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
 each `ApplicationInstance` can also serve as a registry.
 Instance-level registrations are useful for providing instance-level customizations,
 such as A/B testing of a feature._
-
-[1]: http://emberjs.com/api/classes/Ember.Application.html
-[2]: http://emberjs.com/api/classes/Ember.ApplicationInstance.html
 
 ## Factory Registrations
 
@@ -39,10 +36,10 @@ or application instance initializers (with the former being much more common).
 For example, an application initializer could register a `Logger` factory with the key `logger:main`:
 
 ```app/initializers/logger.js
-import Ember from 'ember';
+import EmberObject from "@ember/object";
 
 export function initialize(application) {
-  let Logger = Ember.Object.extend({
+  let Logger = EmberObject.extend({
     log(m) {
       console.log(m);
     }
@@ -95,10 +92,10 @@ register your factories as non-singletons using the `singleton: false` option.
 In the following example, the `Message` class is registered as a non-singleton:
 
 ```app/initializers/notification.js
-import Ember from 'ember';
+import EmberObject from "@ember/object";
 
 export function initialize(application) {
-  let Message = Ember.Object.extend({
+  let Message = EmberObject.extend({
     text: ''
   });
 
@@ -118,10 +115,10 @@ Once a factory is registered, it can be "injected" where it is needed.
 Factories can be injected into whole "types" of factories with *type injections*. For example:
 
 ```app/initializers/logger.js
-import Ember from 'ember';
+import EmberObject from "@ember/object";
 
 export function initialize(application) {
-  let Logger = Ember.Object.extend({
+  let Logger = EmberObject.extend({
     log(m) {
       console.log(m);
     }
@@ -144,9 +141,9 @@ The value of `logger` will come from the factory named `logger:main`.
 Routes in this example application can now access the injected logger:
 
 ```app/routes/index.js
-import Ember from 'ember';
+import Route from "@ember/routing/route"
 
-export default Ember.Route.extend({
+export default Route.extend({
   activate() {
     // The logger property is injected into all routes
     this.get('logger').log('Entered the index route!');
@@ -167,17 +164,18 @@ This includes all of Ember's major framework classes, such as components, helper
 
 ### Ad Hoc Injections
 
-Dependency injections can also be declared directly on Ember classes using `Ember.inject`.
-Currently, `Ember.inject` supports injecting controllers (via `Ember.inject.controller`)
-and services (via `Ember.inject.service`).
+Dependency injections can also be declared directly on Ember classes using `inject`.
+Currently, `inject` supports injecting controllers (via `import { inject } from '@ember/controller';`)
+and services (via `import { inject } from '@ember/service';`).
 
 The following code injects the `shopping-cart` service on the `cart-contents` component as the property `cart`:
 
 ```app/components/cart-contents.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from "@ember/service";
 
-export default Ember.Component.extend({
-  cart: Ember.inject.service('shopping-cart')
+export default Component.extend({
+  cart: service('shopping-cart')
 });
 ```
 
@@ -185,17 +183,18 @@ If you'd like to inject a service with the same name as the property,
 simply leave off the service name (the dasherized version of the name will be used):
 
 ```app/components/cart-contents.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from "@ember/service";
 
-export default Ember.Component.extend({
-  shoppingCart: Ember.inject.service()
+export default Component.extend({
+  shoppingCart: service()
 });
 ```
 
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`][3] method on an application instance. This method takes a string
+[`lookup`](http://emberjs.com/api/classes/Ember.ApplicationInstance.html#method_lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -226,21 +225,18 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`][4] will retrieve the application instance that "owns" an
+[`Ember.getOwner`](http://emberjs.com/api/#method_getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`][4] to perform lookups through their application
+can use [`Ember.getOwner`](http://emberjs.com/api/#method_getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based
 on a song's `audioType`.
 
 ```app/components/play-audio.js
-import Ember from 'ember';
-const {
-  Component,
-  computed,
-  getOwner
-} = Ember;
+import Component from '@ember/component';
+import { computed } from "@ember/object";
+import { getOwner } from "@ember/application";
 
 // Usage:
 //
@@ -259,7 +255,3 @@ export default Component.extend({
   }
 });
 ```
-
-[3]: http://emberjs.com/api/classes/Ember.ApplicationInstance.html#method_lookup
-[4]: http://emberjs.com/api/#method_getOwner
-

--- a/source/applications/dependency-injection.md
+++ b/source/applications/dependency-injection.md
@@ -141,7 +141,7 @@ The value of `logger` will come from the factory named `logger:main`.
 Routes in this example application can now access the injected logger:
 
 ```app/routes/index.js
-import Route from "@ember/routing/route"
+import Route from "@ember/routing/route";
 
 export default Route.extend({
   activate() {

--- a/source/applications/run-loop.md
+++ b/source/applications/run-loop.md
@@ -63,10 +63,15 @@ Essentially, batching similar work allows for better pipelining, and further opt
 Let's look at a similar example that is optimized in Ember, starting with a `User` object:
 
 ```javascript
-let User = Ember.Object.extend({
+import EmberObject, {
+  computed
+} from '@ember/object';
+
+let User = EmberObject.extend({
   firstName: null,
   lastName: null,
-  fullName: Ember.computed('firstName', 'lastName', function() {
+
+  fullName: computed('firstName', 'lastName', function() {
     return `${this.get('firstName')} ${this.get('lastName')}`;
   })
 });
@@ -193,13 +198,9 @@ $('a').click(() => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`][1], [`run.scheduleOnce`][2],
-[`run.once`][3] have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](http://emberjs.com/api/classes/Ember.run.html#method_schedule), [`run.scheduleOnce`](http://emberjs.com/api/classes/Ember.run.html#method_scheduleOnce),
+[`run.once`](http://emberjs.com/api/classes/Ember.run.html#method_once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
-
-[1]: http://emberjs.com/api/classes/Ember.run.html#method_schedule
-[2]: http://emberjs.com/api/classes/Ember.run.html#method_scheduleOnce
-[3]: http://emberjs.com/api/classes/Ember.run.html#method_once
 
 Here is some pseudocode to describe what happens using the example above:
 

--- a/source/applications/services.md
+++ b/source/applications/services.md
@@ -1,6 +1,4 @@
-An [`Ember.Service`][1] is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
-
-[1]: http://emberjs.com/api/classes/Ember.Service.html
+An [`Service`](http://emberjs.com/api/classes/Ember.Service.html) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -22,14 +20,12 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Ember.Service`][1] base class:
-
-[1]: http://emberjs.com/api/classes/Ember.Service.html
+Services must extend the [`Service`](http://emberjs.com/api/classes/Ember.Service.html) base class:
 
 ```app/services/shopping-cart.js
-import Ember from 'ember';
+import Service from '@ember/service';
 
-export default Ember.Service.extend({
+export default Service.extend({
 });
 ```
 
@@ -37,9 +33,9 @@ Like any Ember object, a service is initialized and can have properties and meth
 Below, the shopping cart service manages an items array that represents the items currently in the shopping cart.
 
 ```app/services/shopping-cart.js
-import Ember from 'ember';
+import Service from '@ember/service';
 
-export default Ember.Service.extend({
+export default Service.extend({
   items: null,
 
   init() {
@@ -64,29 +60,31 @@ export default Ember.Service.extend({
 ### Accessing Services
 
 To access a service,
-you can inject it in any container-resolved object such as a component or another service using the `Ember.inject.service` function.
+you can inject it in any container-resolved object such as a component or another service using the `inject` function from the `@ember/service` module.
 There are two ways to use this function.
 You can either invoke it with no arguments, or you can pass it the registered name of the service.
 When no arguments are passed, the service is loaded based on the name of the variable key.
 You can load the shopping cart service with no arguments like below.
 
 ```app/components/cart-contents.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
+export default Component.extend({
   //will load the service in file /app/services/shopping-cart.js
-  shoppingCart: Ember.inject.service()
+  shoppingCart: service()
 });
 ```
 
 Another way to inject a service is to provide the name of the service as the argument.
 
 ```app/components/cart-contents.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
+export default Component.extend({
   //will load the service in file /app/services/shopping-cart.js
-  cart: Ember.inject.service('shopping-cart')
+  cart: service('shopping-cart')
 });
 ```
 
@@ -97,12 +95,14 @@ Since normal injection will throw an error if the service doesn't exist,
 you must look up the service using Ember's [`getOwner`](https://emberjs.com/api/classes/Ember.html#method_getOwner) instead. 
 
 ```app/components/cart-contents.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from "@ember/object";
+import { getOwner } from "@ember/application";
 
-export default Ember.Component.extend({
+export default Component.extend({
   //will load the service in file /app/services/shopping-cart.js
-  cart: Ember.computed(function() {
-    return Ember.getOwner(this).lookup('service:shopping-cart');
+  cart: computed(function() {
+    return getOwner(this).lookup('service:shopping-cart');
   })
 });
 ```
@@ -116,10 +116,11 @@ Below we add a remove action to the `cart-contents` component.
 Notice that below we access the `cart` service with a call to`this.get`.
 
 ```app/components/cart-contents.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  cart: Ember.inject.service('shopping-cart'),
+export default Component.extend({
+  cart: service('shopping-cart'),
 
   actions: {
     remove(item) {

--- a/source/components/customizing-a-components-element.md
+++ b/source/components/customizing-a-components-element.md
@@ -10,18 +10,18 @@ a DOM representation that looked something like:
 
 You can customize what type of element Ember generates for your
 component, including its attributes and class names, by creating a
-subclass of `Ember.Component` in your JavaScript.
+subclass of `Component` in your JavaScript.
 
 ### Customizing the Element
 
-To use a tag other than `div`, subclass `Ember.Component` and assign it
+To use a tag other than `div`, subclass `Component` and assign it
 a `tagName` property. This property can be any valid HTML5 tag name as a
 string.
 
 ```app/components/navigation-bar.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   tagName: 'nav'
 });
 ```
@@ -46,9 +46,9 @@ You can also specify which class names are applied to the component's
 element by setting its `classNames` property to an array of strings:
 
 ```app/components/navigation-bar.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['primary']
 });
 ```
@@ -58,9 +58,9 @@ you can use class name bindings. If you bind to a Boolean property, the
 class name will be added or removed depending on the value:
 
 ```app/components/todo-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: ['isUrgent'],
   isUrgent: true
 });
@@ -78,9 +78,9 @@ By default, the name of the Boolean property is dasherized. You can customize th
 applied by delimiting it with a colon:
 
 ```app/components/todo-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: ['isUrgent:urgent'],
   isUrgent: true
 });
@@ -95,9 +95,9 @@ This would render this HTML:
 Besides the custom class name for the value being `true`, you can also specify a class name which is used when the value is `false`:
 
 ```app/components/todo-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: ['isEnabled:enabled:disabled'],
   isEnabled: false
 });
@@ -113,9 +113,9 @@ You can also specify a class which should only be added when the property is
 `false` by declaring `classNameBindings` like this:
 
 ```app/components/todo-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: ['isEnabled::disabled'],
   isEnabled: false
 });
@@ -137,9 +137,9 @@ If the bound property's value is a string, that value will be added as a class n
 modification:
 
 ```app/components/todo-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: ['priority'],
   priority: 'highestPriority'
 });
@@ -157,11 +157,12 @@ You can bind attributes to the DOM element that represents a component
 by using `attributeBindings`:
 
 ```app/components/link-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   tagName: 'a',
   attributeBindings: ['href'],
+
   href: 'http://emberjs.com'
 });
 ```
@@ -169,11 +170,12 @@ export default Ember.Component.extend({
 You can also bind these attributes to differently named properties:
 
 ```app/components/link-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   tagName: 'a',
   attributeBindings: ['customHref:href'],
+
   customHref: 'http://emberjs.com'
 });
 ```
@@ -181,12 +183,13 @@ export default Ember.Component.extend({
 If the attribute is null, it won't be rendered:
 
 ```app/components/link-item.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   tagName: 'span',
-  title: null,
   attributeBindings: ['title'],
+
+  title: null,
 });
 ```
 This would render this HTML when no title is passed to the component:

--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -33,9 +33,9 @@ Given the above template, you can now use the `{{blog-post}}` component:
 Its model is populated in `model` hook in the route handler:
 
 ```app/routes/index.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.get('store').findAll('post');
   }
@@ -58,12 +58,10 @@ the Handlebars template as described above and use the component that is
 created.
 
 If you need to customize the behavior of the component you'll
-need to define a subclass of [`Ember.Component`][1]. For example, you would
+need to define a subclass of [`Component`](http://emberjs.com/api/classes/Ember.Component.html). For example, you would
 need a custom subclass if you wanted to change a component's element,
 respond to actions from the component's template, or manually make
 changes to the component's element using JavaScript.
-
-[1]: http://emberjs.com/api/classes/Ember.Component.html
 
 Ember knows which subclass powers a component based on its filename. For
 example, if you have a component called `blog-post`, you would create a
@@ -73,7 +71,7 @@ file at `app/components/blog-post.js`. If your component was called
 
 ## Dynamically rendering a component
 
-The [`{{component}}`][2] helper can be used to defer the selection of a component to
+The [`{{component}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_component) helper can be used to defer the selection of a component to
 run time. The `{{my-component}}` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
@@ -83,11 +81,9 @@ allow you to keep different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `{{blog-post}}`.
 
-The real value of [`{{component}}`][2] comes from being able to dynamically pick
+The real value of [`{{component}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_component) comes from being able to dynamically pick
 the component being rendered. Below is an example of using the helper as a
 means of choosing different components for displaying different kinds of posts:
-
-[2]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_component
 
 ```app/templates/components/foo-component.hbs
 <h3>Hello from foo!</h3>
@@ -100,9 +96,9 @@ means of choosing different components for displaying different kinds of posts:
 ```
 
 ```app/routes/index.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.get('store').findAll('post');
   }

--- a/source/components/handling-events.md
+++ b/source/components/handling-events.md
@@ -14,9 +14,9 @@ Let's implement `double-clickable` such that when it is
 clicked, an alert is displayed:
 
 ```app/components/double-clickable.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   doubleClick() {
     alert("DoubleClickableComponent was clicked!");
   }
@@ -28,9 +28,9 @@ in succession. To enable bubbling `return true;` from the event handler method
 in your component.
 
 ```app/components/double-clickable.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   doubleClick() {
     Ember.Logger.info("DoubleClickableComponent was clicked!");
     return true;
@@ -56,9 +56,9 @@ And if you need to, you may also stop events from bubbling, by using
 `return false;`.
 
 ```app/components/drop-target.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   attributeBindings: ['draggable'],
   draggable: 'true',
 
@@ -110,7 +110,7 @@ default behavior using an action.
 
 ```js
 actions: {
-  signUp(){
+  signUp() {
     // No event object is passed to the action.
   }
 }
@@ -128,7 +128,7 @@ To utilize an `event` object as a function parameter:
 
 The event handling examples described above respond to one set of events.
 The names of the built-in events are listed below. Custom events can be
-registered by using [Ember.Application.customEvents][customEvents].
+registered by using [Application.customEvents][customEvents].
 
 Touch events:
 

--- a/source/components/handling-events.md
+++ b/source/components/handling-events.md
@@ -128,7 +128,7 @@ To utilize an `event` object as a function parameter:
 
 The event handling examples described above respond to one set of events.
 The names of the built-in events are listed below. Custom events can be
-registered by using [Application.customEvents][customEvents].
+registered by using [Application.customEvents](http://emberjs.com/api/classes/Ember.Application.html#property_customEvents).
 
 Touch events:
 
@@ -173,5 +173,3 @@ HTML5 drag and drop events:
 * `dragOver`
 * `dragEnd`
 * `drop`
-
-[customEvents]: http://emberjs.com/api/classes/Ember.Application.html#property_customEvents

--- a/source/components/passing-properties-to-a-component.md
+++ b/source/components/passing-properties-to-a-component.md
@@ -14,9 +14,9 @@ display a blog post:
 Now imagine we have the following template and route:
 
 ```app/routes/index.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.get('store').findAll('post');
   }
@@ -66,14 +66,12 @@ In other words, you can invoke the above component example like this:
 ```
 
 To set the component up to receive parameters this way, you need to
-set the [`positionalParams`][1] attribute in your component class.
-
-[1]: http://emberjs.com/api/classes/Ember.Component.html#property_positionalParams
+set the [`positionalParams`](http://emberjs.com/api/classes/Ember.Component.html#property_positionalParams) attribute in your component class.
 
 ```app/components/blog-post.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-const BlogPostComponent = Ember.Component.extend({});
+const BlogPostComponent = Component.extend({});
 
 BlogPostComponent.reopenClass({
   positionalParams: ['title', 'body']
@@ -94,13 +92,14 @@ setting `positionalParams` to a string, e.g. `positionalParams: 'params'`. This
 will allow you to access those params as an array like so:
 
 ```app/components/blog-post.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
-const BlogPostComponent = Ember.Component.extend({
-  title: Ember.computed('params.[]', function(){
+const BlogPostComponent = Component.extend({
+  title: computed('params.[]', function(){
     return this.get('params')[0];
   }),
-  body: Ember.computed('params.[]', function(){
+  body: computed('params.[]', function(){
     return this.get('params')[1];
   })
 });

--- a/source/components/the-component-lifecycle.md
+++ b/source/components/the-component-lifecycle.md
@@ -60,9 +60,9 @@ you can use `didUpdateAttrs` to clear any error state that was built up from edi
 ```
 
 ```/app/components/profile-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   init() {
     this._super(...arguments);
     this.errors = [];
@@ -95,9 +95,9 @@ For example, if you have a component that renders based on a json configuration,
 you can leverage `didReceiveAttrs` to ensure the incoming config is always parsed.
 
 ```app/components/profile-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
     const profile = this.get('data');
@@ -130,9 +130,9 @@ A component's [`$()`][dollar] method allows you to access the component's DOM el
 For example, you can set an attribute using jQuery's `attr()` method:
 
 ```app/components/profile-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.$().attr('contenteditable', true);
@@ -143,9 +143,9 @@ export default Ember.Component.extend({
 [`$()`][dollar] will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
 
 ```app/components/profile-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.$('div p button').addClass('enabled');
@@ -158,9 +158,9 @@ Let's initialize our date picker by overriding the [`didInsertElement()`][did-in
 Date picker libraries usually attach to an `<input>` element, so we will use jQuery to find an appropriate input within our component's template.
 
 ```app/components/profile-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.$('input.date').myDatePickerLib();
@@ -177,9 +177,9 @@ For example, perhaps you have some custom CSS animations trigger when the compon
 is rendered and you want to handle some cleanup when it ends:
 
 ```app/components/profile-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.$().on('animationend', () => {
@@ -230,10 +230,10 @@ When rendered the component will iterate through the given list and apply a clas
 
 The scroll happens on `didRender`, where it will scroll the component's container to the element with the selected class name.
 
-```app/components/selected-item-list.js
-import Ember from 'ember';
+```/app/components/selected-item-list.js
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['item-list'],
 
   didReceiveAttrs() {
@@ -255,7 +255,7 @@ export default Ember.Component.extend({
 
 ### Detaching and Tearing Down Component Elements with `willDestroyElement`
 
-When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`][will-destroy-element] method,
+When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](http://emberjs.com/api/classes/Ember.Component.html#event_willDestroyElement) method,
 allowing for any teardown logic to be performed.
 
 Component teardown can be triggered by a number of different conditions.
@@ -270,9 +270,9 @@ For instance, the user may navigate to a different route, or a conditional Handl
 Let's use this hook to cleanup our date picker and event listener from above:
 
 ```app/components/profile-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   willDestroyElement() {
     this.$().off('animationend');
     this.$('input.date').myDatepickerLib().destroy();
@@ -280,5 +280,3 @@ export default Ember.Component.extend({
   }
 });
 ```
-
-[will-destroy-element]: http://emberjs.com/api/classes/Ember.Component.html#event_willDestroyElement

--- a/source/components/triggering-changes-with-actions.md
+++ b/source/components/triggering-changes-with-actions.md
@@ -79,10 +79,11 @@ We'll implement an action on the parent component called
 `deleteUser()` method.
 
 ```app/components/user-profile.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  login: Ember.inject.service(),
+export default Component.extend({
+  login: service(),
 
   actions: {
     userDidDeleteAccount() {
@@ -101,10 +102,9 @@ Next,
 in the child component we will implement the logic to confirm that the user wants to take the action they indicated by clicking the button:
 
 ```app/components/button-with-confirmation.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
-
+export default Component.extend({
   actions: {
     launchConfirmDialog() {
       this.set('confirmShown', true);
@@ -166,10 +166,9 @@ Now, we can use `onConfirm` in the child component to invoke the action on the
 parent:
 
 ```app/components/button-with-confirmation.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
-
+export default Component.extend({
   actions: {
     launchConfirmDialog() {
       this.set('confirmShown', true);
@@ -213,9 +212,9 @@ This is accomplished by expecting a promise to be returned from `onConfirm`.
 Upon resolution of the promise, we set a property used to indicate the visibility of the confirmation modal.
 
 ```app/components/button-with-confirmation.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   actions: {
     launchConfirmDialog() {
       this.set('confirmShown', true);
@@ -245,7 +244,9 @@ the case where the `button-with-confirmation` component we've defined is used wi
 The `sendMessage` action that we pass to the child component may expect a message type parameter to be provided as an argument:
 
 ```app/components/send-message.js
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
   actions: {
     sendMessage(messageType) {
       //send message here and return a promise
@@ -280,7 +281,9 @@ Suppose we want to extend this by allowing `sendMessage` to take a second argume
 the actual text of the message the user is sending:
 
 ```app/components/send-message.js
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
   actions: {
     sendMessage(messageType, messageText) {
       //send message here and return a promise
@@ -302,7 +305,9 @@ Therefore within the component's javascript file,
 we will use a property `confirmValue` to represent that argument and pass it to `onConfirm` as shown here:
 
 ```app/components/button-with-confirmation.js
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
   actions: {
     //...
     submitConfirm() {
@@ -356,10 +361,11 @@ Actions can be invoked on objects other than the component directly from the tem
 `send-message` component we might include a service that processes the `sendMessage` logic.
 
 ```app/components/send-message.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  messaging: Ember.inject.service(),
+export default Component.extend({
+  messaging: service(),
 
   // component implementation
 });
@@ -380,7 +386,7 @@ By supplying the `target` attribute, the action helper will look to invoke the `
 service, saving us from writing code on the component that just passes the action along to the service.
 
 ```app/services/messaging.js
-import Ember from 'ember';
+import Service from '@ember/service';
 
 export default Ember.Service.extend({
   actions: {
@@ -400,10 +406,11 @@ user's account was deleted, and passes along with it the full user profile objec
 
 
 ```app/components/user-profile.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  login: Ember.inject.service(),
+export default Component.extend({
+  login: service(),
 
   actions: {
     userDidDeleteAccount() {
@@ -425,9 +432,9 @@ object to pull out only what it needs.
 Now when the `system-preferences-editor` handles the delete action, it receives only the user's account `id` string.
 
 ```app/components/system-preferences-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   actions: {
     userDeleted(idStr) {
       //respond to deletion
@@ -446,10 +453,11 @@ For example, say we want to move account deletion from the `user-profile` compon
 First we would move the `deleteUser` action from `user-profile.js` to the actions object on `system-preferences-editor`.
 
 ```app/components/system-preferences-editor.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  login: Ember.inject.service(),
+export default Component.extend({
+  login: service(),
   actions: {
     deleteUser(idStr) {
       return this.get('login').deleteUserAccount(idStr);

--- a/source/configuring-ember/debugging.md
+++ b/source/configuring-ember/debugging.md
@@ -64,9 +64,9 @@ It's useful for understanding which objects Ember is finding when it does a look
 and which it is generating automatically for you.
 
 ```app/app.js
-import Ember from 'ember';
+import Application from '@ember/application';
 
-export default Ember.Application.extend({
+export default Application.extend({
   LOG_RESOLVER: true
 });
 ```
@@ -119,11 +119,11 @@ but a common practice is to call `console.assert` to dump the error to the
 console.
 
 ```app/app.js
-import Ember from 'ember';
+import { assert } from '@ember/debug';
 import RSVP from 'rsvp';
 
 RSVP.on('error', function(error) {
-  Ember.assert(error, false);
+  assert(error, false);
 });
 ```
 

--- a/source/configuring-ember/debugging.md
+++ b/source/configuring-ember/debugging.md
@@ -6,9 +6,9 @@ with your application.
 #### Log router transitions
 
 ```app/app.js
-import Ember from 'ember';
+import Application from '@ember/application';
 
-export default Ember.Application.extend({
+export default Application.extend({
   // Basic logging, e.g. "Transitioned into 'post'"
   LOG_TRANSITIONS: true,
 

--- a/source/configuring-ember/disabling-prototype-extensions.md
+++ b/source/configuring-ember/disabling-prototype-extensions.md
@@ -77,13 +77,15 @@ You can manually coerce a native array into an array that implements the
 required interfaces using the convenience method `Ember.A`:
 
 ```javascript
+import { A } from "@ember/array"
+
 let islands = ['Oahu', 'Kauai'];
 islands.includes('Oahu');
 //=> TypeError: Object Oahu,Kauai has no method 'includes'
 
 // Convert `islands` to an array that implements the
 // Ember enumerable and array interfaces
-Ember.A(islands);
+A(islands);
 
 islands.includes('Oahu');
 //=> true
@@ -98,10 +100,12 @@ you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:
 
 ```javascript
+import { camelize } from "@ember/string"
+
 "my_cool_class".camelize();
 //=> TypeError: Object my_cool_class has no method 'camelize'
 
-Ember.String.camelize("my_cool_class");
+camelize("my_cool_class");
 //=> "myCoolClass"
 ```
 
@@ -116,6 +120,8 @@ To annotate computed properties, use the `Ember.computed()` method to
 wrap the function:
 
 ```javascript
+import { computed } from "@ember/object"
+
 // This won't work:
 fullName: function() {
   return `${this.get('firstName')} ${this.get('lastName')}`;
@@ -123,7 +129,7 @@ fullName: function() {
 
 
 // Instead, do this:
-fullName: Ember.computed('firstName', 'lastName', function() {
+fullName: computed('firstName', 'lastName', function() {
   return `${this.get('firstName')} ${this.get('lastName')}`;
 })
 ```
@@ -131,6 +137,8 @@ fullName: Ember.computed('firstName', 'lastName', function() {
 Observers are annotated using `Ember.observer()`:
 
 ```javascript
+import { observer } from "@ember/object"
+
 // This won't work:
 fullNameDidChange: function() {
   console.log('Full name changed');
@@ -138,7 +146,7 @@ fullNameDidChange: function() {
 
 
 // Instead, do this:
-fullNameDidChange: Ember.observer('fullName', function() {
+fullNameDidChange: observer('fullName', function() {
   console.log('Full name changed');
 })
 ```
@@ -146,13 +154,15 @@ fullNameDidChange: Ember.observer('fullName', function() {
 Evented functions are annotated using `Ember.on()`:
 
 ```javascript
+import { on } from "@ember/object/evented"
+
 // This won't work:
 doStuffWhenInserted: function() {
   /* awesome sauce */
 }.on('didInsertElement');
 
 // Instead, do this:
-doStuffWhenInserted: Ember.on('didInsertElement', function() {
+doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```

--- a/source/configuring-ember/embedding-applications.md
+++ b/source/configuring-ember/embedding-applications.md
@@ -81,7 +81,7 @@ module.exports = function(environment) {
 You will notice that this is then used to configure your application's router:
 
 ```app/router.js
-import Router from "@ember/routing/router"
+import Router from "@ember/routing/router";
 import config from './config/environment';
 
 const Router = Router.extend({

--- a/source/configuring-ember/embedding-applications.md
+++ b/source/configuring-ember/embedding-applications.md
@@ -81,10 +81,10 @@ module.exports = function(environment) {
 You will notice that this is then used to configure your application's router:
 
 ```app/router.js
-import Ember from 'ember';
+import Router from "@ember/routing/router"
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = Router.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/source/controllers/index.md
+++ b/source/controllers/index.md
@@ -79,9 +79,9 @@ You can then define what the action does within the `actions` hook
 of the controller, as you would with a component:
 
 ```app/controllers/blog-post.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   isExpanded: false,
 
   actions: {

--- a/source/ember-inspector/installation.md
+++ b/source/ember-inspector/installation.md
@@ -4,7 +4,7 @@ browsers (via a bookmarklet), and on mobile devices by following the steps below
 ### Google Chrome
 
 You can install the Inspector on Google Chrome as a new Developer
-Tool. To begin, visit the Extension page on the [Chrome Web Store][ember-inspector-chrome].
+Tool. To begin, visit the Extension page on the [Chrome Web Store](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi).
 
 Click on "Add To Chrome":
 
@@ -14,8 +14,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab at the far right.
 
 <img src="../../images/guides/ember-inspector/installation-chrome-panel.png" width="680">
-
-[ember-inspector-chrome]: https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi
 
 #### File:// protocol
 
@@ -81,6 +79,4 @@ To open the Inspector, click on the new bookmark. Safari blocks popups by defaul
 ### Mobile Devices
 
 If you want to run the Inspector on a mobile device,
-you can use the [Ember CLI Remote Inspector][ember-cli-remote-inspector] addon.
-
-[ember-cli-remote-inspector]: https://github.com/joostdevries/ember-cli-remote-inspector
+you can use the [Ember CLI Remote Inspector](https://github.com/joostdevries/ember-cli-remote-inspector) addon.

--- a/source/ember-inspector/troubleshooting.md
+++ b/source/ember-inspector/troubleshooting.md
@@ -1,6 +1,6 @@
 Below are some common issues you may encounter when using the Inspector, along with the
 necessary steps to solve them. If your issue is not listed below, please submit an
-issue to the Inspector's [GitHub repo][ember-inspector-github].
+issue to the Inspector's [GitHub repo](https://github.com/emberjs/ember-inspector).
 
 ### Ember Application Not Detected
 
@@ -64,7 +64,4 @@ Firefox addons need to go through a review process with each update, so the Insp
 
 Unfortunately we don't have control over the Firefox review process, so if you need
 the latest Inspector version, download and install it manually from
-[GitHub][ember-inspector-github].
-
-
-[ember-inspector-github]: https://github.com/emberjs/ember-inspector
+[GitHub](https://github.com/emberjs/ember-inspector).

--- a/source/ember-inspector/view-tree.md
+++ b/source/ember-inspector/view-tree.md
@@ -3,8 +3,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 
 <img src="../../images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
-Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+Use the tips described in [Object Inspector](../object-inspector) to inspect models and controllers. See below for templates and components.
 
 ### Inspecting Templates
 

--- a/source/getting-started/quick-start.md
+++ b/source/getting-started/quick-start.md
@@ -138,9 +138,9 @@ export default Route.extend({
 });
 ```
 
-This code example uses the latest features in JavaScript, some of which
-you may not be familiar with. Learn more with this [overview of the
-newest JavaScript features](https://ponyfoo.com/articles/es6).
+This code example uses the latest features in JavaScript,
+some of which you may not be familiar with.
+Learn more with this [overview of the newest JavaScript features](https://ponyfoo.com/articles/es6).
 
 In a route's `model()` method, you return whatever data you want to make available to the template.
 If you need to fetch data asynchronously,

--- a/source/getting-started/quick-start.md
+++ b/source/getting-started/quick-start.md
@@ -129,9 +129,9 @@ and we can specify a model by editing `app/routes/scientists.js`.
 We'll take the code created for us by the generator and add a `model()` method to the `Route`:
 
 ```app/routes/scientists.js{+4,+5,+6}
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return ['Marie Curie', 'Mae Jemison', 'Albert Hofmann'];
   }
@@ -250,9 +250,9 @@ To handle this function call you need to modify the `people-list` component file
 In the component, add an `actions` object with a `showPerson` function that alerts the first argument.
 
 ```app/components/people-list.js{+4,+5,+6,+7,+8}
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   actions: {
     showPerson(person) {
       alert(person);

--- a/source/models/creating-updating-and-deleting-records.md
+++ b/source/models/creating-updating-and-deleting-records.md
@@ -118,7 +118,7 @@ the errors from saving a blog post in your template:
 ## Promises
 
 [`save()`](http://emberjs.com/api/data/classes/DS.Model.html#method_save) returns
-a promise, which makes it easy to asynchronously handle success and failure 
+a promise, which makes it easy to asynchronously handle success and failure
 scenarios.  Here's a common pattern:
 
 ```javascript

--- a/source/models/customizing-adapters.md
+++ b/source/models/customizing-adapters.md
@@ -183,10 +183,11 @@ underscore_case instead of camelCase you could override the
 
 ```app/adapters/application.js
 import DS from 'ember-data';
+import { underscore } from '@ember/string';
 
 export default DS.JSONAPIAdapter.extend({
   pathForType: function(type) {
-    return Ember.String.underscore(type);
+    return underscore(type);
   }
 });
 ```
@@ -217,10 +218,13 @@ property dependent on the `session` service.
 
 ```app/adapters/application.js
 import DS from 'ember-data';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
 
 export default DS.JSONAPIAdapter.extend({
-  session: Ember.inject.service('session'),
-  headers: Ember.computed('session.authToken', function() {
+  session: service('session'),
+  headers: computed('session.authToken', function() {
     return {
       'API_KEY': this.get('session.authToken'),
       'ANOTHER_HEADER': 'Some header value'
@@ -238,11 +242,13 @@ be recomputed with every request.
 
 ```app/adapters/application.js
 import DS from 'ember-data';
+import { computed } from '@ember/object';
+import { get } from '@ember/object';
 
 export default DS.JSONAPIAdapter.extend({
-  headers: Ember.computed(function() {
+  headers: computed(function() {
     return {
-      'API_KEY': Ember.get(document.cookie.match(/apiKey\=([^;]*)/), '1'),
+      'API_KEY': get(document.cookie.match(/apiKey\=([^;]*)/), '1'),
       'ANOTHER_HEADER': 'Some header value'
     };
   }).volatile()

--- a/source/models/customizing-serializers.md
+++ b/source/models/customizing-serializers.md
@@ -446,13 +446,14 @@ registered for use as attributes:
 
 ```app/transforms/coordinate-point.js
 import DS from 'ember-data';
+import EmberObject from '@ember/object';
 
 export default DS.Transform.extend({
   serialize(value) {
     return [value.get('x'), value.get('y')];
   },
   deserialize(value) {
-    return Ember.Object.create({ x: value[0], y: value[1] });
+    return EmberObject.create({ x: value[0], y: value[1] });
   }
 });
 ```

--- a/source/models/customizing-serializers.md
+++ b/source/models/customizing-serializers.md
@@ -316,12 +316,12 @@ payload. For example, if your backend returned attributes that are
 method like this.
 
 ```app/serializers/application.js
-import Ember from 'ember';
+import { underscore } from '@ember/string';
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
   keyForAttribute(attr) {
-    return Ember.String.underscore(attr);
+    return underscore(attr);
   }
 });
 ```

--- a/source/models/defining-models.md
+++ b/source/models/defining-models.md
@@ -50,11 +50,7 @@ properties that combine or transform primitive attributes.
 
 ```app/models/person.js
 import DS from 'ember-data';
-<<<<<<< HEAD
-import Ember from 'ember';
-=======
 import { computed } from '@ember/object';
->>>>>>> Converts Models (#2015)
 
 export default DS.Model.extend({
   firstName: DS.attr(),

--- a/source/models/defining-models.md
+++ b/source/models/defining-models.md
@@ -50,13 +50,17 @@ properties that combine or transform primitive attributes.
 
 ```app/models/person.js
 import DS from 'ember-data';
+<<<<<<< HEAD
 import Ember from 'ember';
+=======
+import { computed } from '@ember/object';
+>>>>>>> Converts Models (#2015)
 
 export default DS.Model.extend({
   firstName: DS.attr(),
   lastName: DS.attr(),
 
-  fullName: Ember.computed('firstName', 'lastName', function() {
+  fullName: computed('firstName', 'lastName', function() {
     return `${this.get('firstName')} ${this.get('lastName')}`;
   })
 });

--- a/source/models/finding-records.md
+++ b/source/models/finding-records.md
@@ -78,10 +78,11 @@ and the adapter for the `User` model defines a `queryRecord()` method that targe
 
 ```app/adapters/user.js
 import DS from "ember-data";
+import $ from 'jquery';
 
 export default DS.Adapter.extend({
   queryRecord(store, type, query) {
-    return Ember.$.getJSON("/api/current_user");
+    return $.getJSON("/api/current_user");
   }
 });
 ```

--- a/source/models/handling-metadata.md
+++ b/source/models/handling-metadata.md
@@ -66,9 +66,9 @@ After reading it, `meta.total` can be used to calculate how many pages of posts 
 To use the `meta` data outside of the `model` hook, you need to return it:
 
 ```app/routes/users.js
-import Ember from 'ember';
+import Router from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.store.findAll('user').then((results) => {
       return {

--- a/source/models/index.md
+++ b/source/models/index.md
@@ -74,9 +74,9 @@ You might be tempted to make the component responsible for fetching that
 data and storing it:
 
 ```app/components/list-of-drafts.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   willRender() {
     $.getJSON('/drafts').then(data => {
       this.set('drafts', data);
@@ -103,9 +103,9 @@ tempted to copy and paste your existing `willRender` code into the new
 component.
 
 ```app/components/drafts-button.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   willRender() {
     $.getJSON('/drafts').then(data => {
       this.set('drafts', data);

--- a/source/models/pushing-records-into-the-store.md
+++ b/source/models/pushing-records-into-the-store.md
@@ -39,9 +39,9 @@ export default DS.Model.extend({
 ```
 
 ```app/routes/application.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     this.get('store').push({
       data: [{
@@ -94,9 +94,9 @@ export default DS.RestSerializer.extend({
 ```
 
 ```app/routes/application.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     this.get('store').pushPayload({
       albums: [
@@ -128,9 +128,9 @@ so it can be accessed by other parts of your application.
 
 
 ```app/routes/confirm-payment.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   actions: {
     confirm: function(data) {
       $.ajax({

--- a/source/models/relationships.md
+++ b/source/models/relationships.md
@@ -352,7 +352,9 @@ when retrieving a specific post we can have the server also return that post's c
 as follows:
 
 ```app/routes/post.js
-export default Ember.Route.extend({
+import Route from '@ember/routing/route';
+
+export default Route.extend({
   model(params) {
    return this.store.findRecord('post', params.post_id, {include: 'comments'});
   }
@@ -365,7 +367,9 @@ So to request both the post's comments and the authors of those comments the req
 would look like this:
 
 ```app/routes/post.js
-export default Ember.Route.extend({
+import Route from '@ember/routing/route';
+
+export default Route.extend({
   model(params) {
    return this.store.findRecord('post', params.post_id, {include: 'comments,comments.author'});
   }
@@ -377,7 +381,9 @@ form part of that argument.
 For example:
 
 ```app/routes/adele.js
-export default Ember.Route.extend({
+import Route from '@ember/routing/route';
+
+export default Route.extend({
   model() {
     // GET to /artists?filter[name]=Adele&include=albums
     this.store.query('artist', {

--- a/source/models/relationships.md
+++ b/source/models/relationships.md
@@ -169,25 +169,25 @@ export default DS.Model.extend({
 ```
 
 ```app/models/payment-method-cc.js
+import { computed } from '@ember/object';
 import PaymentMethod from './payment-method';
-import Ember from 'ember';
 
 export default PaymentMethod.extend({
-  obfuscatedIdentifier: Ember.computed('last4', function () {
+  obfuscatedIdentifier: computed('last4', function () {
     return `**** **** **** ${this.get('last4')}`;
   })
 });
 ```
 
 ```app/models/payment-method-paypal.js
-import PaymentMethod from './payment-method'
+import { computed } from '@ember/object';
 import DS from 'ember-data';
-import Ember from 'ember';
+import PaymentMethod from './payment-method'
 
 export default PaymentMethod.extend({
   linkedEmail: DS.attr(),
 
-  obfuscatedIdentifier: Ember.computed('linkedEmail', function () {
+  obfuscatedIdentifier: computed('linkedEmail', function () {
     let last5 = this.get('linkedEmail').split('').reverse().slice(0, 5).reverse().join('');
 
     return `••••${last5}`;

--- a/source/object-model/bindings.md
+++ b/source/object-model/bindings.md
@@ -7,12 +7,15 @@ The easiest way to create a two-way binding is to use a [`computed.alias()`](htt
 that specifies the path to another object.
 
 ```javascript
-husband = Ember.Object.create({
+import EmberObject from '@ember/object';
+import { alias } from "@ember/object/computed"
+
+husband = EmberObject.create({
   pets: 0
 });
 
-Wife = Ember.Object.extend({
-  pets: Ember.computed.alias('husband.pets')
+Wife = EmberObject.extend({
+  pets: alias('husband.pets')
 });
 
 wife = Wife.create({
@@ -42,12 +45,16 @@ shipping address that starts the same as a billing address but can later be
 changed)
 
 ```javascript
-user = Ember.Object.create({
+import EmberObject, { computed } from '@ember/object';
+import Component from '@ember/component';
+import { oneWay } from "@ember/object/computed"
+
+user = EmberObject.create({
   fullName: 'Kara Gates'
 });
 
-UserComponent = Ember.Component.extend({
-  userName: Ember.computed.oneWay('user.fullName')
+UserComponent = Component.extend({
+  userName: oneWay('user.fullName')
 });
 
 userComponent = UserComponent.create({

--- a/source/object-model/classes-and-instances.md
+++ b/source/object-model/classes-and-instances.md
@@ -11,7 +11,9 @@ To define a new Ember _class_, call the [`extend()`][1] method on
 [2]: http://emberjs.com/api/classes/Ember.Object.html
 
 ```javascript
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   say(thing) {
     alert(thing);
   }
@@ -27,7 +29,9 @@ of Ember's built-in [`Ember.Component`][3] class:
 [3]: http://emberjs.com/api/classes/Ember.Component.html
 
 ```app/components/todo-item.js
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
   classNameBindings: ['isUrgent'],
   isUrgent: true
 });
@@ -40,7 +44,9 @@ implementation of your parent class by calling the special `_super()`
 method:
 
 ```javascript
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   say(thing) {
     alert(`${this.get('name')} says: ${thing}`);
   }
@@ -90,7 +96,9 @@ instances:
 [5]: http://emberjs.com/api/classes/Ember.Object.html#method_create
 
 ```javascript
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   say(thing) {
     alert(`${this.get('name')} says: ${thing}`);
   }
@@ -105,7 +113,9 @@ When creating an instance, you can initialize the values of its properties
 by passing an optional hash to the `create()` method:
 
 ```javascript
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   helloWorld() {
     alert(`Hi, my name is ${this.get('name')}`);
   }
@@ -138,7 +148,9 @@ instances:
 [6]: http://emberjs.com/api/classes/Ember.Object.html#method_init
 
 ```js
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   init() {
     alert(`${this.get('name')}, reporting for duty!`);
   }
@@ -159,7 +171,9 @@ setup work, and you'll see strange behavior in your application.
 Arrays and objects defined directly on any `Ember.Object` are shared across all instances of that class.
 
 ```js
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   shoppingList: ['eggs', 'cheese']
 });
 
@@ -184,7 +198,9 @@ Person.create({
 To avoid this behavior, it is encouraged to initialize those arrays and object properties during `init()`. Doing so ensures each instance will be unique.
 
 ```js
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   init() {
     this.set('shoppingList', ['eggs', 'cheese']);
   }
@@ -217,7 +233,9 @@ and [`set()`][8] accessor methods:
 [8]: http://emberjs.com/api/classes/Ember.Object.html#method_set
 
 ```js
-const Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+const Person = EmberObject.extend({
   name: 'Robert Jackson'
 });
 

--- a/source/object-model/computed-properties-and-aggregate-data.md
+++ b/source/object-model/computed-properties-and-aggregate-data.md
@@ -7,18 +7,21 @@ to calculate the incomplete todo's based on their `isDone` property.
 To facilitate this, Ember provides the `@each` key illustrated below:
 
 ```app/components/todo-list.js
-export default Ember.Component.extend({
+import EmberObject, { computed } from '@ember/object';
+import Component from '@ember/component';
+
+export default Component.extend({
   todos: null,
 
   init() {
     this.set('todos', [
-      Ember.Object.create({ isDone: true }),
-      Ember.Object.create({ isDone: false }),
-      Ember.Object.create({ isDone: true }),
+      EmberObject.create({ isDone: true }),
+      EmberObject.create({ isDone: false }),
+      EmberObject.create({ isDone: true }),
     ]);
   },
 
-  incomplete: Ember.computed('todos.@each.isDone', function() {
+  incomplete: computed('todos.@each.isDone', function() {
     let todos = this.get('todos');
     return todos.filterBy('isDone', false);
   })
@@ -46,18 +49,22 @@ Ember also provides a computed property macro
 which is a shorter way of expressing the above computed property:
 
 ```app/components/todo-list.js
-export default Ember.Component.extend({
+import EmberObject, { computed } from '@ember/object';
+import { filterBy } from '@ember/object/computed';
+import Component from '@ember/component';
+
+export default Component.extend({
   todos: null,
 
   init() {
     this.set('todos', [
-      Ember.Object.create({ isDone: true }),
-      Ember.Object.create({ isDone: false }),
-      Ember.Object.create({ isDone: true }),
+      EmberObject.create({ isDone: true }),
+      EmberObject.create({ isDone: false }),
+      EmberObject.create({ isDone: true }),
     ]);
   },
 
-  incomplete: Ember.computed.filterBy('todos', 'isDone', false)
+  incomplete: filterBy('todos', 'isDone', false)
 });
 ```
 
@@ -75,6 +82,8 @@ If we change the todo's `isDone` property, the `incomplete` property is updated
 automatically:
 
 ```javascript
+import EmberObject from '@ember/object';
+
 let todos = todoListComponent.get('todos');
 let todo = todos.objectAt(1);
 todo.set('isDone', true);
@@ -82,7 +91,7 @@ todo.set('isDone', true);
 todoListComponent.get('incomplete.length');
 // 0
 
-todo = Ember.Object.create({ isDone: false });
+todo = EmberObject.create({ isDone: false });
 todos.pushObject(todo);
 
 todoListComponent.get('incomplete.length');
@@ -100,19 +109,22 @@ using the `[]` key will only update if items are added to or removed from the ar
 or if the array property is set to a different array. For example:
 
 ```app/components/todo-list.js
-export default Ember.Component.extend({
+import EmberObject, { computed } from '@ember/object';
+import Component from '@ember/component';
+
+export default Component.extend({
   todos: null,
 
   init() {
     this.set('todos', [
-      Ember.Object.create({ isDone: true }),
-      Ember.Object.create({ isDone: false }),
-      Ember.Object.create({ isDone: true }),
+      EmberObject.create({ isDone: true }),
+      EmberObject.create({ isDone: false }),
+      EmberObject.create({ isDone: true }),
     ]);
   },
 
   selectedTodo: null,
-  indexOfSelectedTodo: Ember.computed('selectedTodo', 'todos.[]', function() {
+  indexOfSelectedTodo: computed('selectedTodo', 'todos.[]', function() {
     return this.get('todos').indexOf(this.get('selectedTodo'));
   })
 });
@@ -128,8 +140,10 @@ create a computed property that mapped properties from an array, you could use
 or build the computed property yourself:
 
 ```javascript
-const Hamster = Ember.Object.extend({
-  excitingChores: Ember.computed('chores.[]', function() {
+import EmberObject, { computed } from '@ember/object';
+
+const Hamster = EmberObject.extend({
+  excitingChores: computed('chores.[]', function() {
     return this.get('chores').map(function(chore, index) {
       return `CHORE ${index}: ${chore.toUpperCase()}!`;
     });
@@ -148,8 +162,11 @@ hamster.get('excitingChores'); // ['CHORE 1: CLEAN!', 'CHORE 2: WRITE MORE UNIT 
 By comparison, using the computed macro abstracts some of this away:
 
 ```javascript
-const Hamster = Ember.Object.extend({
-  excitingChores: Ember.computed.map('chores', function(chore, index) {
+import EmberObject from '@ember/object';
+import { map } from '@ember/object/computed';
+
+const Hamster = EmberObject.extend({
+  excitingChores: map('chores', function(chore, index) {
     return `CHORE ${index}: ${chore.toUpperCase()}!`;
   })
 });

--- a/source/object-model/computed-properties.md
+++ b/source/object-model/computed-properties.md
@@ -81,7 +81,7 @@ import EmberObject, { computed } from '@ember/object';
 let obj = EmberObject.extend({
   baz: {foo: 'BLAMMO', bar: 'BLAZORZ'},
 
-  something: Embercomputed('baz.foo', 'baz.bar', function() {
+  something: computed('baz.foo', 'baz.bar', function() {
     return this.get('baz.foo') + ' ' + this.get('baz.bar');
   })
 });

--- a/source/object-model/computed-properties.md
+++ b/source/object-model/computed-properties.md
@@ -12,14 +12,14 @@ We'll start with a simple example.
 We have a `Person` object with `firstName` and `lastName` properties, but we also want a `fullName` property that joins the two names when either of them changes:
 
 ```javascript
-import Ember from 'ember':
+import EmberObject, { computed } from '@ember/object';
 
-Person = Ember.Object.extend({
+Person = EmberObject.extend({
   // these will be supplied by `create`
   firstName: null,
   lastName: null,
 
-  fullName: Ember.computed('firstName', 'lastName', function() {
+  fullName: computed('firstName', 'lastName', function() {
     let firstName = this.get('firstName');
     let lastName = this.get('lastName');
     
@@ -48,7 +48,7 @@ In the previous example, the `fullName` computed property depends on two other p
 import Ember from 'ember':
 
 …
-  fullName: Ember.computed('firstName', 'lastName', function() {
+  fullName: computed('firstName', 'lastName', function() {
     let firstName = this.get('firstName');
     let lastName = this.get('lastName');
     
@@ -64,7 +64,7 @@ You surround the dependent properties with braces (`{}`), and separate with comm
 import Ember from 'ember':
 
 …
-  fullName: Ember.computed('{firstName,lastName}', function() {
+  fullName: computed('{firstName,lastName}', function() {
     let firstName = this.get('firstName');
     let lastName = this.get('lastName');
     
@@ -76,12 +76,12 @@ import Ember from 'ember':
 This is especially useful when you depend on properties of an object, since it allows you to replace:
 
 ```javascript
-import Ember from 'ember':
+import EmberObject, { computed } from '@ember/object';
 
-let obj = Ember.Object.extend({
+let obj = EmberObject.extend({
   baz: {foo: 'BLAMMO', bar: 'BLAZORZ'},
 
-  something: Ember.computed('baz.foo', 'baz.bar', function() {
+  something: Embercomputed('baz.foo', 'baz.bar', function() {
     return this.get('baz.foo') + ' ' + this.get('baz.bar');
   })
 });
@@ -90,12 +90,12 @@ let obj = Ember.Object.extend({
 With:
 
 ```javascript
-import Ember from 'ember':
+import EmberObject, { computed } from '@ember/object';
 
-let obj = Ember.Object.extend({
+let obj = EmberObject.extend({
   baz: {foo: 'BLAMMO', bar: 'BLAZORZ'},
 
-  something: Ember.computed('baz.{foo,bar}', function() {
+  something: computed('baz.{foo,bar}', function() {
     return this.get('baz.foo') + ' ' + this.get('baz.bar');
   })
 });
@@ -108,19 +108,19 @@ Let's add a `description` computed property to the previous example,
 and use the existing `fullName` property and add in some other properties:
 
 ```javascript
-import Ember from 'ember':
+import EmberObject, { computed } from '@ember/object';
 
-Person = Ember.Object.extend({
+Person = EmberObject.extend({
   firstName: null,
   lastName: null,
   age: null,
   country: null,
 
-  fullName: Ember.computed('firstName', 'lastName', function() {
+  fullName: computed('firstName', 'lastName', function() {
     return `${this.get('firstName')} ${this.get('lastName')}`;
   }),
 
-  description: Ember.computed('fullName', 'age', 'country', function() {
+  description: computed('fullName', 'age', 'country', function() {
     return `${this.get('fullName')}; Age: ${this.get('age')}; Country: ${this.get('country')}`;
   })
 });
@@ -157,13 +157,13 @@ If you try to set a computed property, it will be invoked with the key (property
 You must return the new intended value of the computed property from the setter function.
 
 ```javascript
-import Ember from 'ember':
+import EmberObject, { computed } from '@ember/object';
 
-Person = Ember.Object.extend({
+Person = EmberObject.extend({
   firstName: null,
   lastName: null,
 
-  fullName: Ember.computed('firstName', 'lastName', {
+  fullName: computed('firstName', 'lastName', {
     get(key) {
       return `${this.get('firstName')} ${this.get('lastName')}`;
     },
@@ -191,16 +191,17 @@ Ember provides a number of computed property macros, which are shorter ways of e
 In this example, the two computed properties are equivalent:
 
 ```javascript
-import Ember from 'ember':
+import EmberObject, { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 
-Person = Ember.Object.extend({
+Person = EmberObject.extend({
   fullName: 'Tony Stark',
 
-  isIronManLongWay: Ember.computed('fullName', function() {
+  isIronManLongWay: computed('fullName', function() {
     return this.get('fullName') === 'Tony Stark';
   }),
 
-  isIronManShortWay: Ember.computed.equal('fullName', 'Tony Stark')
+  isIronManShortWay: equal('fullName', 'Tony Stark')
 });
 ```
 

--- a/source/object-model/enumerables.md
+++ b/source/object-model/enumerables.md
@@ -105,11 +105,13 @@ in turn and return a new array:
 
 
 ```javascript
-let hawaii = Ember.Object.create({
+import EmberObject from '@ember/object';
+
+let hawaii = EmberObject.create({
   capital: 'Honolulu'
 });
 
-let california = Ember.Object.create({
+let california = EmberObject.create({
   capital: 'Sacramento'
 });
 
@@ -142,7 +144,9 @@ When working with a collection of Ember objects, you will often want to filter a
 
 
 ```javascript
-Todo = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+Todo = EmberObject.extend({
   title: null,
   isDone: false
 });
@@ -169,7 +173,9 @@ use the [`every()`](http://emberjs.com/api/classes/Ember.Enumerable.html#method_
 
 
 ```javascript
-Person = Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+Person = EmberObject.extend({
   name: null,
   isHappy: false
 });

--- a/source/object-model/observers.md
+++ b/source/object-model/observers.md
@@ -8,19 +8,24 @@ Observers should contain behavior that reacts to changes in another property.
 Observers are especially useful when you need to perform some behavior after a
 binding has finished synchronizing.
 
-You can set up an observer on an object by using `Ember.observer`:
+You can set up an observer on an object by using `observer`:
 
 ```javascript
-Person = Ember.Object.extend({
+import EmberObject, {
+  computed,
+  observer
+} from '@ember/object';
+
+Person = EmberObject.extend({
   // these will be supplied by `create`
   firstName: null,
   lastName: null,
 
-  fullName: Ember.computed('firstName', 'lastName', function() {
+  fullName: computed('firstName', 'lastName', function() {
     return `${this.get('firstName')} ${this.get('lastName')}`;
   }),
 
-  fullNameChanged: Ember.observer('fullName', function() {
+  fullNameChanged: observer('fullName', function() {
     // deal with the change
     console.log(`fullName changed to: ${this.get('fullName')}`);
   })
@@ -46,8 +51,10 @@ as soon as one of the properties they observe changes. Because of this, it
 is easy to introduce bugs where properties are not yet synchronized:
 
 ```javascript
+import { observer } from '@ember/object';
+
 Person.reopen({
-  lastNameChanged: Ember.observer('lastName', function() {
+  lastNameChanged: observer('lastName', function() {
     // The observer depends on lastName and so does fullName. Because observers
     // are synchronous, when this function is called the value of fullName is
     // not updated yet so this will log the old value of fullName
@@ -60,8 +67,10 @@ This synchronous behavior can also lead to observers being fired multiple
 times when observing multiple properties:
 
 ```javascript
+import { observer } from '@ember/object';
+
 Person.reopen({
-  partOfNameChanged: Ember.observer('firstName', 'lastName', function() {
+  partOfNameChanged: observer('firstName', 'lastName', function() {
     // Because both firstName and lastName were set, this observer will fire twice.
   })
 });
@@ -76,9 +85,12 @@ happens in the next run loop once all bindings are synchronized:
 
 
 ```javascript
+import { observer } from '@ember/object';
+import { once } from "@ember/runloop"
+
 Person.reopen({
-  partOfNameChanged: Ember.observer('firstName', 'lastName', function() {
-    Ember.run.once(this, 'processFullName');
+  partOfNameChanged: observer('firstName', 'lastName', function() {
+    once(this, 'processFullName');
   }),
 
   processFullName() {
@@ -102,12 +114,15 @@ should also run after `init` by using [`Ember.on()`](http://emberjs.com/api/clas
 
 
 ```javascript
-Person = Ember.Object.extend({
+import EmberObject, { observer } from '@ember/object';
+import { on } from "@ember/object/evented"
+
+Person = EmberObject.extend({
   init() {
     this.set('salutation', 'Mr/Ms');
   },
 
-  salutationDidChange: Ember.on('init', Ember.observer('salutation', function() {
+  salutationDidChange: on('init', observer('salutation', function() {
     // some side effect of salutation changing
   }))
 });

--- a/source/routing/defining-your-routes.md
+++ b/source/routing/defining-your-routes.md
@@ -39,10 +39,8 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`{{link-to}}`][1] to navigate between
+Inside your templates, you can use [`{{link-to}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_link-to) to navigate between
 routes, using the name that you provided to the `route` method.
-
-[1]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_link-to
 
 ```handlebars
 {{#link-to "index"}}<img class="logo">{{/link-to}}

--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -84,9 +84,7 @@ It's important to note that `foo.bar.loading` is not considered now.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`][1] event will be fired on that route.
-
-[1]: http://emberjs.com/api/classes/Ember.Route.html#event_loading
+don't immediately resolve, a [`loading`](http://emberjs.com/api/classes/Ember.Route.html#event_loading) event will be fired on that route.
 
 ```app/routes/foo-slow-model.js
 import Route from '@ember/routing/route';
@@ -201,11 +199,9 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`][1] event will fire from that route and bubble upward.
+etc.), an [`error`](http://emberjs.com/api/classes/Ember.Route.html#event_error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
-
-[1]: http://emberjs.com/api/classes/Ember.Route.html#event_error
 
 ```app/routes/articles-overview.js
 import Route from '@ember/routing/route';

--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -16,9 +16,9 @@ Router.map(function() {
 ```
 
 ```app/routes/slow-model.js
-import Ember from 'ember';
+import Route from '@ember/routing/router';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.get('store').findAll('slow-model');
   }
@@ -89,16 +89,18 @@ don't immediately resolve, a [`loading`][1] event will be fired on that route.
 [1]: http://emberjs.com/api/classes/Ember.Route.html#event_loading
 
 ```app/routes/foo-slow-model.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.get('store').findAll('slow-model');
   },
+
   actions: {
     loading(transition, originRoute) {
       let controller = this.controllerFor('foo');
       controller.set('currentlyLoading', true);
+
       return true; // allows the loading template to be shown
     }
   }
@@ -112,10 +114,11 @@ route, providing the `application` route the opportunity to manage it.
 When using the `loading` handler, we can make use of the transition promise to know when the loading event is over:
 
 ```app/routes/foo-slow-model.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
-  ...
+export default Route.extend({
+  …
+
   actions: {
     loading(transition, originRoute) {
       let controller = this.controllerFor('foo');
@@ -185,7 +188,7 @@ are not called. Only the `setupController` method of the error substate is
 called with the `error` as the model. See example below:
 
 ```js
-setupController: function(controller, error) {
+setupController(controller, error) {
   Ember.Logger.debug(error.message);
   this._super(...arguments);
 }
@@ -205,12 +208,13 @@ redirect to a login page, etc.
 [1]: http://emberjs.com/api/classes/Ember.Route.html#event_error
 
 ```app/routes/articles-overview.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model(params) {
     return this.get('store').findAll('privileged-model');
   },
+
   actions: {
     error(error, transition) {
       if (error.status === '403') {

--- a/source/routing/preventing-and-retrying-transitions.md
+++ b/source/routing/preventing-and-retrying-transitions.md
@@ -20,9 +20,9 @@ made on the form, which can make for a pretty frustrating user experience.
 Here's one way this situation could be handled:
 
 ```app/routes/form.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   actions: {
     willTransition(transition) {
       if (this.controller.get('userHasEnteredData') &&
@@ -54,9 +54,9 @@ each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 
 ```app/routes/disco.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   beforeModel(transition) {
     if (new Date() > new Date('January 1, 1980')) {
       alert('Sorry, you need a time machine to enter this route.');
@@ -74,9 +74,9 @@ page, and then redirecting them back to the authenticated route once
 they've logged in.
 
 ```app/routes/some-authenticated.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   beforeModel(transition) {
     if (!this.controllerFor('auth').get('userIsLoggedIn')) {
       let loginController = this.controllerFor('login');
@@ -88,9 +88,9 @@ export default Ember.Route.extend({
 ```
 
 ```app/controllers/login.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   actions: {
     login() {
       // Log the user in, then reattempt previous transition if it exists.

--- a/source/routing/query-params.md
+++ b/source/routing/query-params.md
@@ -23,9 +23,9 @@ been categorized as popular we'd specify `'category'`
 as one of `controller:article`'s `queryParams`:
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: ['category'],
   category: null
 });
@@ -43,13 +43,14 @@ Now we need to define a computed property of our category-filtered
 array that the `articles` template will render:
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: ['category'],
   category: null,
 
-  filteredArticles: Ember.computed('category', 'model', function() {
+  filteredArticles: computed('category', 'model', function() {
     let category = this.get('category');
     let articles = this.get('model');
 
@@ -130,9 +131,9 @@ If you have a `category` query param and you want it to trigger a model refresh,
 you can set it as follows:
 
 ```app/routes/articles.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   queryParams: {
     category: {
       refreshModel: true
@@ -152,9 +153,9 @@ export default Ember.Route.extend({
 ```
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: ['category'],
   category: null
 });
@@ -169,9 +170,9 @@ additional item from being added to your browser's history,
 you can specify this as follows:
 
 ```app/routes/articles.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   queryParams: {
     category: {
       replace: true
@@ -190,12 +191,13 @@ bind to a query param whose key is `foo`, e.g. `?foo=123`.
 You can also map a controller property to a different query param key using the following configuration syntax:
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: {
     category: 'articles_category'
   },
+
   category: null
 });
 ```
@@ -207,12 +209,13 @@ Query params that require additional customization can
 be provided along with strings in the `queryParams` array.
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: ['page', 'filter', {
     category: 'articles_category'
   }],
+
   category: null,
   page: 1,
   filter: 'recent'
@@ -225,9 +228,9 @@ In the following example,
 the controller query param property `page` is considered to have a default value of `1`.
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: 'page',
   page: 1
 });
@@ -289,9 +292,9 @@ _while still scoped to the pre-transition `ArticlesRoute` model_.
 The result of this is that all links pointing back into the exited route will use the newly reset value `1` as the value for the `page` query param.
 
 ```app/routes/articles.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   resetController(controller, isExiting, transition) {
     if (isExiting) {
       // isExiting would be false if only the route's model was changing
@@ -308,9 +311,9 @@ even as a route's model changes. This can be accomplished by setting the
 config hash:
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: [{
     showMagnifyingGlass: {
       scope: 'controller'
@@ -322,9 +325,9 @@ export default Ember.Controller.extend({
 The following demonstrates how you can override both the scope and the query param URL key of a single controller query param property:
 
 ```app/controllers/articles.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: ['page', 'filter',
     {
       showMagnifyingGlass: {

--- a/source/routing/redirection.md
+++ b/source/routing/redirection.md
@@ -32,9 +32,9 @@ Router.map(function() {
 ```
 
 ```app/routes/index.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   beforeModel(/* transition */) {
     this.transitionTo('posts'); // Implicitly aborts the on-going transition.
   }
@@ -65,9 +65,9 @@ Router.map(function() {
 ```
 
 ```app/routes/posts.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   afterModel(model, transition) {
     if (model.get('length') === 1) {
       this.transitionTo('post', model.get('firstObject'));
@@ -102,9 +102,9 @@ Instead, we can use the [`redirect()`](http://emberjs.com/api/classes/Ember.Rout
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```app/routes/posts.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   redirect(model, transition) {
     if (model.get('length') === 1) {
       this.transitionTo('posts.post', model.get('firstObject'));

--- a/source/routing/rendering-a-template.md
+++ b/source/routing/rendering-a-template.md
@@ -19,7 +19,7 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, set the route's [`templateName`][1] property to the name of
+If you want to render a template other than the default one, set the route's [`templateName`](http://emberjs.com/api/classes/Ember.Route.html#property_templateName) property to the name of
 the template you want to render instead.
 
 ```app/routes/posts.js
@@ -30,8 +30,5 @@ export default Route.extend({
 });
 ```
 
-You can override the [`renderTemplate()`][2] hook if you want finer control over template rendering.
+You can override the [`renderTemplate()`](http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate) hook if you want finer control over template rendering.
 Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.
-
-[1]: http://emberjs.com/api/classes/Ember.Route.html#property_templateName
-[2]: http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate

--- a/source/routing/rendering-a-template.md
+++ b/source/routing/rendering-a-template.md
@@ -23,9 +23,9 @@ If you want to render a template other than the default one, set the route's [`t
 the template you want to render instead.
 
 ```app/routes/posts.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   templateName: 'posts/favorite-posts'
 });
 ```

--- a/source/routing/specifying-a-routes-model.md
+++ b/source/routing/specifying-a-routes-model.md
@@ -9,10 +9,8 @@ Router.map(function() {
 });
 ```
 
-To load a model for the `favorite-posts` route, you would use the [`model()`][1]
+To load a model for the `favorite-posts` route, you would use the [`model()`](http://emberjs.com/api/classes/Ember.Route.html#method_model)
 hook in the `favorite-posts` route handler:
-
-[1]: http://emberjs.com/api/classes/Ember.Route.html#method_model
 
 ```app/routes/favorite-posts.js
 import Route from '@ember/routing/route';

--- a/source/routing/specifying-a-routes-model.md
+++ b/source/routing/specifying-a-routes-model.md
@@ -15,9 +15,9 @@ hook in the `favorite-posts` route handler:
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_model
 
 ```app/routes/favorite-posts.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.get('store').query('post', { favorite: true });
   }
@@ -71,9 +71,9 @@ Router.map(function() {
 ```
 
 ```app/routes/photo.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model(params) {
     return this.get('store').findRecord('photo', params.photo_id);
   }
@@ -130,10 +130,10 @@ parameters that return promises, and when all parameter promises resolve, then
 the `RSVP.hash` promise resolves. For example:
 
 ```app/routes/songs.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return RSVP.hash({
       songs: this.get('store').findAll('song'),
@@ -175,9 +175,9 @@ needs.
 In this scenario, you can use the `paramsFor` method to get the parameters of a parent route.
 
 ```app/routes/album/index.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     let { album_id } = this.paramsFor('album');
 
@@ -199,9 +199,9 @@ Let's rewrite the same route, but use `modelFor`, which works the same way, but 
 from the parent route.
 
 ```app/routes/album/index.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     let { songs } = this.modelFor('album');
 
@@ -213,10 +213,10 @@ export default Ember.Route.extend({
 In the case above, the parent route looked something like this:
 
 ```app/routes/album.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model({ album_id }) {
     return RSVP.hash({
       album: this.store.findRecord('album', album_id),

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -18,9 +18,9 @@ In the component or controller, you can then define what the action does within
 the `actions` hook:
 
 ```app/components/single-post.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   actions: {
     toggleBody() {
       this.toggleProperty('isShowingBody');
@@ -48,9 +48,9 @@ The `select` action handler would be called with a single argument
 containing the post model:
 
 ```app/components/single-post.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   actions: {
     select(post) {
       console.log(post.get('title'));

--- a/source/templates/built-in-helpers.md
+++ b/source/templates/built-in-helpers.md
@@ -10,12 +10,10 @@ passing data to another helper or component.
 
 ### Using a helper to get a property dynamically
 
-The [`{{get}}`][1] helper makes it easy to dynamically send the value of a
+The [`{{get}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_get) helper makes it easy to dynamically send the value of a
 variable to another helper or component.
 This can be useful if you want
 to output one of several values based on the result of a computed property.
-
-[1]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_get
 
 ```handlebars
 {{get address part}}
@@ -28,11 +26,9 @@ if the `part` computed property returns "zip", this will display the result of
 
 In the last section it was discussed that helpers can be nested.
 This can be combined with these sorts of dynamic helpers.
-For example, the [`{{concat}}`][2] helper makes it easy to dynamically send
+For example, the [`{{concat}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_concat) helper makes it easy to dynamically send
 a number of parameters to a component or helper as a single parameter in the
 format of a concatenated string.
-
-[2]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_concat
 
 ```handlebars
 {{get "foo" (concat "item" index)}}

--- a/source/templates/development-helpers.md
+++ b/source/templates/development-helpers.md
@@ -6,11 +6,9 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`][1] helper makes it easy to output variables or expressions in
+The [`{{log}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
-
-[1]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_log
 
 ```handlebars
 {{log 'Name is:' name}}
@@ -20,11 +18,10 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``][2] helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 
-[2]: http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_debugger
 
 ```handlebars
 {{debugger}}

--- a/source/templates/displaying-the-keys-in-an-object.md
+++ b/source/templates/displaying-the-keys-in-an-object.md
@@ -2,9 +2,9 @@ If you need to display all of the keys or values of a JavaScript object in your 
 you can use the [`{{#each-in}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_each-in) helper:
 
 ```/app/components/store-categories.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   willRender() {
     // Set the "categories" property to a JavaScript object
     // with the category name as the key and the value a list

--- a/source/templates/handlebars-basics.md
+++ b/source/templates/handlebars-basics.md
@@ -23,9 +23,9 @@ must be added to the application controller. If you are following along with
 an Ember CLI application, you may need to create this file:
 
 ```app/controllers/application.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   firstName: 'Trek',
   lastName: 'Glowacki'
 });
@@ -51,7 +51,7 @@ Ember gives you the ability to [write your own helpers](../writing-helpers/), to
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 
 ```app/helpers/sum.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper"
 
 export function sum(params) {
   return params.reduce((a, b) => {
@@ -59,7 +59,7 @@ export function sum(params) {
   });
 };
 
-export default Ember.Helper.helper(sum);
+export default helper(sum);
 ```
 
 The above code will allow you invoke the `sum()` function as a `{{sum}}` handlebars "helper" in your templates:

--- a/source/templates/writing-helpers.md
+++ b/source/templates/writing-helpers.md
@@ -42,7 +42,7 @@ That file should export a function wrapped with [`Ember.Helper.helper()`][1]:
 [1]: http://emberjs.com/api/classes/Ember.Helper.html#method_helper
 
 ```app/helpers/format-currency.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper"
 
 export function formatCurrency([value, ...rest]) {
   let dollars = Math.floor(value / 100);
@@ -53,7 +53,7 @@ export function formatCurrency([value, ...rest]) {
   return `${sign}${dollars}.${cents}`;
 }
 
-export default Ember.Helper.helper(formatCurrency);
+export default helper(formatCurrency);
 ```
 
 In this example, the function receives a dollar amount in cents as the first
@@ -99,26 +99,30 @@ list after the helper name:
 An array of these arguments is passed to the helper function:
 
 ```app/helpers/my-helper.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper"
 
-export default Ember.Helper.helper(function(params) {
+export function myHelper(params) {
   let [arg1, arg2] = params;
 
   console.log(arg1); // => "hello"
   console.log(arg2); // => "world"
 });
+
+export default helper(myHelper);
 ```
 
 You can use JavaScript's destructuring assignment shorthand to clean up
 the code. This example is equivalent to the above example (note the function signature):
 
 ```app/helpers/my-helper.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper"
 
-export default Ember.Helper.helper(function([arg1, arg2]) {
+export function myHelper([arg1, arg2]) {
   console.log(arg1); // => "hello"
   console.log(arg2); // => "world"
 });
+
+export default helper(myHelper);
 ```
 
 ### Named Arguments
@@ -157,9 +161,9 @@ to the helper function.  Here is our example from above, updated to
 support the optional `sign` option:
 
 ```app/helpers/format-currency.js
-import Ember from 'ember';
+export default helper(myHelper)
 
-export default Ember.Helper.helper(function([value, ...rest], namedArgs) {
+export function formatCurrency([value, ...rest], namedArgs) {
   let dollars = Math.floor(value / 100);
   let cents = value % 100;
   let sign = namedArgs.sign === undefined ? '$' : namedArgs.sign;
@@ -167,6 +171,8 @@ export default Ember.Helper.helper(function([value, ...rest], namedArgs) {
   if (cents.toString().length === 1) { cents = '0' + cents; }
   return `${sign}${dollars}.${cents}`;
 });
+
+export default helper(formatCurrency);
 ```
 
 You can pass as many named arguments as you'd like. They get added to the
@@ -177,26 +183,30 @@ You can pass as many named arguments as you'd like. They get added to the
 ```
 
 ```app/helpers/my-helper.js
-import Ember from 'ember';
+export default helper(myHelper)
 
-export default Ember.Helper.helper(function(params, namedArgs) {
+export function myHelper(params, namedArgs) {
   console.log(namedArgs.option1); // => "hello"
   console.log(namedArgs.option2); // => "world"
   console.log(namedArgs.option3); // => "goodbye cruel world"
 });
+
+export default helper(myHelper)
 ```
 
 You can use JavaScript's destructuring assignment shorthand in this case
 as well to clean up the above code:
 
 ```app/helpers/my-helper.js
-import Ember from 'ember';
+export default helper(myHelper)
 
-export default Ember.Helper.helper(function(params, { option1, option2, option3 }) {
+export function myHelper(params, { option1, option2, option3 }) {
   console.log(option1); // => "hello"
   console.log(option2); // => "world"
   console.log(option3); // => "goodbye cruel world"
 });
+
+export default helper(myHelper);
 ```
 
 In sum, arguments are good for passing values:
@@ -251,9 +261,9 @@ As an exercise, here is the above `format-currency` helper re-factored
 into a class-based helper:
 
 ```app/helpers/format-currency.js
-import Ember from 'ember';
+import Helper from "@ember/component/helper";
 
-export default Ember.Helper.extend({
+export default Helper.extend({
   compute([value, ...rest], hash) {
     let dollars = Math.floor(value / 100);
     let cents = value % 100;
@@ -273,10 +283,12 @@ As another example, let's make a helper utilizing an authentication
 service that welcomes users by their name if they're logged in:
 
 ```app/helpers/is-authenticated.js
-import Ember from 'ember';
+import Helper from "@ember/component/helper";
+import { inject as service } from "@ember/service";
 
-export default Ember.Helper.extend({
-  authentication: Ember.inject.service(),
+export default Helper.extend({
+  authentication: service(),
+
   compute() {
     let authentication = this.get('authentication');
 
@@ -298,11 +310,13 @@ the browser will not interpret it as HTML.
 For example, here's a `make-bold` helper that returns a string containing HTML:
 
 ```app/helpers/make-bold.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper";
 
-export default Ember.Helper.helper(function([param, ...rest]) {
+export function makeBold([param, ...rest]) {
   return `<b>${param}</b>`;
 });
+
+export default helper(makeBold);
 ```
 
 You can invoke it like this:
@@ -323,11 +337,13 @@ escape the return value (that is, that it is _safe_) by using the
 [`htmlSafe`][4] string utility:
 
 ```app/helpers/make-bold.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper";
 
-export default Ember.Helper.helper(function([param, ...rest]) {
+export function makeBold([param, ...rest]) {
   return Ember.String.htmlSafe(`<b>${param}</b>`);
 });
+
+export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
@@ -358,12 +374,16 @@ escape anything that may have come from an untrusted user with the
 `escapeExpression` utility:
 
 ```app/helpers/make-bold.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper";
+import Handlebars from "handlebars";
+import { htmlSafe } from "@ember/component";
 
-export default Ember.Helper.helper(function([param, ...rest]) {
-  let value = Ember.Handlebars.Utils.escapeExpression(param);
-  return Ember.String.htmlSafe(`<b>${value}</b>`);
+export function makeBold([param, ...rest]) {
+  let value = Handlebars.Utils.escapeExpression(param);
+  return htmlSafe(`<b>${value}</b>`);
 });
+
+export default helper(makeBold);
 ```
 
 Now the value passed into the helper has its HTML escaped, but the trusted

--- a/source/templates/writing-helpers.md
+++ b/source/templates/writing-helpers.md
@@ -37,9 +37,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`][1]:
-
-[1]: http://emberjs.com/api/classes/Ember.Helper.html#method_helper
+That file should export a function wrapped with [`Ember.Helper.helper()`](http://emberjs.com/api/classes/Ember.Helper.html#method_helper):
 
 ```app/helpers/format-currency.js
 import { helper } from "@ember/component/helper"

--- a/source/testing/acceptance.md
+++ b/source/testing/acceptance.md
@@ -9,7 +9,7 @@ This generates this file:
 
 ```tests/acceptance/login-test.js
 import { test } from 'qunit';
-import moduleForAcceptance from 'people/tests/helpers/module-for-acceptance';
+import moduleForAcceptance from 'my-app/tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | login');
 
@@ -31,6 +31,11 @@ Almost every test has a pattern of visiting a route, interacting with the page
 For example:
 
 ```tests/acceptance/new-post-appears-first-test.js
+import { test } from 'qunit';
+import moduleForAcceptance from 'my-app/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | posts');
+
 test('should add new post', function(assert) {
   visit('/posts/new');
   fillIn('input.title', 'My new post');
@@ -114,6 +119,11 @@ complete prior to progressing forward. Let's take a look at the following
 example.
 
 ```tests/acceptance/new-post-appears-first-test.js
+import { test } from 'qunit';
+import moduleForAcceptance from 'my-app/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | posts');
+
 test('should add new post', function(assert) {
   visit('/posts/new');
   fillIn('input.title', 'My new post');

--- a/source/testing/acceptance.md
+++ b/source/testing/acceptance.md
@@ -154,9 +154,9 @@ For creating your own test helper, run `ember generate test-helper
 shouldHaveElementWithCount`:
 
 ```tests/helpers/should-have-element-with-count.js
-import Ember from 'ember';
+import { registerAsyncHelper } from "@ember/test"
 
-export default Ember.Test.registerAsyncHelper(
+export default registerAsyncHelper(
     'shouldHaveElementWithCount', function(app) {
 });
 ```
@@ -178,9 +178,9 @@ first parameter. Other parameters, such as assert, need to be provided when call
 Here is an example of a non-async helper:
 
 ```tests/helpers/should-have-element-with-count.js
-import Ember from 'ember';
+import { registerHelper } from "@ember/test"
 
-export default Ember.Test.registerHelper('shouldHaveElementWithCount',
+export default registerHelper('shouldHaveElementWithCount',
   function(app, assert, selector, n, context) {
     const el = findWithAssert(selector, context);
     const count = el.length;
@@ -194,9 +194,9 @@ export default Ember.Test.registerHelper('shouldHaveElementWithCount',
 Here is an example of an async helper:
 
 ```tests/helpers/dblclick.js
-import Ember from 'ember';
+import { registerAsyncHelper } from "@ember/test"
 
-export default Ember.Test.registerAsyncHelper('dblclick',
+export default registerAsyncHelper('dblclick',
   function(app, assert, selector, context) {
     let $el = findWithAssert(selector, context);
     Ember.run(() => $el.dblclick());
@@ -210,9 +210,9 @@ Async helpers also come in handy when you want to group interaction
 into one helper. For example:
 
 ```tests/helpers/add-contact.js
-import Ember from 'ember';
+import { registerAsyncHelper } from "@ember/test"
 
-export default Ember.Test.registerAsyncHelper('addContact',
+export default registerAsyncHelper('addContact',
   function(app, name) {
     fillIn('#name', name);
     click('button.create');

--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -30,6 +30,8 @@ and its template (if available).  Make sure to set `integration: true` to enable
 integration test capability.
 
 ```tests/integration/components/pretty-color-test.js
+import { moduleForComponent, test } from 'ember-qunit';
+
 moduleForComponent('pretty-color', 'Integration | Component | pretty color', {
   integration: true
 });
@@ -43,7 +45,12 @@ We can test that changing the component's `name` property updates the
 component's `style` attribute and is reflected in the  rendered HTML:
 
 ```tests/integration/components/pretty-color-test.js
+import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('pretty-color', 'Integration | Component | pretty color', {
+  integration: true
+});
 
 test('should change colors', function(assert) {
   assert.expect(2);
@@ -65,6 +72,13 @@ We might also test this component to ensure that the content of its template is
 being rendered properly:
 
 ```tests/integration/components/pretty-color-test.js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('pretty-color', 'Integration | Component | pretty color', {
+  integration: true
+});
+
 test('should be rendered with its color name', function(assert) {
   assert.expect(2);
 
@@ -119,6 +133,14 @@ We recommend using native DOM events wrapped inside the run loop or the [`ember-
 Using jQuery to simulate user click events might lead to unexpected test results as the action can potentially be called twice.
 
 ```tests/integration/components/magic-title-test.js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
+
+moduleForComponent('magic-title', 'Integration | Component | magic title', {
+  integration: true
+});
+
 test('should update title on button click', function(assert) {
   assert.expect(2);
 
@@ -172,6 +194,14 @@ is invoked when the component's internal `submitComment` action is triggered by 
 of a test double (dummy function):
 
 ```tests/integration/components/comment-form-test.js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
+
+moduleForComponent('comment-form', 'Integration | Component | comment form', {
+  integration: true
+});
+
 test('should trigger external action on form submit', function(assert) {
 
   // test double for the external action
@@ -266,7 +296,39 @@ moduleForComponent('location-indicator', 'Integration | Component | location ind
 Once the stub service is registered the test simply needs to check that the stub data that
 is being returned from the service is reflected in the component output.
 
-```tests/integration/components/location-indicator-test.js
+```tests/integration/components/location-indicator-test.js{+33,+34,+35,+36}
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+//Stub location service
+const locationStub = Service.extend({
+  city: 'New York',
+  country: 'USA',
+  currentLocation: {
+    x: 1234,
+    y: 5678
+  },
+
+  getCurrentCity() {
+    return this.get('city');
+  },
+  getCurrentCountry() {
+    return this.get('country');
+  }
+});
+
+moduleForComponent('location-indicator', 'Integration | Component | location indicator', {
+  integration: true,
+
+  beforeEach: function () {
+    this.register('service:location-service', locationStub);
+    // Calling inject puts the service instance in the context of the test,
+    // making it accessible as "locationService" within each test
+    this.inject.service('location-service', { as: 'locationService' });
+  }
+});
+
 test('should reveal current location', function(assert) {
   this.render(hbs`{{location-indicator}}`);
   assert.equal(this.$().text().trim(), 'You currently are located in New York, USA');
@@ -276,7 +338,44 @@ test('should reveal current location', function(assert) {
 In the next example, we'll add another test that validates that the display changes
 when we modify the values on the service.
 
-```tests/integration/components/location-indicator-test.js
+```tests/integration/components/location-indicator-test.js{+38,+39,+40,+41,+42,+43,+44,+45}
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+//Stub location service
+const locationStub = Service.extend({
+  city: 'New York',
+  country: 'USA',
+  currentLocation: {
+    x: 1234,
+    y: 5678
+  },
+
+  getCurrentCity() {
+    return this.get('city');
+  },
+  getCurrentCountry() {
+    return this.get('country');
+  }
+});
+
+moduleForComponent('location-indicator', 'Integration | Component | location indicator', {
+  integration: true,
+
+  beforeEach: function () {
+    this.register('service:location-service', locationStub);
+    // Calling inject puts the service instance in the context of the test,
+    // making it accessible as "locationService" within each test
+    this.inject.service('location-service', { as: 'locationService' });
+  }
+});
+
+test('should reveal current location', function(assert) {
+  this.render(hbs`{{location-indicator}}`);
+  assert.equal(this.$().text().trim(), 'You currently are located in New York, USA');
+});
+
 test('should change displayed location when current location changes', function (assert) {
   this.render(hbs`{{location-indicator}}`);
   assert.equal(this.$().text().trim(), 'You currently are located in New York, USA', 'origin location should display');

--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -8,12 +8,13 @@ component is bound to its `style` property.
 > component pretty-color`.
 
 ```app/components/pretty-color.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
-export default Ember.Component.extend({
+export default Component.extend({
   attributeBindings: ['style'],
 
-  style: Ember.computed('name', function() {
+  style: computed('name', function() {
     const name = this.get('name');
     return `color: ${name}`;
   })
@@ -93,9 +94,9 @@ clicked on:
 > component magic-title`.
 
 ```app/components/magic-title.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   title: 'Hello World',
 
   actions: {
@@ -144,9 +145,9 @@ For example, imagine you have a comment form component that invokes a
 > component comment-form`.
 
 ```app/components/comment-form.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   comment: '',
 
   actions: {
@@ -202,17 +203,19 @@ and country of your current location:
 > component location-indicator`.
 
 ```app/components/location-indicator.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  locationService: Ember.inject.service('location-service'),
+export default Component.extend({
+  locationService: service('location-service'),
 
   // when the coordinates change, call the location service to get the current city and country
-  city: Ember.computed('locationService.currentLocation', function () {
+  city: computed('locationService.currentLocation', function () {
     return this.get('locationService').getCurrentCity();
   }),
 
-  country: Ember.computed('locationService.currentLocation', function () {
+  country: computed('locationService.currentLocation', function () {
     return this.get('locationService').getCurrentCountry();
   })
 });
@@ -229,10 +232,10 @@ beforeEach function.  In this case we initially force location to New York.
 ```tests/integration/components/location-indicator-test.js
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import Service from '@ember/service';
 
 //Stub location service
-const locationStub = Ember.Service.extend({
+const locationStub = Service.extend({
   city: 'New York',
   country: 'USA',
   currentLocation: {
@@ -296,9 +299,10 @@ to limit requests to the server, and you want to verify that results are display
 > component delayed-typeahead`.
 
 ```app/components/delayed-typeahead.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { debounce } from "@ember/runloop";
 
-export default Ember.Component.extend({
+export default Component.extend({
   actions: {
     handleTyping() {
       //the fetchResults function is passed into the component from its parent

--- a/source/testing/testing-controllers.md
+++ b/source/testing/testing-controllers.md
@@ -37,8 +37,9 @@ In our generated test, ember-cli already uses the `moduleFor` helper to set up a
 container:
 
 ```tests/unit/controllers/posts-test.js
-moduleFor('controller:posts', {
-});
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:posts', {});
 ```
 
 Next we use `this.subject()` to get an instance of the `PostsController` and
@@ -47,6 +48,10 @@ write a test to check the action. `this.subject()` is a helper method from the
 using `moduleFor`.
 
 ```tests/unit/controllers/posts-test.js
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:posts', {});
+
 test('should update A and B on setProps action', function(assert) {
   assert.expect(4);
 
@@ -87,9 +92,7 @@ export default Controller.extend({
 ```
 
 ```app/controllers/comments.js
-import Controller, {
-  inject as controller
-} from '@ember/controller';
+import Controller, { inject as controller } from '@ember/controller';
 import { alias } from "@ember/object/computed";
 
 export default Controller.extend({
@@ -102,6 +105,10 @@ This time when we setup our `moduleFor` we need to pass an options object as
 our third argument that has the controller's `needs`.
 
 ```tests/unit/controllers/comments-test.js
+import { moduleFor, test } from 'ember-qunit';
+import EmberObject from "@ember/object";
+import { run } from '@ember/runloop';
+
 moduleFor('controller:comments', 'Comments Controller', {
   needs: ['controller:post']
 });
@@ -111,6 +118,14 @@ Now let's write a test that sets a property on our `post` model in the
 `PostController` that would be available on the `CommentsController`.
 
 ```tests/unit/controllers/comments-test.js
+import { moduleFor, test } from 'ember-qunit';
+import EmberObject from "@ember/object";
+import { run } from '@ember/runloop';
+
+moduleFor('controller:comments', 'Comments Controller', {
+  needs: ['controller:post']
+});
+
 test('should modify the post model', function(assert) {
   assert.expect(2);
 

--- a/source/testing/testing-controllers.md
+++ b/source/testing/testing-controllers.md
@@ -13,9 +13,9 @@ sets one of those properties, and an action named `setProps`.
 > controller posts`.
 
 ```app/controllers/posts.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   propA: 'You need to write tests',
   propB: 'And write one for me too',
 
@@ -78,19 +78,23 @@ accomplished by injecting one controller into another. For example, here are two
 > controller post`, and `ember generate controller comments`.
 
 ```app/controllers/post.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
+import { alias } from "@ember/object/computed";
 
-export default Ember.Controller.extend({
-  title: Ember.computed.alias('model.title')
+export default Controller.extend({
+  title: alias('model.title')
 });
 ```
 
 ```app/controllers/comments.js
-import Ember from 'ember';
+import Controller, {
+  inject as controller
+} from '@ember/controller';
+import { alias } from "@ember/object/computed";
 
-export default Ember.Controller.extend({
-  post: Ember.inject.controller(),
-  title: Ember.computed.alias('post.title')
+export default Controller.extend({
+  post: controller(),
+  title: alias('post.title')
 });
 ```
 

--- a/source/testing/testing-helpers.md
+++ b/source/testing/testing-helpers.md
@@ -54,7 +54,7 @@ with the `moduleForComponent` helpers, as shown in [Testing Components].
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('format-currency', 'Integration | Component | pretty color', {
+moduleForComponent('format-currency', 'Integration | Helper | format currency', {
   integration: true
 });
 
@@ -71,6 +71,13 @@ test('formats 199 with $ as currency sign', function(assert) {
 We can now also properly test if a helper will respond to property changes.
 
 ```tests/integration/helpers/format-currency-test.js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('format-currency', 'Integration | Helper | format currency', {
+  integration: true
+});
+
 test('updates the currency sign when it changes', function(assert) {
   this.set('value', 199);
   this.set('sign', '$');

--- a/source/testing/testing-helpers.md
+++ b/source/testing/testing-helpers.md
@@ -12,7 +12,7 @@ helper from [Writing Helpers].
 > format-currency`.
 
 ```app/helpers/format-currency.js
-import Ember from 'ember';
+import { helper } from "@ember/component/helper";
 
 export function formatCurrency([value, ...rest], namedArgs) {
   let dollars = Math.floor(value / 100);
@@ -23,7 +23,7 @@ export function formatCurrency([value, ...rest], namedArgs) {
   return `${sign}${dollars}.${cents}`;
 }
 
-export default Ember.Helper.helper(formatCurrency);
+export default helper(formatCurrency);
 ```
 
 Let's start by testing the helper by showing a simple unit test and then move on

--- a/source/testing/testing-models.md
+++ b/source/testing/testing-models.md
@@ -11,11 +11,12 @@ new `levelName` when the player reaches level 5.
 > model player`.
 
 ```app/models/player.js
-import DS from 'ember-data';
+import Model from 'ember-data/model';
+import { attr } from 'ember-data/model';
 
-export default DS.Model.extend({
-  level:     DS.attr('number', { defaultValue: 0 }),
-  levelName: DS.attr('string', { defaultValue: 'Noob' }),
+export default Model.extend({
+  level: attr('number', { defaultValue: 0 }),
+  levelName: attr('string', { defaultValue: 'Noob' }),
 
   levelUp() {
     let newLevel = this.incrementProperty('level');
@@ -31,7 +32,7 @@ level 4 to assert that the `levelName` changes. We will use `moduleForModel`:
 
 ```tests/unit/models/player-test.js
 import { moduleForModel, test } from 'ember-qunit';
-import Ember from 'ember';
+import { run } from "@ember/runloop";
 
 moduleForModel('player', 'Unit | Model | player', {
   // Specify the other units that are required for this test.
@@ -43,7 +44,7 @@ test('should increment level when told to', function(assert) {
   const player = this.subject({ level: 4 });
 
   // wrap asynchronous call in run loop
-  Ember.run(() => player.levelUp());
+  run(() => player.levelUp());
 
   assert.equal(player.get('level'), 5, 'level gets incremented');
   assert.equal(player.get('levelName'), 'Professional', 'new level is called professional');
@@ -61,17 +62,18 @@ Assume that a `User` can own a `Profile`.
 > generate model user` and `ember generate model profile`.
 
 ```app/models/profile.js
-import DS from 'ember-data';
+import Model from 'ember-data/model';
 
-export default DS.Model.extend({
+export default Model.extend({
 });
 ```
 
 ```app/models/user.js
-import DS from 'ember-data';
+import Model from 'ember-data/model';
+import { belongsTo } from 'ember-data/model';
 
-export default DS.Model.extend({
-  profile: DS.belongsTo('profile')
+export default Model.extend({
+  profile: belongsTo('profile')
 });
 ```
 
@@ -80,7 +82,7 @@ with this test.
 
 ```tests/unit/models/user-test.js
 import { moduleForModel, test } from 'ember-qunit';
-import Ember from 'ember';
+import { get } from "@ember/object"
 
 moduleForModel('user', 'Unit | Model | user', {
   // Specify the other units that are required for this test.
@@ -89,7 +91,7 @@ moduleForModel('user', 'Unit | Model | user', {
 
 test('should own a profile', function(assert) {
   const User = this.store().modelFor('user');
-  const relationship = Ember.get(User, 'relationshipsByName').get('profile');
+  const relationship = get(User, 'relationshipsByName').get('profile');
 
   assert.equal(relationship.key, 'profile', 'has relationship with profile');
   assert.equal(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');

--- a/source/testing/testing-routes.md
+++ b/source/testing/testing-routes.md
@@ -19,9 +19,9 @@ sub-routes and controllers.
 > we will answer 'n'.
 
 ```app/routes/application.js
-import Ember from 'ember';
+import Route from '@ember/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   actions: {
     displayAlert(text) {
       this._displayAlert(text);

--- a/source/testing/unit-testing-basics.md
+++ b/source/testing/unit-testing-basics.md
@@ -76,6 +76,12 @@ call the `testMethod` method and assert that the internal state is correct as a
 result of the method call.
 
 ```tests/unit/models/some-thing-test.js
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('model:some-thing', 'Unit | some thing', {
+  unit: true
+});
+
 test('should update foo on testMethod', function(assert) {
   const someThing = this.subject();
   someThing.testMethod();
@@ -105,6 +111,12 @@ export default EmberObject.extend({
 The test would call the `calc` method and assert it gets back the correct value.
 
 ```tests/unit/models/some-thing-test.js
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('model:some-thing', 'Unit | some thing', {
+  unit: true
+});
+
 test('should return incremented count on calc', function(assert) {
   const someThing = this.subject();
   assert.equal(someThing.calc(), 'count: 1');
@@ -134,6 +146,12 @@ In order to test the `doSomething` method we create an instance of `SomeThing`,
 update the observed property (`foo`), and assert that the expected effects are present.
 
 ```tests/unit/models/some-thing-test.js
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('model:some-thing', 'Unit | some thing', {
+  unit: true
+});
+
 test('should set other prop to yes when foo changes', function(assert) {
   const someThing = this.subject();
   someThing.set('foo', 'baz');

--- a/source/testing/unit-testing-basics.md
+++ b/source/testing/unit-testing-basics.md
@@ -17,13 +17,14 @@ Let's start by creating an object that has a `computedFoo` computed property
 based on a `foo` property.
 
 ```app/models/some-thing.js
-import Ember from 'ember';
+import EmberObject, { computed } from '@ember/object';
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
   foo: 'bar',
 
-  computedFoo: Ember.computed('foo', function() {
+  computedFoo: computed('foo', function() {
     const foo = this.get('foo');
+
     return `computed ${foo}`;
   })
 });
@@ -43,6 +44,7 @@ moduleFor('model:some-thing', 'Unit | some thing', {
 test('should correctly concat foo', function(assert) {
   const someThing = this.subject();
   someThing.set('foo', 'baz');
+
   assert.equal(someThing.get('computedFoo'), 'computed baz');
 });
 ```
@@ -60,10 +62,11 @@ the `testMethod` method alters some internal state of the object (by updating
 the `foo` property).
 
 ```app/models/some-thing.js
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
   foo: 'bar',
+
   testMethod() {
     this.set('foo', 'baz');
   }
@@ -87,13 +90,15 @@ return value is calculated correctly. Suppose our object has a `calc` method
 that returns a value based on some internal state.
 
 ```app/models/some-thing.js
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
   count: 0,
+
   calc() {
     this.incrementProperty('count');
     let count = this.get('count');
+
     return `count: ${count}`;
   }
 });
@@ -114,12 +119,14 @@ test('should return incremented count on calc', function(assert) {
 Suppose we have an object that has a property and a method observing that property.
 
 ```app/models/some-thing.js
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { observer } from "@ember/object";
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
   foo: 'bar',
   other: 'no',
-  doSomething: Ember.observer('foo', function() {
+
+  doSomething: observer('foo', function() {
     this.set('other', 'yes');
   })
 });

--- a/source/testing/unit-testing-basics.md
+++ b/source/testing/unit-testing-basics.md
@@ -3,13 +3,11 @@ is doing what was intended. Unlike acceptance tests, they are narrow in scope
 and do not require the Ember application to be running.
 
 As it is the basic object type in Ember, being able to test a simple
-[`Ember.Object`][1] sets the foundation for testing more specific parts of your
-Ember application such as controllers, components, etc. Testing an `Ember.Object`
+[`EmberObject`](http://emberjs.com/api/classes/Ember.Object.html) sets the foundation for testing more specific parts of your
+Ember application such as controllers, components, etc. Testing an `EmberObject`
 is as simple as creating an instance of the object, setting its state, and
 running assertions against the object. By way of example, let's look at a few
 common cases.
-
-[1]: http://emberjs.com/api/classes/Ember.Object.html
 
 ### Testing Computed Properties
 

--- a/source/tutorial/autocomplete-component.md
+++ b/source/tutorial/autocomplete-component.md
@@ -74,9 +74,9 @@ The `key-up` property will be bound to the `handleFilterEntry` action.
 Here is what the component's JavaScript looks like:
 
 ```app/components/list-filter.js
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['list-filter'],
   value: '',
 
@@ -124,9 +124,9 @@ ember g controller rentals
 Now, define your new controller like so:
 
 ```app/controllers/rentals.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   actions: {
     filterByCity(param) {
       if (param !== '') {

--- a/source/tutorial/ember-cli.md
+++ b/source/tutorial/ember-cli.md
@@ -81,10 +81,10 @@ If you take a look at `app/router.js`, you'll notice some syntax that may be
 unfamiliar to you.
 
 ```app/router.js
-import Ember from 'ember';
+import Router from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = Router.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });
@@ -97,7 +97,7 @@ export default Router;
 
 Ember CLI uses ECMAScript 2015 (ES2015 for short or previously known as ES6) modules to organize application
 code.
-For example, the line `import Ember from 'ember';` gives us access to the actual
+For example, the line `import Router from '@ember/routing/router';` gives us access to the actual
 Ember.js library as the variable `Ember`. And the `import config from
 './config/environment';` line gives us access to our app's configuration data
 as the variable `config`. `const` is a way to declare a read-only variable to make

--- a/source/tutorial/ember-data.md
+++ b/source/tutorial/ember-data.md
@@ -61,9 +61,9 @@ It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) function on the store and provide it with the name of your newly created rental model class.
 
 ```app/routes/rentals.js{+5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33}
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.get('store').findAll('rental');
     return [{

--- a/source/tutorial/hbs-helper.md
+++ b/source/tutorial/hbs-helper.md
@@ -21,13 +21,13 @@ installing helper-test
 Our new helper starts out with some boilerplate code from the generator:
 
 ```app/helpers/rental-property-type.js
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 export function rentalPropertyType(params/*, hash*/) {
   return params;
 }
 
-export default Ember.Helper.helper(rentalPropertyType);
+export default helper(rentalPropertyType);
 ```
 
 Let's update our `rental-listing` component template to use our new helper and pass in `rental.propertyType`:
@@ -62,7 +62,7 @@ Let's update our helper to look if a property exists in an array of `communityPr
 if so, we'll return either `'Community'` or `'Standalone'`:
 
 ```app/helpers/rental-property-type.js{-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+17,+18,+19}
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 export function rentalPropertyType(params/*, hash*/) {
   return params;
@@ -82,7 +82,7 @@ export function rentalPropertyType([propertyType]) {
   return 'Standalone';
 }
 
-export default Ember.Helper.helper(rentalPropertyType);
+export default helper(rentalPropertyType);
 ```
 
 Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.

--- a/source/tutorial/installing-addons.md
+++ b/source/tutorial/installing-addons.md
@@ -133,9 +133,7 @@ For now, let's generate an adapter for our application:
 ember generate adapter application
 ```
 
-This adapter will extend the [`JSONAPIAdapter`][1] base class from Ember Data:
-
-[1]: http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html
+This adapter will extend the [`JSONAPIAdapter`](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html) base class from Ember Data:
 
 ```app/adapters/application.js{+4}
 import DS from 'ember-data';
@@ -143,7 +141,6 @@ import DS from 'ember-data';
 export default DS.JSONAPIAdapter.extend({
   namespace: 'api'
 });
-
 ```
 
 If you were running `ember serve` in another shell, restart the server to include Mirage in your build.

--- a/source/tutorial/model-hook.md
+++ b/source/tutorial/model-hook.md
@@ -17,10 +17,10 @@ The model function we've added to our `rentals` route handler will be called whe
 
 Let's open `app/routes/rentals.js` and return an array of rental objects from the `model` function:
 
-```app/routes/rentals.js{+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29,+30,+31,+32,+33,+34,+35}
-import Ember from 'ember';
+```app/routes/rentals.js{-3,-4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29,+30,+31,+32,+33,+34,+35,+36,+37,+38}
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return [{
       id: 'grand-old-mansion',

--- a/source/tutorial/routes-and-templates.md
+++ b/source/tutorial/routes-and-templates.md
@@ -46,10 +46,10 @@ If we open `/app/router.js`, we'll see a new line of code for the **about** rout
 to run our `/app/routes/about.js` file when a visitor navigates to `/about`.
 
 ```app/router.js{+10}
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });
@@ -233,9 +233,9 @@ Since we want our `rentals` route to serve as our home page, we will use the `re
 In our index route handler, we add the `replaceWith` invocation to `beforeModel`.
 
 ```app/routes/index.js{+4,+5,+6}
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   beforeModel() {
     this.replaceWith('rentals');
   }
@@ -364,4 +364,3 @@ In the screen recording below, we run the tests, deselect "Hide passed tests", a
 revealing the 3 tests we got passing.
 
 ![passing navigation tests](../../images/routes-and-templates/ember-route-tests.gif)
-

--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -54,11 +54,11 @@ which makes use of `google.maps.Map` to create our map element,
 and `google.maps.Marker` to pin our map based on the resolved location.
 
 ```app/utils/google-maps.js
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 
 const google = window.google;
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
 
   init() {
     this.set('geocoder', new google.maps.Geocoder());
@@ -113,14 +113,16 @@ Note that we check if a map already exists for the given location and use that o
 otherwise we call a Google Maps utility to create one.
 
 ```app/services/maps.js
-import Ember from 'ember';
+import Service from '@ember/service';
+import EmberObject from '@ember/object';
+
 import MapUtil from '../utils/google-maps';
 
-export default Ember.Service.extend({
+export default Service.extend({
 
   init() {
     if (!this.get('cachedMaps')) {
-      this.set('cachedMaps', Ember.Object.create());
+      this.set('cachedMaps', EmberObject.create());
     }
     if (!this.get('mapUtil')) {
       this.set('mapUtil', MapUtil.create());
@@ -171,7 +173,7 @@ Next, update the component to append the map output to the `div` element we crea
 
 We provide the maps service into our component by initializing a property of our component, called `maps`.
 Services are commonly made available in components and other Ember objects by ["service injection"](../../applications/services/#toc_accessing-services).
-When you initialize a property with `Ember.inject.service()`,
+When you initialize a property with `import { inject } from '@ember/service';`,
 Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
@@ -180,10 +182,11 @@ which is a [component lifecycle hook](../../components/the-component-lifecycle/#
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```app/components/location-map.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  maps: Ember.inject.service(),
+export default Component.extend({
+  maps: service(),
 
   didInsertElement() {
     this._super(...arguments);
@@ -244,11 +247,11 @@ In our case we are passing in our fake map utility object in the first test, and
 
 ```tests/unit/services/maps-test.js
 import { moduleFor, test } from 'ember-qunit';
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 
 const DUMMY_ELEMENT = {};
 
-let MapUtilStub = Ember.Object.extend({
+let MapUtilStub = EmberObject.extend({
   createMap(element, location) {
     this.assert.ok(element, 'createMap called with element');
     this.assert.ok(location, 'createMap called with location');
@@ -269,7 +272,7 @@ test('should create a new map if one isnt cached for location', function (assert
 
 test('should use existing map if one is cached for location', function (assert) {
   assert.expect(1);
-  let stubCachedMaps = Ember.Object.create({
+  let stubCachedMaps = EmberObject.create({
     sanFrancisco: DUMMY_ELEMENT
   });
   let mapService = this.subject({ cachedMaps: stubCachedMaps });
@@ -302,9 +305,9 @@ In the stub service, define a method that will fetch the map based on location, 
 ```tests/integration/components/location-map-test.js
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import Service from '@ember/service';
 
-let StubMapsService = Ember.Service.extend({
+let StubMapsService = Service.extend({
   getMapElement(location) {
     this.set('calledWithLocation', location);
     // We create a div here to simulate our maps service,
@@ -351,9 +354,9 @@ Add the following code after the imports to our acceptance test:
 ```/tests/acceptance/list-rentals-test.js{+3,+5,+6,+7,+8,+9,+10,-11,+12,+13,+14,+15,+16,+17}
 import { test } from 'qunit';
 import moduleForAcceptance from 'super-rentals/tests/helpers/module-for-acceptance';
-import Ember from 'ember';
+import Service from '@ember/service';
 
-let StubMapsService = Ember.Service.extend({
+let StubMapsService = Service.extend({
   getMapElement() {
     return document.createElement('div');
   }

--- a/source/tutorial/simple-component.md
+++ b/source/tutorial/simple-component.md
@@ -125,9 +125,9 @@ The value of `isWide` comes from our component's JavaScript file, in this case `
 Since we want the image to be smaller at first, we will set the property to start as `false`:
 
 ```app/components/rental-listing.js{+4}
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   isWide: false
 });
 ```
@@ -167,9 +167,9 @@ These functions are called when the user interacts with the UI, such as clicking
 Let's create the `toggleImageSize` function and toggle the `isWide` property on our component:
 
 ```app/components/rental-listing.js{-4,+5,+6,+7,+8,+9,+10}
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   isWide: false
   isWide: false,
   actions: {
@@ -202,10 +202,11 @@ Our component integration test will test two different behaviors:
 
 Let's update the default test to contain the scenarios we want to verify:
 
-```tests/integration/components/rental-listing-test.js{+3,+9,+10,+11,+12,+13,+14,+15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33}
+```tests/integration/components/rental-listing-test.js{+3,+4,+9,+10,+11,+12,+13,+14,+15,+16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33,-34}
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 
 moduleForComponent('rental-listing', 'Integration | Component | rental listing', {
   integration: true
@@ -242,12 +243,13 @@ For the test we'll pass the component a fake object that has all the properties 
 We'll give the variable the name `rental`, and in each test we'll set `rental` to our local scope, represented by the `this` object.
 The render template can access values in local scope.
 
-```tests/integration/components/rental-listing-test.js{+5,+6,+7,+8,+9,+10,+11,+12,+19,+23}
+```tests/integration/components/rental-listing-test.js{+6,+7,+8,+9,+10,+11,+12,+13,+20,+24}
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 
-let rental = Ember.Object.create({
+let rental = EmberObject.create({
   image: 'fake.png',
   title: 'test-title',
   owner: 'test-owner',
@@ -273,12 +275,13 @@ Now let's render our component using the `render` function.
 The `render` function allows us to pass a template string, so that we can declare the component in the same way we do in our templates.
 Since we set the `rentalObj` variable to our local scope, we can access it as part of our render string.
 
-```tests/integration/components/rental-listing-test.js{+20,+25}
+```tests/integration/components/rental-listing-test.js{+21,+26}
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 
-let rental = Ember.Object.create({
+let rental = EmberObject.create({
   image: 'fake.png',
   title: 'test-title',
   owner: 'test-owner',
@@ -324,9 +327,9 @@ test('should toggle wide class on click', function(assert) {
   this.set('rentalObj', rental);
   this.render(hbs`{{rental-listing rental=rentalObj}}`);
   assert.equal(this.$('.image.wide').length, 0, 'initially rendered small');
-  Ember.run(() => document.querySelector('.image').click());
+  run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 1, 'rendered wide after click');
-  Ember.run(() => document.querySelector('.image').click());
+  run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 0, 'rendered small after second click');
 });
 ```
@@ -335,9 +338,10 @@ The final test should look as follows:
 ```tests/integration/components/rental-listing-test.js
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 
-let rental = Ember.Object.create({
+let rental = EmberObject.create({
   image: 'fake.png',
   title: 'test-title',
   owner: 'test-owner',
@@ -361,9 +365,9 @@ test('should toggle wide class on click', function(assert) {
   this.set('rentalObj', rental);
   this.render(hbs`{{rental-listing rental=rentalObj}}`);
   assert.equal(this.$('.image.wide').length, 0, 'initially rendered small');
-  Ember.run(() => document.querySelector('.image').click());
+  run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 1, 'rendered wide after click');
-  Ember.run(() => document.querySelector('.image').click());
+  run(() => document.querySelector('.image').click());
   assert.equal(this.$('.image.wide').length, 0, 'rendered small after second click');
 });
 ```

--- a/source/tutorial/subroutes.md
+++ b/source/tutorial/subroutes.md
@@ -79,16 +79,20 @@ For example, you can modify the `index` route's path by specifying `this.route('
 In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
-```app/routes/rentals.js{-2,-3,-4}
-export default Ember.Route.extend({
+```app/routes/rentals.js{-4,-5,-6}
+import Route from '@ember/routing/route';
+
+export default Route.extend({
   model() {
     return this.get('store').findAll('rental');
   }
 });
 ```
 
-```app/routes/rentals/index.js{+2,+3,+4}
-export default Ember.Route.extend({
+```app/routes/rentals/index.js{+4,+5,+6}
+import Route from '@ember/routing/route';
+
+export default Route.extend({
   model() {
     return this.get('store').findAll('rental');
   }
@@ -279,8 +283,10 @@ The `rental_id` will now be passed to the route.
 
 Next, we want to edit our `show` route to retrieve the requested rental:
 
-```app/routes/rentals/show.js{+2,+3,+4}
-export default Ember.Route.extend({
+```app/routes/rentals/show.js{+4,+5,+6}
+import Route from '@ember/routing/route';
+
+export default Route.extend({
   model(params) {
     return this.get('store').findRecord('rental', params.rental_id);
   }


### PR DESCRIPTION
[RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-javascript-module-api.md) introduces new modular imports so that you can import only the parts of Ember that you require inside that file.

We need your help converting all of the code samples in the Guides to the new style of imports!

## Contributing

1. Pick a section from the list below. If a section is already taken and you would like to help, please contact the person it was assigned to directly and coordinate with them.
2. Using the correspondence tables in [ember-rfc176-data](https://github.com/ember-cli/ember-rfc176-data):
  2.1. Update `import` statements in code sample to the new imports.
  2.2. Update links to API docs. For example, change the link text from `Ember.Component` to `Component`.
3. Make a PR **against the `new-imports` branch**, which is this one.

### FAQ

#### I can't find the class/method in the correspondence table

Check if the API is **private** or **public**.

If it is **private**, the Guide should be changed to not use it.
You can post here for help, or in your own PR.

If it is **public**, there might have been a lapse.
Comment in https://github.com/ember-cli/ember-rfc176-data/issues/12 and we'll help you sort it out!

#### Should I rebase? Why do I have to target the `new-imports` branch?

We will take care of rebasing and otherwise updating this branch as works continues.
We need to do this until 2.16 is released because we have Continuous Integration on the master branch, so any PRs merged get deployed as soon as CI finishes building.

## Guides section list 

- [x] Getting Started
- [x] Tutorial
- [x] The Object Model
- [x] Routing
- [x] Templates
- [x] Components
- [x] Controllers
- [x] Models
- [x] Application Concerns
- [x] Testing
- [x] Ember Inspector
- [x] Addons and Dependencies
- [x] Configuring Ember.js
- [x] Contributing to Ember.js
- [x] Glossary