### PR TITLE
Use Public Website Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,9 @@
-FROM ruby:2.3
+FROM dockerizedember/website-dev:latest
 
-USER root
-
-ENV BUNDLER_VERSION 1.15.1
-
-# en - English
-# pt - Portuguese and Brazilian Portuguese
-# es - Spanish
-# pl - Polish
-ENV ASPELL_LANGUAGES aspell-en aspell-pt aspell-es aspell-pl
-
-# JavaScript runtime required by execjs gem
-# Spellchecking
-ENV PACKAGES nodejs aspell $ASPELL_LANGUAGES
-
-RUN apt-get update && apt-get -y install $PACKAGES
-
-# Fix the Bundler version
-RUN gem install bundler -v $BUNDLER_VERSION
-RUN mkdir /guides
-
-WORKDIR /guides
-
-ADD Gemfile /guides/Gemfile
-ADD Gemfile.lock /guides/Gemfile.lock
-RUN bundle install
-
-ADD . /guides
-
-CMD bundle exec middleman
+# Customizations for this project here.
+# e.g.: if you have dependencies in addition to what the base image provides:
+# ADD Gemfile /src/Gemfile
+# ADD Gemfile.lock /src/Gemfile.lock
+# RUN bundle install
+#
+# ADD . /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM dockerizedember/website-dev:latest
 
 # Customizations for this project here.
 # e.g.: if you have dependencies in addition to what the base image provides:
-# ADD Gemfile /src/Gemfile
-# ADD Gemfile.lock /src/Gemfile.lock
-# RUN bundle install
-#
-# ADD . /src
+ADD Gemfile /src/Gemfile
+ADD Gemfile.lock /src/Gemfile.lock
+RUN bundle install
+
+ADD . /src

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Although the Guides are built with Ruby, most work is done in Markdown files.
 You don't need to know Ruby or install its dependencies to help out. Simply follow
 the Docker container instructions below to install and run locally.
 
-First, install [Docker](https://www.docker.com/) and leave it running.
+First, install [Docker and Compose](https://www.docker.com/) and leave it running.
 
 Next, the commands below will install all necessary dependencies for the Guides
 app and start a server. This will take a little while to run,

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Although the Guides are built with Ruby, most work is done in Markdown files.
 You don't need to know Ruby or install its dependencies to help out. Simply follow
 the Docker container instructions below to install and run locally.
 
-First, install [Docker and Compose](https://www.docker.com/) and leave it running.
+First, install [Docker and Compose](https://store.docker.com/search?offering=community&type=edition) and leave it running.
 
 Next, the commands below will install all necessary dependencies for the Guides
 app and start a server. This will take a little while to run,
@@ -84,14 +84,6 @@ git clone git://github.com/emberjs/guides.git
 cd guides
 bundle
 bundle exec middleman
-```
-
-#### With Docker
-```sh
-git clone git://github.com/emberjs/guides.git
-cd guides
-docker-compose build
-docker-compose up
 ```
 
 #### Viewing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     ports:
       - "4567:4567"
     volumes:
-      - .:/guides
+      - .:/src


### PR DESCRIPTION
This should have no impact on contributors. The command to start up the container is still `docker-compose up`