### PR TITLE
Fix "Testing Models" test example

### DIFF
--- a/source/testing/testing-models.md
+++ b/source/testing/testing-models.md
@@ -36,6 +36,8 @@ import { setupTest } from 'ember-qunit';
 import { run } from "@ember/runloop";
 
 module('Unit | Model | player', function(hooks) {
+  setupTest(hooks);
+
   // Specify the other units that are required for this test.
   test('should increment level when told to', function(assert) {
     const player = run(() => this.owner.lookup('service:store').createRecord('player'));


### PR DESCRIPTION
I noticed the [Testing Models](https://guides.emberjs.com/v3.0.0/testing/testing-models/) example was missing the `setupTest` call.