### PR TITLE
Add missing Service import to component test guide

### DIFF
--- a/source/testing/testing-components.md
+++ b/source/testing/testing-components.md
@@ -321,6 +321,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
 
 //Stub location service
 const locationStub = Service.extend({


### PR DESCRIPTION
I noticed that this one example was missing the `Service` import, while the one beneath it had the import. I added it where it was missing.