### PR TITLE
Update handling-metadata.md

### DIFF
--- a/source/models/handling-metadata.md
+++ b/source/models/handling-metadata.md
@@ -70,7 +70,7 @@ import Router from '@ember/routing/route';
 
 export default Route.extend({
   model() {
-    return this.store.findAll('user').then((results) => {
+    return this.store.query('user', {}).then((results) => {
       return {
         users: results,
         meta: results.get('meta')


### PR DESCRIPTION
JSONAPI meta key is not available on a collection retrieved using the findAll method, but it is available on a collection retrieved using the query method and the last example in this guide makes it confusing as it simply does not work.