### PR TITLE
Fix incorrect reference to `Ember` in updated example code

### DIFF
--- a/source/tutorial/ember-cli.md
+++ b/source/tutorial/ember-cli.md
@@ -97,8 +97,8 @@ export default Router;
 
 Ember CLI uses ECMAScript 2015 (ES2015 for short or previously known as ES6) modules to organize application
 code.
-For example, the line `import Router from '@ember/routing/router';` gives us access to the actual
-Ember.js library as the variable `Ember`. And the `import config from
+For example, the line `import Router from '@ember/routing/router';` gives us access to
+Ember's Router class as the variable `Router`. And the `import config from
 './config/environment';` line gives us access to our app's configuration data
 as the variable `config`. `const` is a way to declare a read-only variable to make
 sure it is not accidentally reassigned elsewhere. At the end of the file,


### PR DESCRIPTION
Commit 9f5d402 changed a code snippet, but left a reference in the text to the previous code in place. This change updates the text so that it reflects the change in the code.