### PR TITLE
added "let" to correct Person example

### DIFF
--- a/source/object-model/computed-properties.md
+++ b/source/object-model/computed-properties.md
@@ -110,7 +110,7 @@ and use the existing `fullName` property and add in some other properties:
 ```javascript
 import EmberObject, { computed } from '@ember/object';
 
-Person = EmberObject.extend({
+let Person = EmberObject.extend({
   firstName: null,
   lastName: null,
   age: null,
@@ -159,7 +159,7 @@ You must return the new intended value of the computed property from the setter 
 ```javascript
 import EmberObject, { computed } from '@ember/object';
 
-Person = EmberObject.extend({
+let Person = EmberObject.extend({
   firstName: null,
   lastName: null,
 
@@ -194,7 +194,7 @@ In this example, the two computed properties are equivalent:
 import EmberObject, { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 
-Person = EmberObject.extend({
+let Person = EmberObject.extend({
   fullName: 'Tony Stark',
 
   isIronManLongWay: computed('fullName', function() {

--- a/source/object-model/computed-properties.md
+++ b/source/object-model/computed-properties.md
@@ -14,7 +14,7 @@ We have a `Person` object with `firstName` and `lastName` properties, but we als
 ```javascript
 import EmberObject, { computed } from '@ember/object';
 
-Person = EmberObject.extend({
+let Person = EmberObject.extend({
   // these will be supplied by `create`
   firstName: null,
   lastName: null,


### PR DESCRIPTION
Example shows instantiation of Person object extending EmberObject. Some variable declaration statement needs to precede the creation of the Person object, and "let" makes sense here.