### PR TITLE
Update index.md Test documentation

### DIFF
--- a/source/testing/index.md
+++ b/source/testing/index.md
@@ -117,11 +117,6 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
-A word of caution using this approach:
-Tests run using `ember server` have the environment configuration `development`,
-whereas tests executed under `ember test --server` are run with the configuration `test`.
-This could cause differences in execution, such as which libraries are loaded and available.
-Therefore it's recommended that you use `ember test --server` for test execution.
 
 These commands run your tests using [Testem] to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.


### PR DESCRIPTION
This cautionary note seems to be out of date. In a testing environment in a 3.0 app, after running ember s, typing `require('app-name/config/environment').default` in the console returns an object with `environment: "test"`. 

Also, in a 2.18 addon, `require('dummy/config/environment').default` returns an object with `environment: "test"`.