### PR TITLE
Can not use keyword 'await' outside an async function

### DIFF
--- a/source/tutorial/hbs-helper.md
+++ b/source/tutorial/hbs-helper.md
@@ -107,7 +107,7 @@ module('Integration | Helper | my-helper', function(hooks) {
   // Replace this with your real tests.
   test('it renders', async function(assert) {
     this.set('inputValue', '1234');
-  test('it renders correctly for a Standalone rental', function(assert) {
+  test('it renders correctly for a Standalone rental', async function(assert) {
     this.set('inputValue', 'Estate');
 
     await render(hbs`{{rental-property-type inputValue}}`);
@@ -116,7 +116,7 @@ module('Integration | Helper | my-helper', function(hooks) {
     assert.equal(this.element.textContent.trim(), 'Standalone');
   });
 
-  test('it renders correctly for a Community rental', function(assert) {
+  test('it renders correctly for a Community rental', async function(assert) {
     this.set('inputValue', 'Apartment');
 
     await render(hbs`{{rental-property-type inputValue}}`);


### PR DESCRIPTION
helper tests 'rental-property-type-test' are failing since async keyword is not allowed outside an async function.