### PR TITLE
Fix github edit page

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -42,7 +42,7 @@
       <article class="chapter">
         <h1>
           <%= page_title %>
-          <a href="https://github.com/emberjs/guides/edit/master/source/localizable/<%= current_page.path.gsub('html', 'md') %>"
+          <a href="https://github.com/emberjs/guides/edit/master/source/<%= current_page.path.gsub('html', 'md') %>"
              target="_blank" class="edit-page icon-pencil">Edit Page</a>
         </h1>
         <hr>


### PR DESCRIPTION
Example:

https://guides.emberjs.com/v2.14.0/getting-started/quick-start/

**Click in icon pencil for edit page**

Link broken: https://github.com/emberjs/guides/edit/master/source/localizable/getting-started/quick-start.md

Link OK: https://github.com/emberjs/guides/edit/master/source/getting-started/quick-start.md 