### PR TITLE
Typo: Comma after by default at the beginning of a sentence.

### DIFF
--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -42,7 +42,7 @@ export default Route.extend({
 });
 ```
 
-Each component, under the hood, is backed by an element. By default, 
+Each component is backed by an element under the hood. By default, 
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's

--- a/source/components/defining-a-component.md
+++ b/source/components/defining-a-component.md
@@ -42,7 +42,7 @@ export default Route.extend({
 });
 ```
 
-Each component, under the hood, is backed by an element. By default
+Each component, under the hood, is backed by an element. By default, 
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's

--- a/source/models/customizing-adapters.md
+++ b/source/models/customizing-adapters.md
@@ -46,7 +46,7 @@ export default DS.JSONAPIAdapter.extend({
 });
 ```
 
-By default Ember Data comes with several built-in adapters. Feel free
+By default, Ember Data comes with several built-in adapters. Feel free
 to use these adapters as a starting point for creating your own custom
 adapter.
 
@@ -156,7 +156,7 @@ Requests for `person` would now target `http://emberjs.com/api/1/people/1`.
 
 #### Host Customization
 
-By default the adapter will target the current domain. If you would
+By default, the adapter will target the current domain. If you would
 like to specify a new domain you can do so by setting the `host`
 property on the adapter.
 
@@ -173,7 +173,7 @@ Requests for `person` would now target `https://api.example.com/people/1`.
 
 #### Path Customization
 
-By default the `JSONAPIAdapter` will attempt to pluralize and dasherize
+By default, the `JSONAPIAdapter` will attempt to pluralize and dasherize
 the model name to generate the path name. If this convention does not
 conform to your backend you can override the `pathForType` method.
 

--- a/source/models/customizing-adapters.md
+++ b/source/models/customizing-adapters.md
@@ -46,9 +46,8 @@ export default DS.JSONAPIAdapter.extend({
 });
 ```
 
-By default, Ember Data comes with several built-in adapters. Feel free
-to use these adapters as a starting point for creating your own custom
-adapter.
+Ember Data comes with several built-in adapters.
+Feel free to use these adapters as a starting point for creating your own custom adapter.
 
 - [DS.Adapter](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Adapter) is the basic adapter
 with no functionality. It is generally a good starting point if you

--- a/source/templates/actions.md
+++ b/source/templates/actions.md
@@ -80,7 +80,7 @@ become `keyPress`.
 
 ## Allowing Modifier Keys
 
-By default the `{{action}}` helper will ignore click events with
+By default, the `{{action}}` helper will ignore click events with
 pressed modifier keys. You can supply an `allowedKeys` option
 to specify which keys should not be ignored.
 


### PR DESCRIPTION
Just add some comma after by default at the beginning of a sentence.