### PR TITLE
Add Strings namespace import (#2095)

### DIFF
--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -114,6 +114,7 @@ otherwise we call a Google Maps utility to create one.
 
 ```app/services/maps.js
 import Service from '@ember/service';
+import { camelize } from '@ember/string';
 import EmberObject from '@ember/object';
 
 import MapUtil from '../utils/google-maps';
@@ -130,7 +131,7 @@ export default Service.extend({
   },
 
   getMapElement(location) {
-    let camelizedLocation = Ember.String.camelize(location);
+    let camelizedLocation = camelize(location);
     let element = this.get(`cachedMaps.${camelizedLocation}`);
     if (!element) {
       element = this.createMapElement();


### PR DESCRIPTION
As-is, the provided sample code compiles with an error because the Ember global object is not defined anywhere.

This update adds an import of the Strings namespace and adjusts the usage from "Ember.Strings.camelize" to just "camelize".

Fixes: #2095 