### PR TITLE
Flushing out references to Ember.logger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ master, set an upstream and pull from it. For this to work, you should make sure
 you're always committing to a branch, not master.
 
 ```
-git remote add upstream https://github.com/emberjs/website.git
+git remote add upstream https://github.com/emberjs/guides.git
 git pull upstream master
 ```
 

--- a/source/components/handling-events.md
+++ b/source/components/handling-events.md
@@ -33,7 +33,7 @@ import Ember from 'ember';
 
 export default Component.extend({
   doubleClick() {
-    Ember.Logger.info('DoubleClickableComponent was clicked!');
+    console.info('DoubleClickableComponent was clicked!');
     return true;
   }
 });

--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -191,7 +191,7 @@ called with the `error` as the model. See example below:
 
 ```js
 setupController(controller, error) {
-  Ember.Logger.debug(error.message);
+  console.log(error.message);
   this._super(...arguments);
 }
 ```


### PR DESCRIPTION
This is part of the work for RFC 297: Deprecation of Ember.Logger - there were passing references to it in a couple of examples that I replaced with console calls.