### PR TITLE
Dasherize type attributes in API response example

### DIFF
--- a/source/models/relationships.md
+++ b/source/models/relationships.md
@@ -209,32 +209,32 @@ And our API might setup these relationships like so:
 			"payment-methods": {
 				"data": [{
 					"id": "1",
-					"type": "PaymentMethodPaypal"
+					"type": "payment-method-paypal"
 				}, {
 					"id": "2",
-					"type": "PaymentMethodCc"
+					"type": "payment-method-cc"
 				}, {
 					"id": "3",
-					"type": "PaymentMethodApplePay"
+					"type": "payment-method-apple-pay"
 				}]
 			}
 		}
 	},
 	"included": [{
 		"id": "1",
-		"type": "PaymentMethodPaypal",
+		"type": "payment-method-paypal",
 		"attributes": {
 			"linked-email": "ryan@gosling.io"
 		}
 	}, {
 		"id": "2",
-		"type": "PaymentMethodCc",
+		"type": "payment-method-cc",
 		"attributes": {
 			"last4": "1335"
 		}
 	}, {
 		"id": "3",
-		"type": "PaymentMethodApplePay",
+		"type": "payment-method-apple-pay",
 		"attributes": {
 			"last4": "5513"
 		}


### PR DESCRIPTION
I think it's better to dasherize type attribute values here rather than camel case.
Because it's described an API response, not a normalized JSON by Ember DATA,
and `linked-email` in attributes is dasherized.