### PR TITLE
[WIP] Remove jQuery guide

### DIFF
--- a/data/pages.yml
+++ b/data/pages.yml
@@ -228,6 +228,8 @@
   pages:
     - title: "Managing Dependencies"
       url: "managing-dependencies"
+    - title: "Removing jQuery"
+      url: "removing-jquery"
 
 - title: "Configuring Ember.js"
   url: 'configuring-ember'

--- a/source/addons-and-dependencies/removing-jquery.md
+++ b/source/addons-and-dependencies/removing-jquery.md
@@ -1,0 +1,23 @@
+Ember has been relying on jQuery in the past, and it still ships it by default.
+However since Ember 3.x it is an optional dependency, that you can opt out from.
+
+To do so, add the [`@ember/optional-features`](https://github.com/emberjs/ember-optional-features) addon,
+if you have not done so already, and disable the `jquery-integration` flag:
+
+```shell
+ember install @ember/optional-features
+ember feature:disable jquery-integration
+```
+
+This will remove jQuery from your `vendor.js` bundle and disable any use of jQuery in Ember itself.
+
+## Caveats
+
+With jQuery not being available anymore, this will break any code that still relies on it, especially any usage of
+
+* [`this.$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) in components
+* `jQuery` or `$` directly as a global, through `Ember.$()` or by importing it (`import jQuery from jquery;`) 
+* global acceptance test helpers like `find()` or `click()`
+* `this.$()` in component tests
+
+Note that this also applies to all addons that your app uses, so make sure these support to be used without jQuery!

--- a/source/addons-and-dependencies/removing-jquery.md
+++ b/source/addons-and-dependencies/removing-jquery.md
@@ -1,8 +1,8 @@
-Ember has been relying on jQuery in the past, and it still ships it by default.
-However since Ember 3.x it is an optional dependency, that you can opt out from.
+Ember relied on jQuery in the past, and it still ships with it by default.
+However, in Ember 3.x it is an optional dependency that you can opt out from.
 
-To do so, add the [`@ember/optional-features`](https://github.com/emberjs/ember-optional-features) addon,
-if you have not done so already, and disable the `jquery-integration` flag:
+To do so, install the [`@ember/optional-features`](https://github.com/emberjs/ember-optional-features) addon
+and disable the `jquery-integration` flag:
 
 ```shell
 ember install @ember/optional-features
@@ -10,14 +10,15 @@ ember feature:disable jquery-integration
 ```
 
 This will remove jQuery from your `vendor.js` bundle and disable any use of jQuery in Ember itself.
+Now your app will be about 30KB lighter!
 
 ## Caveats
 
-With jQuery not being available anymore, this will break any code that still relies on it, especially any usage of
+Without jQuery, any code that still relies on it will break, especially any usage of
 
 * [`this.$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) in components
 * `jQuery` or `$` directly as a global, through `Ember.$()` or by importing it (`import jQuery from jquery;`) 
 * global acceptance test helpers like `find()` or `click()`
 * `this.$()` in component tests
 
-Note that this also applies to all addons that your app uses, so make sure these support to be used without jQuery!
+Note that this also applies to all addons that your app uses, so make sure they support being used without jQuery.


### PR DESCRIPTION
This is a first draft for the necessary changes as per [RFC 294](https://github.com/emberjs/rfcs/pull/294):
* adds a "Remove jQuery" guide
* removes `this.$()` references from component guide in favor of `this.element` and native DOM

Please double check, as I am not a native speaker! 😬

*And don't merge this yet, unless the RFC is fully implemented*