### PR TITLE
hardcode most api urls as a stopgap #2082

### DIFF
--- a/source/applications/applications-and-instances.md
+++ b/source/applications/applications-and-instances.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`](http://emberjs.com/api/classes/Application.html).
+Every Ember application is represented by a class that extends [`Application`](https://emberjs.com/api/ember/2.16/classes/Application).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`](http://emberjs.com/api/classes/ApplicationInstance.html) that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](https://emberjs.com/api/ember/2.16/classes/ApplicationInstance) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/source/applications/dependency-injection.md
+++ b/source/applications/dependency-injection.md
@@ -2,11 +2,11 @@ Ember applications utilize the [dependency injection](https://en.wikipedia.org/w
 ("DI") design pattern to declare and instantiate classes of objects and dependencies between them.
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`](http://emberjs.com/api/classes/Ember.Application.html) serves as a "registry" for dependency declarations.
+An [`Application`](https://emberjs.com/api/ember/2.16/classes/Application) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`](http://emberjs.com/api/classes/Ember.ApplicationInstance.html) serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](https://emberjs.com/api/ember/2.16/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
@@ -194,7 +194,7 @@ export default Component.extend({
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`](http://emberjs.com/api/classes/Ember.ApplicationInstance.html#method_lookup) method on an application instance. This method takes a string
+[`lookup`](https://emberjs.com/api/ember/2.16/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -225,9 +225,9 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`](http://emberjs.com/api/#method_getOwner) will retrieve the application instance that "owns" an
+[`Ember.getOwner`](https://emberjs.com/api/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`](http://emberjs.com/api/#method_getOwner) to perform lookups through their application
+can use [`Ember.getOwner`](https://emberjs.com/api/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based

--- a/source/applications/run-loop.md
+++ b/source/applications/run-loop.md
@@ -198,8 +198,9 @@ $('a').click(() => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`](http://emberjs.com/api/classes/Ember.run.html#method_schedule), [`run.scheduleOnce`](http://emberjs.com/api/classes/Ember.run.html#method_scheduleOnce),
-[`run.once`](http://emberjs.com/api/classes/Ember.run.html#method_once) have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
+[`run.scheduleOnce`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
+[`run.once`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
 
 Here is some pseudocode to describe what happens using the example above:
@@ -264,5 +265,5 @@ Disabling autoruns help you identify these scenarios and helps both your testing
 
 ## Where can I find more information?
 
-Check out the [Ember.run](http://emberjs.com/api/classes/Ember.run.html) API documentation,
+Check out the [Ember.run](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Frunloop) API documentation,
 as well as the [Backburner library](https://github.com/ebryn/backburner.js/) that powers the run loop.

--- a/source/applications/services.md
+++ b/source/applications/services.md
@@ -1,4 +1,4 @@
-An [`Service`](http://emberjs.com/api/classes/Ember.Service.html) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+An [`Service`](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](http://emberjs.com/api/classes/Ember.Service.html) base class:
+Services must extend the [`Service`](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fservice) base class:
 
 ```app/services/shopping-cart.js
 import Service from '@ember/service';
@@ -92,7 +92,7 @@ This injects the shopping cart service into the component and makes it available
 
 Sometimes a service may or may not exist, like when an initializer conditionally registers a service.
 Since normal injection will throw an error if the service doesn't exist,
-you must look up the service using Ember's [`getOwner`](https://emberjs.com/api/classes/Ember.html#method_getOwner) instead. 
+you must look up the service using Ember's [`getOwner`](https://emberjs.com/api/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
 
 ```app/components/cart-contents.js
 import Component from '@ember/component';

--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -58,7 +58,7 @@ the Handlebars template as described above and use the component that is
 created.
 
 If you need to customize the behavior of the component you'll
-need to define a subclass of [`Component`](http://emberjs.com/api/classes/Ember.Component.html). For example, you would
+need to define a subclass of [`Component`](https://www.emberjs.com/api/ember/2.16/classes/Component). For example, you would
 need a custom subclass if you wanted to change a component's element,
 respond to actions from the component's template, or manually make
 changes to the component's element using JavaScript.
@@ -71,7 +71,7 @@ file at `app/components/blog-post.js`. If your component was called
 
 ## Dynamically rendering a component
 
-The [`{{component}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_component) helper can be used to defer the selection of a component to
+The [`{{component}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
 run time. The `{{my-component}}` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
@@ -81,7 +81,7 @@ allow you to keep different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `{{blog-post}}`.
 
-The real value of [`{{component}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_component) comes from being able to dynamically pick
+The real value of [`{{component}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
 the component being rendered. Below is an example of using the helper as a
 means of choosing different components for displaying different kinds of posts:
 

--- a/source/components/handling-events.md
+++ b/source/components/handling-events.md
@@ -92,7 +92,7 @@ function definition can define the event object as its first parameter.
 
 ```js
 actions: {
-  signUp(event){ 
+  signUp(event){
   	// Only when assigning the action to an inline handler, the event object
     // is passed to the action as the first parameter.
   }
@@ -116,7 +116,7 @@ actions: {
 }
 ```
 
-To utilize an `event` object as a function parameter: 
+To utilize an `event` object as a function parameter:
 
 - Define the event handler in the component (which is designed to receive the
   browser event object).
@@ -128,7 +128,7 @@ To utilize an `event` object as a function parameter:
 
 The event handling examples described above respond to one set of events.
 The names of the built-in events are listed below. Custom events can be
-registered by using [Application.customEvents](http://emberjs.com/api/classes/Ember.Application.html#property_customEvents).
+registered by using [Application.customEvents](https://www.emberjs.com/api/ember/2.16/classes/Application/properties/customEvents?anchor=customEvents).
 
 Touch events:
 

--- a/source/components/passing-properties-to-a-component.md
+++ b/source/components/passing-properties-to-a-component.md
@@ -66,7 +66,7 @@ In other words, you can invoke the above component example like this:
 ```
 
 To set the component up to receive parameters this way, you need to
-set the [`positionalParams`](http://emberjs.com/api/classes/Ember.Component.html#property_positionalParams) attribute in your component class.
+set the [`positionalParams`](https://www.emberjs.com/api/ember/2.16/classes/Component/properties/positionalParams?anchor=positionalParams) attribute in your component class.
 
 ```app/components/blog-post.js
 import Component from '@ember/component';

--- a/source/components/the-component-lifecycle.md
+++ b/source/components/the-component-lifecycle.md
@@ -193,15 +193,14 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and  for performance reasons,
+- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using [`on()`][on], it is encouraged to override the default method itself,
+- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
 
-[did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
-[dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
+[did-insert-element]: https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement
+[dollar]: https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24
 [event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
-[on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`
 
@@ -255,7 +254,7 @@ export default Component.extend({
 
 ### Detaching and Tearing Down Component Elements with `willDestroyElement`
 
-When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](http://emberjs.com/api/classes/Ember.Component.html#event_willDestroyElement) method,
+When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://www.emberjs.com/api/ember/2.16/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method,
 allowing for any teardown logic to be performed.
 
 Component teardown can be triggered by a number of different conditions.

--- a/source/components/wrapping-content-in-a-component.md
+++ b/source/components/wrapping-content-in-a-component.md
@@ -65,7 +65,7 @@ We will give them the option to specify either `markdown-style` or `html-style`.
 
 Supporting different editing styles will require different body components to provide special validation and highlighting.
 To load a different body component based on editing style,
-you can yield the component using the [`component helper`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_component) and [`hash helper`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_hash). 
+you can yield the component using the [`component helper`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) and [`hash helper`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/hash?anchor=hash). 
 Here, the appropriate component is assigned to a hash using nested helpers and yielded to the template.
 Notice `editStyle` being used as an argument to the component helper.
 
@@ -90,7 +90,7 @@ To pass the blog text to the body component, we'll add a `postData` argument to 
 ```app/templates/components/blog-post.hbs
 <h2>{{title}}</h2>
 <div class="body">
-  {{yield (hash 
+  {{yield (hash
     body=(component editStyle postData=postData)
   )}}
 </div>

--- a/source/configuring-ember/disabling-prototype-extensions.md
+++ b/source/configuring-ember/disabling-prototype-extensions.md
@@ -9,7 +9,7 @@ objects in the following ways:
 
 * `String` is extended to add convenience methods, such as
   `camelize()` and `w()`. You can find a list of these methods with the
-  [Ember.String documentation](http://emberjs.com/api/classes/Ember.String.html).
+  [Ember.String documentation](https://www.emberjs.com/api/ember/2.16/classes/String).
 
 * `Function` is extended with methods to annotate functions as
   computed properties, via the `property()` method, and as observers,
@@ -94,7 +94,7 @@ islands.includes('Oahu');
 ### Strings
 
 Strings will no longer have the convenience methods described in the
-[`Ember.String` API reference](http://emberjs.com/api/classes/Ember.String.html).
+[`Ember.String` API reference](https://www.emberjs.com/api/ember/2.16/classes/String).
 Instead,
 you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:

--- a/source/models/creating-updating-and-deleting-records.md
+++ b/source/models/creating-updating-and-deleting-records.md
@@ -1,7 +1,7 @@
 ## Creating Records
 
 You can create records by calling the
-[`createRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_createRecord)
+[`createRecord()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/createRecord?anchor=createRecord)
 method on the store.
 
 ```js
@@ -36,7 +36,7 @@ person.incrementProperty('age'); // Happy birthday!
 ## Persisting Records
 
 Records in Ember Data are persisted on a per-instance basis.
-Call [`save()`](http://emberjs.com/api/data/classes/DS.Model.html#method_save)
+Call [`save()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/methods/save?anchor=save)
 on any instance of `DS.Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
@@ -68,10 +68,10 @@ store.findRecord('post', 1).then(function(post) {
 
 You can tell if a record has outstanding changes that have not yet been
 saved by checking its
-[`hasDirtyAttributes`](http://emberjs.com/api/data/classes/DS.Model.html#property_hasDirtyAttributes)
+[`hasDirtyAttributes`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
 property. You can also see what parts of
 the record were changed and what the original value was using the
-[`changedAttributes()`](http://emberjs.com/api/data/classes/DS.Model.html#method_changedAttributes)
+[`changedAttributes()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/methods/changedAttributes?anchor=changedAttributes)
 method. `changedAttributes` returns an object, whose keys are the changed
 properties and values are an array of values `[oldValue, newValue]`.
 
@@ -85,7 +85,7 @@ person.changedAttributes();       //=> { isAdmin: [false, true] }
 
 At this point, you can either persist your changes via `save()` or you can roll
 back your changes. Calling
-[`rollbackAttributes()`](http://emberjs.com/api/data/classes/DS.Model.html#method_rollbackAttributes)
+[`rollbackAttributes()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/methods/rollbackAttributes?anchor=rollbackAttributes)
 for a saved record reverts all the `changedAttributes` to their original value.
 If the record `isNew` it will be removed from the store.
 
@@ -117,7 +117,7 @@ the errors from saving a blog post in your template:
 
 ## Promises
 
-[`save()`](http://emberjs.com/api/data/classes/DS.Model.html#method_save) returns
+[`save()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/methods/save?anchor=save) returns
 a promise, which makes it easy to asynchronously handle success and failure
 scenarios.  Here's a common pattern:
 
@@ -145,10 +145,10 @@ post.save().then(transitionToPost).catch(failure);
 
 ## Deleting Records
 
-Deleting records is as straightforward as creating records. Call [`deleteRecord()`](http://emberjs.com/api/data/classes/DS.Model.html#method_deleteRecord)
-on any instance of `DS.Model`. This flags the record as `isDeleted`. The 
-deletion can then be persisted using `save()`.  Alternatively, you can use 
-the [`destroyRecord`](http://emberjs.com/api/data/classes/DS.Model.html#method_destroyRecord) method to delete and persist at the same time.
+Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
+on any instance of `DS.Model`. This flags the record as `isDeleted`. The
+deletion can then be persisted using `save()`.  Alternatively, you can use
+the [`destroyRecord`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```js
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {
@@ -165,4 +165,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 
 The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
 
-[findRecord]: <http://emberjs.com/api/data/classes/DS.Store.html#method_findRecord>
+[findRecord]: <https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord>

--- a/source/models/customizing-adapters.md
+++ b/source/models/customizing-adapters.md
@@ -50,17 +50,17 @@ By default Ember Data comes with several built-in adapters. Feel free
 to use these adapters as a starting point for creating your own custom
 adapter.
 
-- [DS.Adapter](http://emberjs.com/api/data/classes/DS.Adapter.html) is the basic adapter
+- [DS.Adapter](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Adapter) is the basic adapter
 with no functionality. It is generally a good starting point if you
 want to create an adapter that is radically different from the other
 Ember adapters.
 
-- [DS.JSONAPIAdapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
+- [DS.JSONAPIAdapter](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPIAdapter)
 The `JSONAPIAdapter` is the default adapter and follows JSON API
 conventions to communicate with an HTTP server by transmitting JSON
 via XHR.
 
-- [DS.RESTAdapter](http://emberjs.com/api/data/classes/DS.RESTAdapter.html)
+- [DS.RESTAdapter](https://www.emberjs.com/api/ember-data/2.16/classes/DS.RESTAdapter)
 The `RESTAdapter` allows your store to communicate with an HTTP server
 by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default.
 
@@ -68,7 +68,7 @@ by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default
 ## Customizing the JSONAPIAdapter
 
 The
-[DS.JSONAPIAdapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
+[DS.JSONAPIAdapter](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPIAdapter)
 has a handful of hooks that are commonly used to extend it to work
 with non-standard backends.
 
@@ -236,7 +236,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](http://emberjs.com/api/classes/Ember.ComputedProperty.html#method_volatile)
+[volatile](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile&show=inherited%2Cprotected%2Cprivate%2Cdeprecated)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/source/models/customizing-serializers.md
+++ b/source/models/customizing-serializers.md
@@ -5,11 +5,11 @@ format, Ember Data allows you to customize the serializer or use a
 different serializer entirely.
 
 Ember Data ships with 3 serializers. The
-[`JSONAPISerializer`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html)
+[`JSONAPISerializer`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer)
 is the default serializer and works with JSON API backends. The
-[`JSONSerializer`](http://emberjs.com/api/data/classes/DS.JSONSerializer.html)
+[`JSONSerializer`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONSerializer.html)
 is a simple serializer for working with single json object or arrays of records. The
-[`RESTSerializer`](http://emberjs.com/api/data/classes/DS.RESTSerializer.html)
+[`RESTSerializer`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.RESTSerializer.html)
 is a more complex serializer that supports sideloading and was the default
 serializer before 2.0.
 
@@ -139,7 +139,7 @@ export default DS.JSONAPISerializer.extend({});
 ```
 
 To change the format of the data that is sent to the backend store, you can use
-the [`serialize()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_serialize)
+the [`serialize()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/serialize?anchor=serialize)
 hook. Let's say that we have this JSON API response from Ember Data:
 
 ```json
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_normalizeResponse)
+[`normalizeResponse()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,11 +252,11 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_normalize)
+[`normalize()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
-API documentation](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#index).
+API documentation](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer).
 
 ### IDs
 
@@ -309,7 +309,7 @@ in the document payload returned by your server:
 
 If the attributes returned by your server use a different convention
 you can use the serializer's
-[`keyForAttribute()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_keyForAttribute)
+[`keyForAttribute()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
 method to convert an attribute name in your model to a key in your JSON
 payload. For example, if your backend returned attributes that are
 `under_scored` instead of `dash-cased` you could override the `keyForAttribute`
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_keyForRelationship)
+[`keyForRelationship()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
 method.
 
 ```app/serializers/application.js
@@ -544,7 +544,7 @@ looks similar to this:
 The `JSONAPISerializer` is built on top of the `JSONSerializer` so they share
 many of the same hooks for customizing the behavior of the
 serialization process. Be sure to check out the
-[API docs](http://emberjs.com/api/data/classes/DS.JSONSerializer.html)
+[API docs](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONSerializer)
 for a full list of methods and properties.
 
 
@@ -752,7 +752,7 @@ Note that the type is `"post"` to match the post model and the
 #### Normalizing adapter responses
 
 When creating a custom serializer you will need to define a
-[normalizeResponse](http://emberjs.com/api/data/classes/DS.Serializer.html#method_normalizeResponse)
+[normalizeResponse](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Serializer/methods/normalizeResponse?anchor=normalizeResponse)
 method to transform the response from the adapter into the normalized
 JSON object described above.
 
@@ -773,7 +773,7 @@ do not fall into the normal CRUD flow that the adapter provides.
 #### Serializing records
 
 Finally a serializer will need to implement a
-[serialize](http://emberjs.com/api/data/classes/DS.Serializer.html#method_serialize)
+[serialize](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Serializer/methods/serialize?anchor=serialize)
 method.
 Ember Data will provide a record snapshot and an options hash and this
 method should return an object that the adapter will send to the

--- a/source/models/defining-models.md
+++ b/source/models/defining-models.md
@@ -28,7 +28,7 @@ and [working with records](../creating-updating-and-deleting-records) of that ty
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`DS.attr`](http://emberjs.com/api/data/classes/DS.html#method_attr):
+add first and last name, as well as the birthday, using [`DS.attr`](https://www.emberjs.com/api/ember-data/2.16/classes/DS/methods/attr?anchor=attr):
 
 ```app/models/person.js
 import DS from 'ember-data';

--- a/source/models/finding-records.md
+++ b/source/models/finding-records.md
@@ -2,14 +2,14 @@ The Ember Data store provides an interface for retrieving records of a single ty
 
 ### Retrieving a Single Record
 
-Use [`store.findRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_findRecord) to retrieve a record by its type and ID.
+Use [`store.findRecord()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord) to retrieve a record by its type and ID.
 This will return a promise that fulfills with the requested record:
 
 ```javascript
 let blogPost = this.get('store').findRecord('blog-post', 1); // => GET /blog-posts/1
 ```
 
-Use [`store.peekRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -18,7 +18,7 @@ let blogPost = this.get('store').peekRecord('blog-post', 1); // => no network re
 
 ### Retrieving Multiple Records
 
-Use [`store.findAll()`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) to retrieve all of the records for a given type:
+Use [`store.findAll()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
 
 ```javascript
 let blogPosts = this.get('store').findAll('blog-post'); // => GET /blog-posts
@@ -39,7 +39,7 @@ the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 ### Querying for Multiple Records
 
 Ember Data provides the ability to query for records that meet certain criteria.
-Calling [`store.query()`](http://emberjs.com/api/data/classes/DS.Store.html#method_query) will make a `GET` request with the passed object serialized as query params.
+Calling [`store.query()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
 This method returns a `DS.PromiseArray` in the same way as `findAll`.
 
 For example, we could search for all `person` models who have the name of
@@ -59,7 +59,7 @@ this.get('store').query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -87,7 +87,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](http://emberjs.com/api/data/classes/DS.Store.html#method_queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {
@@ -100,7 +100,7 @@ As in the case of `store.query()`, a query object can also be passed to `store.q
 However the adapter must return a single model object, not an array containing one element,
 otherwise Ember Data will throw an exception.
 
-Note that Ember's default [JSON API adapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
+Note that Ember's default [JSON API adapter](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
 
 If your server API or your adapter only provides array responses but you wish to retrieve just a single record, you can alternatively use the `query()` method as follows:
 

--- a/source/models/pushing-records-into-the-store.md
+++ b/source/models/pushing-records-into-the-store.md
@@ -19,7 +19,7 @@ you want to update the UI immediately.
 
 ### Pushing Records
 
-To push a record into the store, call the store's [`push()`](http://emberjs.com/api/data/classes/DS.Store.html#method_push) method.
+To push a record into the store, call the store's [`push()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/push?anchor=push) method.
 
 For example, imagine we want to preload some data into the store when
 the application boots for the first time.
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](http://emberjs.com/api/data/classes/DS.Store.html#method_pushPayload) method.
+[`store.pushPayload()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/push?anchor=pushPayload) method.
 
 ```app/serializers/album.js
 import DS from 'ember-data';

--- a/source/models/relationships.md
+++ b/source/models/relationships.md
@@ -340,7 +340,7 @@ include those related records in the response returned to the client.
 The value of the parameter should be a comma-separated list of names of the
 relationships required.
 
-If you are using an adapter that supports JSON API, such as Ember's default [`JSONAPIAdapter`](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html),
+If you are using an adapter that supports JSON API, such as Ember's default [`JSONAPIAdapter`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPIAdapter),
 you can easily add the `include` parameter to the server requests created by
 the `findRecord()`, `findAll()`,
 `query()` and `queryRecord()` methods.

--- a/source/object-model/bindings.md
+++ b/source/object-model/bindings.md
@@ -3,7 +3,7 @@ bindings in Ember.js can be used with any object. That said, bindings are most
 often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](http://emberjs.com/api/classes/Ember.computed.html#method_alias),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
 that specifies the path to another object.
 
 ```javascript
@@ -37,11 +37,11 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](http://emberjs.com/api/classes/Ember.computed.html#method_oneWay). Often, one-way bindings are a performance 
+[`computed.oneWay()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behaviour such as a
 default that is the same as another property but can be overridden (e.g. a
-shipping address that starts the same as a billing address but can later be 
+shipping address that starts the same as a billing address but can later be
 changed)
 
 ```javascript

--- a/source/object-model/classes-and-instances.md
+++ b/source/object-model/classes-and-instances.md
@@ -1,11 +1,11 @@
-As you learn about Ember, you'll see code like `Ember.Component.extend()` and
+As you learn about Ember, you'll see code like `Component.extend()` and
 `DS.Model.extend()`. Here, you'll learn about this `extend()` method, as well
 as other major features of the Ember object model.
 
 ### Defining Classes
 
 To define a new Ember _class_, call the [`extend()`][1] method on
-[`Ember.Object`][2]:
+[`EmberObject`][2]:
 
 [1]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend
 [2]: https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject
@@ -24,7 +24,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Ember.Component`][3] class:
+of Ember's built-in [`Component`][3] class:
 
 [3]: https://www.emberjs.com/api/ember/2.16/classes/Component
 

--- a/source/object-model/classes-and-instances.md
+++ b/source/object-model/classes-and-instances.md
@@ -7,8 +7,8 @@ as other major features of the Ember object model.
 To define a new Ember _class_, call the [`extend()`][1] method on
 [`Ember.Object`][2]:
 
-[1]: http://emberjs.com/api/classes/Ember.Object.html#method_extend
-[2]: http://emberjs.com/api/classes/Ember.Object.html
+[1]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend
+[2]: https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -26,7 +26,7 @@ You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
 of Ember's built-in [`Ember.Component`][3] class:
 
-[3]: http://emberjs.com/api/classes/Ember.Component.html
+[3]: https://www.emberjs.com/api/ember/2.16/classes/Component
 
 ```app/components/todo-item.js
 import Component from '@ember/component';
@@ -75,7 +75,7 @@ One common example is when overriding the [`normalizeResponse()`][4] hook in one
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 
-[4]: http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_normalizeResponse
+[4]: https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -93,7 +93,7 @@ class by calling its [`create()`][5] method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[5]: http://emberjs.com/api/classes/Ember.Object.html#method_create
+[5]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -145,7 +145,7 @@ When a new instance is created, its [`init()`][6] method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
 
-[6]: http://emberjs.com/api/classes/Ember.Object.html#method_init
+[6]: https://www.emberjs.com/api/ember/2.16/classes/EmberObject/methods/init?anchor=init
 
 ```js
 import EmberObject from '@ember/object';
@@ -229,8 +229,8 @@ Person.create({
 When accessing the properties of an object, use the [`get()`][7]
 and [`set()`][8] accessor methods:
 
-[7]: http://emberjs.com/api/classes/Ember.Object.html#method_get
-[8]: http://emberjs.com/api/classes/Ember.Object.html#method_set
+[7]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get
+[8]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set
 
 ```js
 import EmberObject from '@ember/object';

--- a/source/object-model/computed-properties-and-aggregate-data.md
+++ b/source/object-model/computed-properties-and-aggregate-data.md
@@ -38,14 +38,14 @@ and fire observers when any of the following events occurs:
 
 ### Multiple Dependent Keys
 
-It's important to note that the `@each` key can be dependant on more than one key. 
-For example, if you are using `Ember.computed` to sort an array by multiple keys, 
+It's important to note that the `@each` key can be dependant on more than one key.
+For example, if you are using `Ember.computed` to sort an array by multiple keys,
 you would declare the dependency with braces: `todos.@each.{priority,title}`
 
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](http://emberjs.com/api/classes/Ember.computed.html#method_filterBy),
+[`computed.filterBy`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
 which is a shorter way of expressing the above computed property:
 
 ```app/components/todo-list.js
@@ -133,10 +133,10 @@ export default Component.extend({
 Here, `indexOfSelectedTodo` depends on `todos.[]`, so it will update if we add an item
 to `todos`, but won't update if the value of `isDone` on a `todo` changes.
 
-Several of the [Ember.computed](http://emberjs.com/api/classes/Ember.computed.html) macros
+Several of the [Ember.computed](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject%2Fcomputed) macros
 utilize the `[]` key to implement common use-cases. For instance, to
 create a computed property that mapped properties from an array, you could use
-[Ember.computed.map](http://emberjs.com/api/classes/Ember.computed.html#method_map)
+[Ember.computed.map](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
 or build the computed property yourself:
 
 ```javascript

--- a/source/object-model/computed-properties.md
+++ b/source/object-model/computed-properties.md
@@ -22,7 +22,7 @@ Person = EmberObject.extend({
   fullName: computed('firstName', 'lastName', function() {
     let firstName = this.get('firstName');
     let lastName = this.get('lastName');
-    
+
     return `${firstName} ${lastName}`;
   })
 });
@@ -51,7 +51,7 @@ import Ember from 'ember':
   fullName: computed('firstName', 'lastName', function() {
     let firstName = this.get('firstName');
     let lastName = this.get('lastName');
-    
+
     return `${firstName} ${lastName}`;
   })
 …
@@ -67,7 +67,7 @@ import Ember from 'ember':
   fullName: computed('{firstName,lastName}', function() {
     let firstName = this.get('firstName');
     let lastName = this.get('lastName');
-    
+
     return `${firstName} ${lastName}`;
   })
 …
@@ -206,4 +206,4 @@ Person = EmberObject.extend({
 ```
 
 To see the full list of computed property macros, have a look at
-[the API documentation](http://emberjs.com/api/classes/Ember.computed.html)
+[the API documentation](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject)

--- a/source/object-model/index.md
+++ b/source/object-model/index.md
@@ -6,7 +6,7 @@ JavaScript objects don't support the observation of property value changes.
 Consequently, if an object is going to participate in Ember's binding
 system you may see an `Ember.Object` instead of a plain object.
 
-[Ember.Object](http://emberjs.com/api/classes/Ember.Object.html) also provides a class system, supporting features like mixins
+[Ember.Object](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject) also provides a class system, supporting features like mixins
 and constructor methods. Some features in Ember's object model are not present in
 JavaScript classes or common patterns, but all are aligned as much as possible
 with the language and proposed additions.
@@ -15,4 +15,4 @@ Ember also extends the JavaScript `Array` prototype with its
 [Ember.Enumerable](http://emberjs.com/api/classes/Ember.Enumerable.html) interface to provide change observation for arrays.
 
 Finally, Ember extends the `String` prototype with a few [formatting and
-localization methods](http://emberjs.com/api/classes/Ember.String.html).
+localization methods](https://www.emberjs.com/api/ember/2.16/classes/String).

--- a/source/object-model/observers.md
+++ b/source/object-model/observers.md
@@ -79,7 +79,7 @@ person.set('firstName', 'John');
 person.set('lastName', 'Smith');
 ```
 
-To get around these problems, you should make use of [`Ember.run.once()`](http://emberjs.com/api/classes/Ember.run.html#method_once).
+To get around these problems, you should make use of [`Ember.run.once()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Frunloop/methods/once?anchor=once).
 This will ensure that any processing you need to do only happens once, and
 happens in the next run loop once all bindings are synchronized:
 
@@ -145,7 +145,7 @@ get it in your `init()` method.
 ### Outside of class definitions
 
 You can also add observers to an object outside of a class definition
-using [`addObserver()`](http://emberjs.com/api/classes/Ember.Object.html#method_addObserver):
+using [`addObserver()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
 
 
 ```javascript

--- a/source/routing/asynchronous-routing.md
+++ b/source/routing/asynchronous-routing.md
@@ -8,7 +8,7 @@ heavy use of the concept of Promises. In short, promises are objects that
 represent an eventual value. A promise can either _fulfill_
 (successfully resolve the value) or _reject_ (fail to resolve the
 value). The way to retrieve this eventual value, or handle the cases
-when the promise rejects, is via the promise's [`then()`](http://emberjs.com/api/classes/RSVP.Promise.html#method_then) method, which
+when the promise rejects, is via the promise's [`then()`](https://www.emberjs.com/api/ember/2.16/classes/Promise/methods/then?anchor=then) method, which
 accepts two optional callbacks, one for fulfillment and one for
 rejection. If the promise fulfills, the fulfillment handler gets called
 with the fulfilled value as its sole argument, and if the promise rejects,
@@ -74,7 +74,7 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`](http://emberjs.com/api/classes/Ember.Route.html#method_setupController) hook for each route
+resolved. The values passed to the [`setupController()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/setupController?anchor=setupController) hook for each route
 will be the fulfilled values from the promises.
 
 

--- a/source/routing/defining-your-routes.md
+++ b/source/routing/defining-your-routes.md
@@ -14,7 +14,7 @@ It also adds the route to the router.
 
 ## Basic Routes
 
-The [`map()`](http://emberjs.com/api/classes/Ember.Router.html#method_map) method
+The [`map()`](https://www.emberjs.com/api/ember/2.16/classes/Router/methods/map?anchor=map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map()`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create routes.
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`{{link-to}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_link-to) to navigate between
+Inside your templates, you can use [`{{link-to}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -269,5 +269,5 @@ so that when a user navigates to `/a/non-existent/path` they will be shown a mes
 To have your route do something beyond render a template with the same name, you'll
 need to create a route handler. The following guides will explore the different
 features of route handlers. For more information on routes, see the API documentation
-for [the router](http://emberjs.com/api/classes/Ember.Router.html) and for [route
-handlers](http://emberjs.com/api/classes/Ember.Route.html).
+for [the router](https://www.emberjs.com/api/ember/2.16/classes/Router) and for [route
+handlers](https://www.emberjs.com/api/ember/2.16/classes/Route).

--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -84,7 +84,7 @@ It's important to note that `foo.bar.loading` is not considered now.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`](http://emberjs.com/api/classes/Ember.Route.html#event_loading) event will be fired on that route.
+don't immediately resolve, a [`loading`](https://www.emberjs.com/api/ember/2.16/classes/Route/events/loading?anchor=loading) event will be fired on that route.
 
 ```app/routes/foo-slow-model.js
 import Route from '@ember/routing/route';
@@ -199,7 +199,7 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`](http://emberjs.com/api/classes/Ember.Route.html#event_error) event will fire from that route and bubble upward.
+etc.), an [`error`](https://www.emberjs.com/api/ember/2.16/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
 

--- a/source/routing/redirection.md
+++ b/source/routing/redirection.md
@@ -7,12 +7,12 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
+One of the methods is [`transitionTo()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://www.emberjs.com/api/ember/2.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
 
-The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](http://emberjs.com/api/classes/Ember.Route.html#method_beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```app/router.js
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](http://emberjs.com/api/classes/Ember.Route.html#method_afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](http://emberjs.com/api/classes/Ember.Route.html#method_redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```app/routes/posts.js

--- a/source/routing/rendering-a-template.md
+++ b/source/routing/rendering-a-template.md
@@ -19,7 +19,7 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, set the route's [`templateName`](http://emberjs.com/api/classes/Ember.Route.html#property_templateName) property to the name of
+If you want to render a template other than the default one, set the route's [`templateName`](https://www.emberjs.com/api/ember/2.16/classes/Route/properties/templateName?anchor=templateName) property to the name of
 the template you want to render instead.
 
 ```app/routes/posts.js
@@ -30,5 +30,5 @@ export default Route.extend({
 });
 ```
 
-You can override the [`renderTemplate()`](http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate) hook if you want finer control over template rendering.
+You can override the [`renderTemplate()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
 Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.

--- a/source/routing/specifying-a-routes-model.md
+++ b/source/routing/specifying-a-routes-model.md
@@ -9,7 +9,7 @@ Router.map(function() {
 });
 ```
 
-To load a model for the `favorite-posts` route, you would use the [`model()`](http://emberjs.com/api/classes/Ember.Route.html#method_model)
+To load a model for the `favorite-posts` route, you would use the [`model()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/model?anchor=model)
 hook in the `favorite-posts` route handler:
 
 ```app/routes/favorite-posts.js
@@ -122,7 +122,7 @@ Routes without dynamic segments will always execute the model hook.
 ## Multiple Models
 
 Multiple models can be returned through an
-[RSVP.hash](http://emberjs.com/api/classes/RSVP.html#method_hash).
+[RSVP.hash](https://www.emberjs.com/api/ember/2.16/classes/rsvp/methods/hash?anchor=hash).
 The `RSVP.hash` takes
 parameters that return promises, and when all parameter promises resolve, then
 the `RSVP.hash` promise resolves. For example:

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -3,7 +3,7 @@ change application state. For example, imagine that you have a template
 that shows a blog title, and supports expanding the post to show the body.
 
 If you add the
-[`{{action}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_action)
+[`{{action}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper to any HTML DOM element, when a user clicks the element, the named event
 will be sent to the template's corresponding component or controller.
 
@@ -62,7 +62,7 @@ export default Component.extend({
 ## Specifying the Type of Event
 
 By default, the
-[`{{action}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_action)
+[`{{action}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper listens for click events and triggers the action when the user clicks
 on the element.
 
@@ -116,7 +116,7 @@ will trigger the action *and* the user will be directed to the new page.
 ## Modifying the action's first parameter
 
 If a `value` option for the
-[`{{action}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_action)
+[`{{action}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper is specified, its value will be considered a property path that will
 be read off of the first parameter of the action. This comes very handy with
 event listeners and enables to work with one-way bindings.

--- a/source/templates/binding-element-attributes.md
+++ b/source/templates/binding-element-attributes.md
@@ -59,8 +59,8 @@ renders the following HTML:
 
 To enable support for data attributes an attribute binding must be
 added to the component, e.g.
-[`Ember.LinkComponent`](http://emberjs.com/api/classes/Ember.LinkComponent.html)
-or [`Ember.TextField`](http://emberjs.com/api/classes/Ember.TextField.html)
+[`Ember.LinkComponent`](https://www.emberjs.com/api/ember/2.16/classes/LinkComponent)
+or [`Ember.TextField`](https://www.emberjs.com/api/ember/2.16/classes/TextField)
 for the specific attribute:
 
 ```javascript

--- a/source/templates/built-in-helpers.md
+++ b/source/templates/built-in-helpers.md
@@ -10,7 +10,7 @@ passing data to another helper or component.
 
 ### Using a helper to get a property dynamically
 
-The [`{{get}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_get) helper makes it easy to dynamically send the value of a
+The [`{{get}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=get) helper makes it easy to dynamically send the value of a
 variable to another helper or component.
 This can be useful if you want
 to output one of several values based on the result of a computed property.
@@ -26,7 +26,7 @@ if the `part` computed property returns "zip", this will display the result of
 
 In the last section it was discussed that helpers can be nested.
 This can be combined with these sorts of dynamic helpers.
-For example, the [`{{concat}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_concat) helper makes it easy to dynamically send
+For example, the [`{{concat}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=concat) helper makes it easy to dynamically send
 a number of parameters to a component or helper as a single parameter in the
 format of a concatenated string.
 

--- a/source/templates/conditionals.md
+++ b/source/templates/conditionals.md
@@ -1,6 +1,6 @@
-Statements like [`if`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_if)
-and [`unless`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_unless)
-are implemented as built-in helpers. Helpers can be invoked three ways, each 
+Statements like [`if`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=if)
+and [`unless`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
 The first style of invocation is **inline invocation**. This looks similar to
@@ -12,7 +12,7 @@ displaying a property, but helpers accept arguments. For example:
 </div>
 ```
 
-[`{{if}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_if)
+[`{{if}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=if)
 in this case returns `"zoooom"` when `isFast` is true and
 `"putt-putt-putt"` when `isFast` is false. Helpers invoked as inline expressions
 render a single value, the same way that properties are a single value.
@@ -53,7 +53,7 @@ properties on `person` only if that it is present:
 {{/if}}
 ```
 
-[`{{if}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_if)
+[`{{if}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=if)
 checks for truthiness, which means all values except `false`,
 `undefined`, `null`, `''`, `0`  or `[]` (i.e., any JavaScript falsy value or an
 empty array).
@@ -81,8 +81,8 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_unless),
-which can be used in the same three styles of invocation. For example, this 
+[`{{unless}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 
 ```handlebars

--- a/source/templates/development-helpers.md
+++ b/source/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/source/templates/displaying-a-list-of-items.md
+++ b/source/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_each)
+[`{{#each}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
+helper](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_each)
+The [`{{#each}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/source/templates/displaying-the-keys-in-an-object.md
+++ b/source/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_each-in) helper:
+you can use the [`{{#each-in}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
 
 ```/app/components/store-categories.js
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_each-in) helper instead.
+and use the [`{{#each}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_each-in)
+The [`{{#each-in}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/source/templates/input-helpers.md
+++ b/source/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_input)
-and [`{{textarea}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_textarea)
+The [`{{input}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=input)
+and [`{{textarea}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://emberjs.com/api/classes/Ember.Component.html#toc_event-names) must be dasherized.
+[Event Names](https://www.emberjs.com/api/ember/2.16/classes/Component#toc_event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_input)
+[`{{input}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
@@ -84,7 +84,7 @@ Which can be bound or set as described in the previous section.
 
 Will bind the value of the text area to `name` on the current context.
 
-[`{{textarea}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_textarea) supports binding and/or setting the following properties:
+[`{{textarea}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`
@@ -106,7 +106,7 @@ Will bind the value of the text area to `name` on the current context.
 
 ### Binding dynamic attribute
 
-You might need to bind a property dynamically to an input if you're building a flexible form, for example. To achieve this you need to use the [`{{get}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_get) and [`{{mut}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_mut) in conjunction like shown in the following example:
+You might need to bind a property dynamically to an input if you're building a flexible form, for example. To achieve this you need to use the [`{{get}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/mut?anchor=mut) in conjunction like shown in the following example:
 
 ```handlebars
 {{input value=(mut (get person field))}}

--- a/source/templates/links.md
+++ b/source/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_link-to)
+[`{{link-to}}`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 component.
 
 ```app/router.js
@@ -116,7 +116,7 @@ The `query-params` helper can be used to set query params on a link:
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_link-to)
+[`link-to`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -149,7 +149,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](http://emberjs.com/api/classes/Ember.Templates.helpers.html#method_link-to)
+[`link-to`](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/source/templates/writing-helpers.md
+++ b/source/templates/writing-helpers.md
@@ -393,7 +393,7 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: http://emberjs.com/api/classes/Ember.Helper.html
-[2]: http://emberjs.com/api/classes/Ember.Helper.html#method_compute
+[1]: https://www.emberjs.com/api/ember/2.16/classes/Helper
+[2]: https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute
 [3]: http://emberjs.com/api/classes/Ember.Helper.html#method_helper
 [4]: http://emberjs.com/api/classes/Ember.String.html#method_htmlSafe

--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -206,7 +206,7 @@ moduleForComponent('comment-form', 'Integration | Component | comment form', {
 
 test('should trigger external action on form submit', function(assert) {
   assert.expect(1);
-  
+
   // test double for the external action
   this.set('externalAction', (actual) => {
     let expected = { comment: 'You are not a wizard!' };
@@ -395,7 +395,7 @@ Often, interacting with a component will cause asynchronous behavior to occur, s
 `wait` helper is designed to handle these scenarios, by providing a hook to ensure assertions are made after
 all Ajax requests and timers are complete.
 
-Imagine you have a typeahead component that uses [`Ember.run.debounce`](http://emberjs.com/api/classes/Ember.run.html#method_debounce)
+Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Frunloop/methods/debounce?anchor=debounce)
 to limit requests to the server, and you want to verify that results are displayed after typing a character.
 
 > You can follow along by generating your own component with `ember generate

--- a/source/testing/unit-testing-basics.md
+++ b/source/testing/unit-testing-basics.md
@@ -3,7 +3,7 @@ is doing what was intended. Unlike acceptance tests, they are narrow in scope
 and do not require the Ember application to be running.
 
 As it is the basic object type in Ember, being able to test a simple
-[`EmberObject`](http://emberjs.com/api/classes/Ember.Object.html) sets the foundation for testing more specific parts of your
+[`EmberObject`](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject?show=inherited%2Cprotected%2Cprivate%2Cdeprecated) sets the foundation for testing more specific parts of your
 Ember application such as controllers, components, etc. Testing an `EmberObject`
 is as simple as creating an instance of the object, setting its state, and
 running assertions against the object. By way of example, let's look at a few

--- a/source/tutorial/autocomplete-component.md
+++ b/source/tutorial/autocomplete-component.md
@@ -105,7 +105,7 @@ The `filter` function is passed in by the calling object. This is a pattern know
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
-A [promise](http://emberjs.com/api/classes/RSVP.Promise.html) is a JavaScript object that represents the result of an asynchronous function.
+A [promise](https://www.emberjs.com/api/ember/2.16/classes/Promise) is a JavaScript object that represents the result of an asynchronous function.
 A promise may or may not be executed at the time you receive it.
 To account for this, it provides functions, like `then` that let you give it code it will run when it eventually does receive a result.
 
@@ -279,7 +279,7 @@ The `value` property represents the latest state of the input field.
 Therefore we now check that results match the input field, ensuring that results will stay in sync with the last thing the user has typed.
 
 While this approach will keep our results order consistent, there are other things to consider when dealing with multiple concurrent tasks,
-such as [limiting the number of requests made to the server](https://emberjs.com/api/classes/Ember.run.html#method_debounce).
+such as [limiting the number of requests made to the server](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Frunloop/methods/debounce?anchor=debounce).
 To create effective and robust autocomplete behavior for your applications,
 we recommend considering the [`ember-concurrency`](http://ember-concurrency.com/#/docs/introduction) addon project.
 
@@ -340,7 +340,7 @@ Our `filterByCity` function is going to pretend to be the action function for ou
 We are not testing the actual filtering of rentals in this test, since it is focused on only the capability of the component.
 We will test the full logic of filtering in acceptance tests, described in the next section.
 
-Since our component is expecting the filter process to be asynchronous, we return promises from our filter, using [Ember's RSVP library](http://emberjs.com/api/classes/RSVP.html).
+Since our component is expecting the filter process to be asynchronous, we return promises from our filter, using [Ember's RSVP library](https://www.emberjs.com/api/ember/2.16/modules/rsvp).
 
 Next, we'll add the call to render the component to show the cities we've provided above.
 

--- a/source/tutorial/ember-data.md
+++ b/source/tutorial/ember-data.md
@@ -3,7 +3,7 @@ As our application grows, we will want to persist our rental data on a server, a
 
 Ember comes with a data management library called [Ember Data](https://github.com/emberjs/data) to help deal with persistent application data.
 
-Ember Data requires you to define the structure of the data you wish to provide to your application by extending [`DS.Model`](http://emberjs.com/api/data/classes/DS.Model.html).
+Ember Data requires you to define the structure of the data you wish to provide to your application by extending [`DS.Model`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model).
 
 You can generate an Ember Data Model using Ember CLI.
 We'll call our model `rental` and generate it as follows:
@@ -21,7 +21,7 @@ installing model-test
   create tests/unit/models/rental-test.js
 ```
 
-When we open the model file, we can see a blank class extending [`DS.Model`](http://emberjs.com/api/data/classes/DS.Model.html):
+When we open the model file, we can see a blank class extending [`DS.Model`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model):
 
 ```app/models/rental.js
 import DS from 'ember-data';
@@ -33,7 +33,7 @@ export default DS.Model.extend({
 
 Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
-Define attributes by giving them the result of the function [`DS.attr()`](http://emberjs.com/api/data/classes/DS.html#method_attr).
+Define attributes by giving them the result of the function [`DS.attr()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS/methods/attr?anchor=attr).
 For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js
@@ -56,9 +56,9 @@ We now have a model object that we can use for our Ember Data implementation.
 
 To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
 Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
-The [store service](http://emberjs.com/api/data/classes/DS.Store.html) is injected into all routes and components in Ember.
+The [store service](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
-In this case, call the [`findAll`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) function on the store and provide it with the name of your newly created rental model class.
+In this case, call the [`findAll`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findAll?anchor=findAll) function on the store and provide it with the name of your newly created rental model class.
 
 ```app/routes/rentals.js{+5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33}
 import Route from '@ember/routing/route';

--- a/source/tutorial/installing-addons.md
+++ b/source/tutorial/installing-addons.md
@@ -95,14 +95,14 @@ export default function() {
 
   /*
     Config (with defaults).
-    
+
     Note: these only affect routes defined *after* them!
   */
-  
+
   // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
   // this.namespace = '';    // make this `/api`, for example, if your API is namespaced
   // this.timing = 400;      // delay for each request, automatically set to 0 during testing
-  
+
   /*
     Shorthand cheatsheet:
 
@@ -111,7 +111,7 @@ export default function() {
     this.get('/posts/:id');
     this.put('/posts/:id'); // or this.patch
     this.del('/posts/:id');
-    
+
     http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
   */
 }
@@ -133,7 +133,7 @@ For now, let's generate an adapter for our application:
 ember generate adapter application
 ```
 
-This adapter will extend the [`JSONAPIAdapter`](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html) base class from Ember Data:
+This adapter will extend the [`JSONAPIAdapter`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPIAdapter) base class from Ember Data:
 
 ```app/adapters/application.js{+4}
 import DS from 'ember-data';

--- a/source/tutorial/model-hook.md
+++ b/source/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](../../images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](http://emberjs.com/api/classes/Ember.Route.html#method_model).
+It loads the data in a function called [`model`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/model?anchor=model).
 The `model` function acts as a **hook**, meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/source/tutorial/routes-and-templates.md
+++ b/source/tutorial/routes-and-templates.md
@@ -220,11 +220,11 @@ To do this we will add code to our index route handler by implementing a route l
 called `beforeModel`.
 
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
-The [`beforeModel`](http://emberjs.com/api/classes/Ember.Route.html#method_beforeModel)
+The [`beforeModel`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook) for an explanation of the model hook.
 
-In our index route handler, we'll call the [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) function.
+In our index route handler, we'll call the [`replaceWith`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's `transitionTo` function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.

--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -288,7 +288,7 @@ In the second test, only one assert is expected (line 26), since the map element
 Also, note that the second test uses a dummy object as the returned map element (defined on line 4).
 Our map element can be substituted with any object because we are only asserting that the cache has been accessed (see line 32).
 
-The location in the cache has been [`camelized`](http://emberjs.com/api/classes/Ember.String.html#method_camelize) (line 30),
+The location in the cache has been [`camelized`](https://www.emberjs.com/api/ember/2.16/classes/String/methods/camelize?anchor=camelize) (line 30),
 so that it may be used as a key to look up our element.
 This matches the behavior in `getMapElement` when city has not yet been cached.
 

--- a/source/tutorial/subroutes.md
+++ b/source/tutorial/subroutes.md
@@ -330,7 +330,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](http://emberjs.com/api/classes/Ember.Route.html#method_serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Clicking on the title will load the detail page for that rental.


### PR DESCRIPTION
I almost certainly made mistakes. But maybe :shipit: until we have a better solution. It's not simple to hack the new changes into ember-api-docs.

I couldn't find these things:
- `on()`
- http://emberjs.com/api/classes/Ember.Debug.html#method_registerDeprecationHandler
- http://emberjs.com/api/classes/Ember.Object.html#method_incrementProperty
- http://emberjs.com/api/classes/Ember.Enumerable.html
- http://emberjs.com/api/classes/Ember.Object.html#method_reopen and reopenClass
- http://emberjs.com/api/classes/Ember.Helper.html#method_helper
- http://emberjs.com/api/classes/Ember.String.html#method_htmlSafe
- http://emberjs.com/api/classes/Ember.Test