### PR TITLE
Make docs for CP laziness more explicit.

### DIFF
--- a/source/object-model/computed-properties.md
+++ b/source/object-model/computed-properties.md
@@ -40,6 +40,48 @@ The first time you access the `fullName` property, the function will be called a
 Subsequent access of `fullName` will read from the cache without calling the function.
 Changing any of the dependent properties causes the cache to invalidate, so that the computed function runs again on the next access.
 
+### Computed properties only recompute when they are consumed
+
+A computed property will only recompute its value when it is _consumed._ Properties are consumed in two ways:
+
+1. By a `get`, for example `ironMan.get('fullName')`
+2. By being referenced in a handlebars template that is currently being rendered, for example `{{ironMan.fullName}}`
+
+Outside of those two circumstances the code in the property will not run, even if one of the property's dependencies are changed.
+
+We'll modify the `fullName` property from the previous example to log to the console:
+
+```javascript
+import Ember from 'ember':
+
+…
+  fullName: computed('firstName', 'lastName', function() {
+    console.log('compute fullName'); // track when the property recomputes
+    let firstName = this.get('firstName');
+    let lastName = this.get('lastName');
+
+    return `${firstName} ${lastName}`;
+  })
+…
+```
+
+Using the new property, it will only log after a `get`, and then only if either the `firstName` or `lastName` has been previously changed:
+
+```javascript
+
+let ironMan = Person.create({
+  firstName: 'Tony',
+  lastName:  'Stark'
+});
+
+ironMan.get('fullName'); // 'compute fullName'
+ironMan.set('firstName', 'Bruce') // no console output
+
+ironMan.get('fullName'); // 'compute fullName'
+ironMan.get('fullName'); // no console output since dependencies have not changed
+```
+
+
 ### Multiple dependents on the same object
 
 In the previous example, the `fullName` computed property depends on two other properties:


### PR DESCRIPTION
Fixes #2263.

This first pass adds the section about computed property laziness right after the very first introduction.  It might be better further down with the 'Dynamic Updating' section though.  