### PR TITLE
Update routes-and-templates.md

### DIFF
--- a/source/tutorial/routes-and-templates.md
+++ b/source/tutorial/routes-and-templates.md
@@ -225,7 +225,7 @@ hook gets executed before the data gets fetched from the model hook, and before 
 See [the next section](../model-hook) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=replaceWith) function.
-The `replaceWith` function is similar to the route's `transitionTo` function,
+The `replaceWith` function is similar to the route's [`transitionTo()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.
 Since we want our `rentals` route to serve as our home page, we will use the `replaceWith` function.


### PR DESCRIPTION
This change adds the link to the `transitionTo` function so that someone walking through the tutorial can see an example of how `transitionTo` is used. Since there is a link to `replaceWith` in this paragraph, I think it is useful to link to `transitionTo` as well.