### PR TITLE
Minor stuff I came across following the tutorial

### DIFF
--- a/source/tutorial/autocomplete-component.md
+++ b/source/tutorial/autocomplete-component.md
@@ -397,12 +397,12 @@ import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import RSVP from 'rsvp';
 
+const ITEMS = [{city: 'San Francisco'}, {city: 'Portland'}, {city: 'Seattle'}];
+const FILTERED_ITEMS = [{city: 'San Francisco'}];
+
 moduleForComponent('list-filter', 'Integration | Component | filter listing', {
   integration: true
 });
-
-const ITEMS = [{city: 'San Francisco'}, {city: 'Portland'}, {city: 'Seattle'}];
-const FILTERED_ITEMS = [{city: 'San Francisco'}];
 
 test('should initially load all listings', function (assert) {
   // we want our actions to return promises, since they are potentially fetching data asynchronously

--- a/source/tutorial/hbs-helper.md
+++ b/source/tutorial/hbs-helper.md
@@ -61,8 +61,12 @@ Instead, our default template helper is returning back our `rental.propertyType`
 Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
-```app/helpers/rental-property-type.js
+```app/helpers/rental-property-type.js{-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+17,+18,+19}
 import Ember from 'ember';
+
+export function rentalPropertyType(params/*, hash*/) {
+  return params;
+}
 
 const communityPropertyTypes = [
   'Condo',

--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -128,7 +128,7 @@ export default Ember.Service.extend({
   },
 
   getMapElement(location) {
-    let camelizedLocation = location.camelize();
+    let camelizedLocation = Ember.String.camelize(location);
     let element = this.get(`cachedMaps.${camelizedLocation}`);
     if (!element) {
       element = this.createMapElement();
@@ -146,8 +146,6 @@ export default Ember.Service.extend({
 
 });
 ```
-
-Note that line 16 of `getMapElement` uses the `camelize()` helper method from [`Ember.String`](http://emberjs.com/api/classes/Ember.String.html#method_camelize).
 
 ### Display Maps With a Component
 

--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -147,6 +147,8 @@ export default Ember.Service.extend({
 });
 ```
 
+Note that line 16 of `getMapElement` uses the `camelize()` helper method from [`Ember.String`](http://emberjs.com/api/classes/Ember.String.html#method_camelize).
+
 ### Display Maps With a Component
 
 With a service and utility that render a map to a web page element,
@@ -258,7 +260,7 @@ let MapUtilStub = Ember.Object.extend({
 
 moduleFor('service:maps', 'Unit | Service | maps');
 
-test('should create a new map if one isnt cached for location', function (assert) {
+test('should create a new map if one isn\'t cached for location', function (assert) {
   assert.expect(4);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });

--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -260,7 +260,7 @@ let MapUtilStub = Ember.Object.extend({
 
 moduleFor('service:maps', 'Unit | Service | maps');
 
-test('should create a new map if one isn\'t cached for location', function (assert) {
+test('should create a new map if one isnt cached for location', function (assert) {
   assert.expect(4);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });


### PR DESCRIPTION
autocomplete-component.md: in one example, the module and consts were switched.
hbs-helper.md: one example did have code addition/deletion that I believe it should have from seeing other examples.
service.md: The first use of camelize() really threw me when I was reading the docs, so I added a note about it.