### PR TITLE
Fixes deep link for Component#event-names

### DIFF
--- a/source/templates/input-helpers.md
+++ b/source/templates/input-helpers.md
@@ -51,7 +51,7 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://www.emberjs.com/api/ember/2.16/classes/Component#toc_event-names) must be dasherized.
+[Event Names](https://www.emberjs.com/api/ember/2.16/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 

--- a/source/templates/input-helpers.md
+++ b/source/templates/input-helpers.md
@@ -51,7 +51,7 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://www.emberjs.com/api/ember/2.16/classes/Component#event-names) must be dasherized.
+[Event Names](https://www.emberjs.com/api/ember/release/classes/Component) must be dasherized.
 
 ## Checkboxes
 


### PR DESCRIPTION
As I was trying to figure out an issue with events not triggering in the app I was working on, I looked up the input helper in the docs. After clicking on `Event Names` I get taken to:

![](https://ac-screenshots.s3.amazonaws.com/Firefox_Developer_Edition_2017-11-28_11-11-10.jpg)

Took some time to quickly patch this up.

## Changes

- Updates link to event names in input-helpers.md

Cheers!