### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ruby:2.3
+
+USER root
+
+ENV BUNDLER_VERSION 1.15.1
+
+# en - English
+# pt - Portuguese and Brazilian Portuguese
+# es - Spanish
+# pl - Polish
+ENV ASPELL_LANGUAGES aspell-en aspell-pt aspell-es aspell-pl
+
+# JavaScript runtime required by execjs gem
+# Spellchecking
+ENV PACKAGES nodejs aspell $ASPELL_LANGUAGES
+
+RUN apt-get update && apt-get -y install $PACKAGES
+
+# Fix the Bundler version
+RUN gem install bundler -v $BUNDLER_VERSION
+RUN mkdir /guides
+
+WORKDIR /guides
+
+ADD Gemfile /guides/Gemfile
+ADD Gemfile.lock /guides/Gemfile.lock
+RUN bundle install
+
+ADD . /guides
+
+CMD bundle exec middleman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,4 +244,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -52,12 +52,23 @@ Some Mac users may also need to install openSSL, which will be indicated in an e
 
 To get started:
 
+#### Local Dev
 ``` sh
 git clone git://github.com/emberjs/guides.git
 cd guides
 bundle
 bundle exec middleman
 ```
+
+#### With Docker
+```sh
+git clone git://github.com/emberjs/guides.git
+cd guides
+docker-compose build
+docker-compose up
+```
+
+#### Viewing
 
 Then visit [http://localhost:4567/](http://localhost:4567/).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  guides:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    command: bundle exec middleman
+    ports:
+      - "4567:4567"
+    volumes:
+      - .:/guides


### PR DESCRIPTION
Motivation:
Dependency management is not fun. Let docker explicitly define what it takes to get this project running.