### PR TITLE
Updated for new modules @ember/object/evented documentation link

### DIFF
--- a/source/object-model/observers.md
+++ b/source/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](http://emberjs.com/api/classes/Ember.html#method_on):
+should also run after `init` by using [`@ember/object/evented/on`](https://emberjs.com/api/ember/release/classes/@ember%2Fobject%2Fevented/methods/on?anchor=on):
 
 
 ```javascript


### PR DESCRIPTION
`Ember.on` is the old-way, now it should be referenced `{on} from @ember/object/evented`