### PR TITLE
Show people how to stub service in acceptance test

### DIFF
--- a/source/testing/acceptance.md
+++ b/source/testing/acceptance.md
@@ -39,6 +39,37 @@ test('should add new post', function(assert) {
 });
 ```
 
+You can also stub a service into the acceptance test:
+```tests/acceptance/login-test.js
+import { test } from 'qunit';
+import moduleForAcceptance from 'people/tests/helpers/module-for-acceptance';
+
+const userStub = Ember.Service.extend({
+  email: 'test@testing.com',
+  token: '',
+  isLoggedIn() {
+    return true;
+  },
+});
+
+moduleForAcceptance('Acceptance | login', {
+  beforeEach(){
+    this.application.register('service:user-service', userStub);
+    this.application.inject('route:application', 'currentUser', 'service:user-service');
+  }
+});
+
+test('visiting /login', function(assert) {
+  visit('/login');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/login');
+  });
+});
+```
+
+
+
 ## Test Helpers
 
 One of the major issues in testing web applications is that all code is


### PR DESCRIPTION
It took me hours to figure it out. 
I tried to follow things here:https://guides.emberjs.com/v2.15.0/testing/testing-components/#toc_stubbing-services, but it didn't work out for acceptance.
Finally I found a solution here: https://guides.emberjs.com/v2.15.0/tutorial/service/#toc_stubbing-services-in-acceptance-tests
The documentation about testing seems scattering around inside the guides, so I hope putting them back together will save people's time.