### PR TITLE
Set headers in init() so people following the guides don't get eslint errors

### DIFF
--- a/source/models/customizing-adapters.md
+++ b/source/models/customizing-adapters.md
@@ -199,14 +199,19 @@ Requests for `user-profile` would now target `/user_profile/1`.
 Some APIs require HTTP headers, e.g. to provide an API key. Arbitrary
 headers can be set as key/value pairs on the `JSONAPIAdapter`'s `headers`
 object and Ember Data will send them along with each ajax request.
+(Note that we set headers in `init()` because default property values
+should not be arrays or objects.)
 
 ```app/adapters/application.js
 import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend({
-  headers: {
-    'API_KEY': 'secret key',
-    'ANOTHER_HEADER': 'Some header value'
+  init() {
+    this._super(...arguments);
+    this.set('headers', {
+      'API_KEY': 'secret key',
+      'ANOTHER_HEADER': 'Some header value'
+    });
   }
 });
 ```


### PR DESCRIPTION
As [suggested](https://embercommunity.slack.com/archives/C04KG57CF/p1523580736000122) on the `#-team-learning` slack channel, this example has been updated so it won't produce eslint errors for people who copy it directly out of the guide.

I added a note in parentheses explaining why, which I was kind of on the fence about including. Happy to update this as the wise learning team sees fit, lmk.