### PR TITLE
Triggering changes with action fix: Makes it easier to read/consistent

### DIFF
--- a/source/components/triggering-changes-with-actions.md
+++ b/source/components/triggering-changes-with-actions.md
@@ -261,7 +261,10 @@ In cases like this, the parent template can provide the required parameter when 
 For example, if we want to use the button to send a message of type `"info"`:
 
 ```app/templates/components/send-message.hbs
-{{button-with-confirmation text="Click to send your message." onConfirm=(action "sendMessage" "info")}}
+{{button-with-confirmation
+  text="Click to send your message."
+  onConfirm=(action "sendMessage" "info")
+}}
 ```
 
 Within `button-with-confirmation`, the code in the `submitConfirm` action does not change.


### PR DESCRIPTION
Consistent with previous code snippets.
Eg: 
![ss1](https://puu.sh/xW5xJ.png)
The same template file being referenced further down (and edited in this commit). It's kinda annoying to slide to see the rest of the code.
![ss2](https://puu.sh/xW5zP.png)

Edit: live link can be found here https://guides.emberjs.com/v2.16.0/components/triggering-changes-with-actions/#toc_passing-arguments