### PR TITLE
Services: change to stubMapUtil and need to restart test server for unit tests

### DIFF
--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -246,7 +246,7 @@ and are intended for testing specific logic within a class.
 
 For our service unit test, we'll want to verify that locations that have been previously loaded are fetched from cache, while new locations are created using the utility.
 We will isolate our tests from actually calling Google Maps by stubbing our map utility.
-On line 6 of `maps-test.js` below we create an Ember object to simulate the behavior of the utility, but instead of creating a google map, we return an empty JavaScript object.
+On line 19 of `maps-test.js` below we create a Javascript object to simulate the behavior of the utility, but instead of creating a google map, we return an empty JavaScript object.
 
 To instantiate the service, we can instantiate it through ember's resolver using the [`factoryFor`](https://emberjs.com/api/ember/release/classes/ApplicationInstance/methods/factoryFor?anchor=factoryFor) method.
 `factoryFor` allows us to have control over the creation of the service in Ember, to pass arguments to the constructor that can override parts of the service for our tests.

--- a/source/tutorial/service.md
+++ b/source/tutorial/service.md
@@ -243,6 +243,7 @@ You may now either move onto the [next feature](../subroutes/), or continue here
 We'll use a unit test to validate the service.
 Unit tests are more isolated than integration tests and application tests,
 and are intended for testing specific logic within a class.
+(Note: you should restart `ember test --server` whenever you add a new service, otherwise the new service will not be available to your unit tests).
 
 For our service unit test, we'll want to verify that locations that have been previously loaded are fetched from cache, while new locations are created using the utility.
 We will isolate our tests from actually calling Google Maps by stubbing our map utility.


### PR DESCRIPTION
In 3.0.0, MapUtilStub was an EmberObject. In 3.1.0, it has become stubMapUtil, been moved from line 6 to line 19 and is now just a Javascript object.