### PR TITLE
Update older 'moduleFor' comment in 'testing routes'

### DIFF
--- a/source/testing/testing-routes.md
+++ b/source/testing/testing-routes.md
@@ -63,7 +63,7 @@ module('Unit | Route | application', function(hooks) {
   test('should display an alert', function(assert) {
     assert.expect(2);
 
-    // with moduleFor, the subject returns an instance of the route
+    // get the route instance
     let route = this.owner.lookup('route:application');
 
     // stub window.alert to perform a qunit test


### PR DESCRIPTION
Since we're not using `moduleFor` anymore, this comment was incorrect.

I updated the comment in the same way as it's used in e.g. 'testing controllers'