### PR TITLE
Update hbs-helper.md

### DIFF
--- a/source/tutorial/hbs-helper.md
+++ b/source/tutorial/hbs-helper.md
@@ -61,7 +61,7 @@ Instead, our default template helper is returning back our `rental.propertyType`
 Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
-```app/helpers/rental-property-type.js{-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+17,+18,+19}
+```app/helpers/rental-property-type.js{-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+18,+19}
 import { helper } from '@ember/component/helper';
 
 export function rentalPropertyType(params/*, hash*/) {


### PR DESCRIPTION
Adding line 17 as a + is causing the lines from 17 to the end to highlight in green since the line is blank. However, lines 20 and 21 should not be highlighted as they are not additions to the file.