### PR TITLE
Fix JS code comment for `for` loop behavior

### DIFF
--- a/source/getting-started/js-primer.md
+++ b/source/getting-started/js-primer.md
@@ -139,7 +139,7 @@ But if you use `let`, this happens instead:
 
 ```javascript
 for (let i = 0; i < 3; i++) {
-  console.log(i) // 0, 1, 2, 3
+  console.log(i) // 0, 1, 2
 }
 
 console.log(i) // ReferenceError: i is not defined


### PR DESCRIPTION
Both loops only count up to `2`; the code comment for the loop using `let` incorrectly described it as behaving differently from `var` and counting up to `3`.