### PR TITLE
Switched to default of serve

### DIFF
--- a/source/tutorial/routes-and-templates.md
+++ b/source/tutorial/routes-and-templates.md
@@ -77,7 +77,7 @@ Super Rentals:
 </div>
 ```
 
-Now run `ember server` (or `ember serve`, or even `ember s` for short) on your command line to start
+Now run `ember serve` (or `ember server`, or even `ember s` for short) on your command line to start
 the Ember development server and then go to [`http://localhost:4200/about`](http://localhost:4200/about) to
 see our new page in action!
 


### PR DESCRIPTION
We've decided to standardize on `ember serve` in the past (see https://github.com/emberjs/guides/pull/2062) but this isn't in step here ...